### PR TITLE
Agent: increase gunicorn timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt update
 # install git as we need it for the git clone client
 RUN apt install git -y
 
-CMD . $VENV_DIR/bin/activate && gunicorn --timeout 900 --bind :$PORT apollo.interfaces.cloudrun.main:app
+CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 


### PR DESCRIPTION
Set 930 seconds (15:30 mins) timeout in gunicorn (default is 30 seconds), CloudRun will actually timeout at 15 mins if the Terraform template is used, so we're intentionally setting a higher timeout to let CloudRun timeout first.