### PR TITLE
KIL-2578: [Agent] Redshift proxy client

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -286,7 +286,7 @@ class Agent:
         except Exception:
             return AgentUtils.agent_response_for_last_exception(client=client)
         finally:
-            # discard clients that raised exceptions, sometimes they keep failing
+            # discard clients that raised exceptions, clients like Redshift keep failing after an error
             if (response is None or response.is_error) and not operation.skip_cache:
                 ProxyClientFactory.dispose_proxy_client(
                     connection_type, credentials, operation.skip_cache

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -281,6 +281,11 @@ class Agent:
                 connection_type, client, operation_name, operation
             )
         except Exception:
+            # discard clients that raised exceptions, sometimes they keep failing
+            if not operation.skip_cache:
+                ProxyClientFactory.dispose_proxy_client(
+                    connection_type, credentials, operation.skip_cache
+                )
             return AgentUtils.agent_response_for_last_exception(client=client)
 
     def _execute_client_operation(

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -87,7 +87,7 @@ class Agent:
         - version
         - build
         - platform
-        - env (some relevant env information like sys.version or vars like PYTHON_VERSION and MCD_*)
+        - env (some relevant env information like `sys.version` or vars like PYTHON_VERSION and MCD_*)
         - specific platform information set using `platform_info` setter
         - the received value for `trace_id` if any
         :return: an `AgentHealthInformation` object that can be converted to JSON.
@@ -205,7 +205,7 @@ class Agent:
                     **kwargs,
                 )
                 return AgentUtils.agent_ok_response(result, trace_id)
-            except Exception:
+            except Exception:  # noqa
                 return AgentUtils.agent_response_for_last_exception("Update failed:")
 
     def _perform_update(
@@ -274,7 +274,8 @@ class Agent:
         and then the list of commands in the operation are executed on the client object.
         :param connection_type: for example "bigquery"
         :param operation_name: operation name, just for logging purposes
-        :param operation_dict: the required dictionary containing the definition of the operation to run, if None an error will be raised
+        :param operation_dict: the required dictionary containing the definition of the operation to run,
+            if None an error will be raised.
         :param credentials: the optional credentials dictionary
         :return: the result of executing the given operation
         """
@@ -284,7 +285,7 @@ class Agent:
             )
         try:
             operation = AgentOperation.from_dict(operation_dict)
-        except Exception:
+        except Exception:  # noqa
             logger.exception("Failed to read operation")
             return AgentUtils.agent_response_for_last_exception(
                 prefix="Failed to read operation:", status_code=400

--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -37,6 +37,9 @@ ATTRIBUTE_VALUE_TYPE_BYTES = "bytes"
 # Value for the attribute __type__ to indicate this is a datetime
 ATTRIBUTE_VALUE_TYPE_DATETIME = "datetime"
 
+# Value for the attribute __type__ to indicate this is a date
+ATTRIBUTE_VALUE_TYPE_DATE = "date"
+
 # Value for the attribute __type__ to indicate this is a Looker category enum, client side it will be converted to
 # the right type
 ATTRIBUTE_VALUE_TYPE_LOOKER_CATEGORY = "looker.category"

--- a/apollo/agent/evaluation_utils.py
+++ b/apollo/agent/evaluation_utils.py
@@ -102,10 +102,14 @@ class AgentEvaluationUtils:
             target = cls._resolve_context_variable(context, target_name)
         method = cls._resolve_method(target, command.method)
         if isinstance(method, Callable):
-            result = method(
-                *cls._resolve_args(command.args, context),
-                **cls._resolve_kwargs(command.kwargs, context),
-            )
+            try:
+                result = method(
+                    *cls._resolve_args(command.args, context),
+                    **cls._resolve_kwargs(command.kwargs, context),
+                )
+            except Exception as ex:
+                logger.info(f"Error calling method {command.method}: {ex}")
+                raise
         else:
             result = method  # assume it is a property
         if store := command.store:

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -152,6 +152,7 @@ class ProxyClientFactory:
             return
         key = cls._get_cache_key(connection_type, credentials)
         cls._dispose_cached_client(key)
+        logger.info(f"Discarded {connection_type} client")
 
     @classmethod
     def _create_proxy_client(

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -142,6 +142,18 @@ class ProxyClientFactory:
             raise
 
     @classmethod
+    def dispose_proxy_client(
+        cls,
+        connection_type: str,
+        credentials: Optional[Dict],
+        skip_cache: bool,
+    ):
+        if skip_cache:
+            return
+        key = cls._get_cache_key(connection_type, credentials)
+        cls._dispose_cached_client(key)
+
+    @classmethod
     def _create_proxy_client(
         cls, connection_type: str, credentials: Optional[Dict], platform: str
     ) -> BaseProxyClient:
@@ -187,3 +199,7 @@ class ProxyClientFactory:
         ):
             return None
         return entry.client
+
+    @classmethod
+    def _dispose_cached_client(cls, key: str):
+        cls._clients_cache.pop(key, None)

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -70,6 +70,14 @@ def _get_proxy_client_git(
     return GitProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_redshift(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.redshift.redshift_proxy_client import RedshiftProxyClient
+
+    return RedshiftProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -83,6 +91,7 @@ _CLIENT_FACTORY_MAPPING = {
     "storage": _get_proxy_client_storage,
     "looker": _get_proxy_client_looker,
     "git": _get_proxy_client_git,
+    "redshift": _get_proxy_client_redshift,
 }
 
 

--- a/apollo/agent/utils.py
+++ b/apollo/agent/utils.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 import traceback
 import uuid
-from datetime import datetime
+from datetime import datetime, date
 from typing import Optional, Dict, List, BinaryIO, Any
 
 from apollo.agent.constants import (
@@ -15,6 +15,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_NAME_TYPE,
     ATTRIBUTE_NAME_DATA,
     ATTRIBUTE_VALUE_TYPE_DATETIME,
+    ATTRIBUTE_VALUE_TYPE_DATE,
 )
 from apollo.agent.env_vars import TEMP_PATH_ENV_VAR, DEFAULT_TEMP_PATH
 from apollo.integrations.base_proxy_client import BaseProxyClient
@@ -123,6 +124,11 @@ class AgentUtils:
         if isinstance(value, datetime):
             return {
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DATETIME,
+                ATTRIBUTE_NAME_DATA: value.isoformat(),
+            }
+        elif isinstance(value, date):
+            return {
+                ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DATE,
                 ATTRIBUTE_NAME_DATA: value.isoformat(),
             }
         return value

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, List
+
+from apollo.agent.utils import AgentUtils
+from apollo.integrations.base_proxy_client import BaseProxyClient
+
+
+class BaseDbProxyClient(BaseProxyClient):
+    def process_result(self, value: Any) -> Any:
+        """
+        Converts "Column" objects in the description into a list of objects that can be serialized to JSON.
+        From the DBAPI standard, description is supposed to return tuples with 7 elements, so we're returning
+        those 7 elements back for each element in description.
+        """
+        if isinstance(value, Dict):
+            if "description" in value:
+                description = value["description"]
+                value["description"] = [
+                    [col[0], col[1], col[2], col[3], col[4], col[5], col[6]]
+                    for col in description
+                ]
+            if "all_results" in value:
+                all_results: List = value["all_results"]
+                value["all_results"] = [
+                    AgentUtils.serialize_value(v) for r in all_results for v in r
+                ]
+
+        return value

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -1,15 +1,18 @@
+from abc import ABC
 from typing import Any, Dict, List
 
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
 
 
-class BaseDbProxyClient(BaseProxyClient):
+class BaseDbProxyClient(BaseProxyClient, ABC):
     def process_result(self, value: Any) -> Any:
         """
         Converts "Column" objects in the description into a list of objects that can be serialized to JSON.
         From the DBAPI standard, description is supposed to return tuples with 7 elements, so we're returning
         those 7 elements back for each element in description.
+        Results are serialized using `AgentUtils.serialize_value`, this allows us to properly serialize
+        date, datetime and any other data type that requires a custom serialization in the future.
         """
         if isinstance(value, Dict):
             if "description" in value:

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -20,8 +20,10 @@ class BaseDbProxyClient(BaseProxyClient):
                 ]
             if "all_results" in value:
                 all_results: List = value["all_results"]
-                value["all_results"] = [
-                    AgentUtils.serialize_value(v) for r in all_results for v in r
-                ]
+                value["all_results"] = [self._process_row(r) for r in all_results]
 
         return value
+
+    @staticmethod
+    def _process_row(row: List) -> List:
+        return [AgentUtils.serialize_value(v) for v in row]

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -1,15 +1,15 @@
-from typing import Dict, Optional, Any
+from typing import Dict, Optional
 
 import psycopg2
 from psycopg2 import DatabaseError
 from psycopg2.errors import QueryCanceled, InsufficientPrivilege
 
-from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
 
 
-class RedshiftProxyClient(BaseProxyClient):
+class RedshiftProxyClient(BaseDbProxyClient):
     """
     Proxy client for Redshift.
     Credentials are expected to be supplied under "connect_args" and will be passed directly to `psycopg2.connect`, so
@@ -31,20 +31,6 @@ class RedshiftProxyClient(BaseProxyClient):
     @property
     def wrapped_client(self):
         return self._connection
-
-    def process_result(self, value: Any) -> Any:
-        """
-        Converts "Column" objects in the description into a list of objects that can be serialized to JSON.
-        From the DBAPI standard, description is supposed to return tuples with 7 elements, so we're returning
-        those 7 elements back for each element in description.
-        """
-        if isinstance(value, Dict) and "description" in value:
-            description = value["description"]
-            value["description"] = [
-                [col[0], col[1], col[2], col[3], col[4], col[5], col[6]]
-                for col in description
-            ]
-        return value
 
     def get_error_type(self, error: Exception) -> Optional[str]:
         """

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional
 
 import psycopg2
 from psycopg2 import DatabaseError
-from psycopg2.errors import QueryCanceled, InsufficientPrivilege
+from psycopg2.errors import QueryCanceled, InsufficientPrivilege  # noqa
 
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
@@ -14,6 +14,7 @@ class RedshiftProxyClient(BaseDbProxyClient):
     Proxy client for Redshift.
     Credentials are expected to be supplied under "connect_args" and will be passed directly to `psycopg2.connect`, so
     only attributes supported as parameters by `psycopg2.connect` should be passed.
+    If "autocommit" is present in credentials it will be set in _connection.autocommit.
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs):  # type: ignore
@@ -34,8 +35,8 @@ class RedshiftProxyClient(BaseDbProxyClient):
 
     def get_error_type(self, error: Exception) -> Optional[str]:
         """
-        Convert PG errors QueryCanceled and DatabaseError to error types that can be converted back to PG errors
-        client side.
+        Convert PG errors QueryCanceled, InsufficientPrivilege and DatabaseError to error types
+        that can be converted back to PG errors client side.
         """
         if isinstance(error, QueryCanceled):
             return "QueryCanceled"

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -1,0 +1,58 @@
+from typing import Dict, Optional, Any
+
+import psycopg2
+from psycopg2 import DatabaseError
+from psycopg2.errors import QueryCanceled
+
+from apollo.integrations.base_proxy_client import BaseProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class RedshiftProxyClient(BaseProxyClient):
+    """
+    Proxy client for Redshift.
+    Credentials are expected to be supplied under "connect_args" and will be passed directly to `psycopg2.connect`, so
+    only attributes supported as parameters by `psycopg2.connect` should be passed.
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs):  # type: ignore
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Redshift agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+
+        self._connection = psycopg2.connect(
+            **credentials[_ATTR_CONNECT_ARGS],
+        )
+        if credentials.get("autocommit", False):
+            self._connection.autocommit = True
+
+    @property
+    def wrapped_client(self):
+        return self._connection
+
+    def process_result(self, value: Any) -> Any:
+        """
+        Converts "Column" objects in the description into a list of objects that can be serialized to JSON.
+        From the DBAPI standard, description is supposed to return tuples with 7 elements, so we're returning
+        those 7 elements back for each element in description.
+        """
+        if isinstance(value, Dict) and "description" in value:
+            description = value["description"]
+            value["description"] = [
+                [col[0], col[1], col[2], col[3], col[4], col[5], col[6]]
+                for col in description
+            ]
+        return value
+
+    def get_error_type(self, error: Exception) -> Optional[str]:
+        """
+        Convert PG errors QueryCanceled and DatabaseError to error types that can be converted back to PG errors
+        client side.
+        """
+        if isinstance(error, QueryCanceled):
+            return "QueryCanceled"
+        elif isinstance(error, DatabaseError):
+            return "DatabaseError"
+        return super().get_error_type(error)

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional, Any
 
 import psycopg2
 from psycopg2 import DatabaseError
-from psycopg2.errors import QueryCanceled
+from psycopg2.errors import QueryCanceled, InsufficientPrivilege
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
 
@@ -53,6 +53,8 @@ class RedshiftProxyClient(BaseProxyClient):
         """
         if isinstance(error, QueryCanceled):
             return "QueryCanceled"
+        elif isinstance(error, InsufficientPrivilege):
+            return "InsufficientPrivilege"
         elif isinstance(error, DatabaseError):
             return "DatabaseError"
         return super().get_error_type(error)

--- a/apollo/interfaces/agent_response.py
+++ b/apollo/interfaces/agent_response.py
@@ -27,6 +27,10 @@ class AgentResponse:
         if self.trace_id and isinstance(self.result, Dict):
             self.result[ATTRIBUTE_NAME_TRACE_ID] = self.trace_id
 
+    @property
+    def is_error(self) -> bool:
+        return self._is_error_response(self.result)
+
     @staticmethod
     def _is_binary_response(result: Any):
         return (

--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,5 @@ google-cloud-storage==2.10.0
 gunicorn==21.2.0
 lambda-git==0.1.1
 looker-sdk==23.16.0
+psycopg2-binary==2.9.7
 retry2==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -116,6 +116,8 @@ protobuf==4.24.2
     # via
     #   google-api-core
     #   googleapis-common-protos
+psycopg2-binary==2.9.7
+    # via -r requirements.in
 pyarrow==13.0.0
     # via databricks-sql-connector
 pyasn1==0.5.0

--- a/tests/test_redshift_client.py
+++ b/tests/test_redshift_client.py
@@ -1,0 +1,189 @@
+import datetime
+from typing import List, Any, Optional
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+from psycopg2.errors import InsufficientPrivilege  # noqa
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_RS_CREDENTIALS = {
+    "host": "www.test.com",
+    "user": "u",
+    "password": "p",
+    "port": "5439",
+    "db_name": "db1",
+}
+
+
+class RedshiftClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+
+    @patch("psycopg2.connect")
+    def test_query(self, mock_connect):
+        query = "SELECT name, value FROM table"  # noqa
+        expected_data = [
+            [
+                "name_1",
+                11.1,
+            ],
+            [
+                "name_2",
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["name", "string", None, None, None, None, None],
+            ["value", "float", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, expected_data, expected_description)
+
+    @patch("psycopg2.connect")
+    def test_datetime_query(self, mock_connect):
+        query = "SELECT name, created_date, updated_datetime FROM table"  # noqa
+        data = [
+            [
+                "name_1",
+                datetime.date.fromisoformat("2023-11-01"),
+                datetime.datetime.fromisoformat("2023-11-01T10:59:00"),
+            ],
+        ]
+        description = [
+            ["name", "string", None, None, None, None, None],
+            ["created_date", "date", None, None, None, None, None],
+            ["updated_datetime", "date", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, data, description)
+
+    @patch("psycopg2.connect")
+    def test_privilege_error(self, mock_connect):
+        query = ""
+        data = []
+        description = []
+        self._test_run_query(
+            mock_connect,
+            query,
+            data,
+            description,
+            raise_exception=InsufficientPrivilege("insufficient privilege"),
+            expected_error_type="InsufficientPrivilege",
+        )
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "execute",
+                    "args": [
+                        query,
+                        None,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "redshift",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _RS_CREDENTIALS,
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+
+        mock_connect.assert_called_with(**_RS_CREDENTIALS)
+        self._mock_cursor.execute.assert_has_calls(
+            [
+                call(query, None),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        self.assertTrue("description" in result)
+        self.assertEqual(description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        else:
+            return value


### PR DESCRIPTION
- New Redshift proxy client that uses `psycopg2` library.
- Created a base class: `BaseDbProxyClient` that should work in the future as the base class for other database clients like Postgres, MSSQL, etc.
- Added code to discard cached clients if an exception was raised during the execution of an operation, noticed that Redshift clients keep raising errors after an Exception occurred.
