### PR TITLE
Improved how we obtain the current image attribute for the GCP service

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -23,6 +23,7 @@ from apollo.agent.updater import AgentUpdater
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.interfaces.agent_response import AgentResponse
+from apollo.interfaces.cloudrun.metadata_service import GCP_PLATFORM_INFO_KEY_IMAGE
 from apollo.validators.validate_network import ValidateNetwork
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,13 @@ class Agent:
                 operation_name="health_information",
             ),
         )
+        if self._updater:
+            if self._platform_info is None:
+                self._platform_info = {}
+            self._platform_info[
+                GCP_PLATFORM_INFO_KEY_IMAGE
+            ] = self._updater.get_current_image(self._platform_info)
+
         return AgentHealthInformation(
             version=VERSION,
             build=BUILD_NUMBER,

--- a/apollo/agent/updater.py
+++ b/apollo/agent/updater.py
@@ -25,3 +25,10 @@ class AgentUpdater(ABC):
         :param timeout_seconds: optional timeout, the default value is decided by the implementation.
         """
         pass
+
+    @abstractmethod
+    def get_current_image(self, platform_info: Optional[Dict]) -> Optional[str]:
+        """
+        Returns the image currently used by this service, used by the `health` endpoint.
+        """
+        pass

--- a/apollo/interfaces/cloudrun/cloudrun_updater.py
+++ b/apollo/interfaces/cloudrun/cloudrun_updater.py
@@ -85,8 +85,16 @@ class CloudRunUpdater(AgentUpdater):
             "revision": update_result.latest_created_revision,
         }
 
+    def get_current_image(self, platform_info: Optional[Dict]) -> Optional[str]:
+        """
+        Returns the image currently used by this service, used by the `health` endpoint.
+        """
+        if not platform_info:
+            return None
+        return self._get_service_image(platform_info)
+
     @classmethod
-    def get_service_image(cls, platform_info: Dict) -> Optional[str]:
+    def _get_service_image(cls, platform_info: Dict) -> Optional[str]:
         """
         Returns the current image used by the service, the information is retrieved from the `image` attribute
         for the first container in the template, that should be the only container for CloudRun services, the
@@ -135,9 +143,7 @@ class CloudRunUpdater(AgentUpdater):
                 "Service name and region are required to update a CloudRun service"
             )
 
-        logger.info(
-            f"CloudRun update requested, service={service_name}, region={region}"
-        )
+        logger.info(f"CloudRun service lookup, service={service_name}, region={region}")
         client = run_v2.ServicesClient()
         service_full_name = cls._get_service_full_name(service_name, region)
         logger.info(f"CloudRun service full name resolved to {service_full_name}")

--- a/apollo/interfaces/cloudrun/main.py
+++ b/apollo/interfaces/cloudrun/main.py
@@ -11,7 +11,6 @@ from apollo.interfaces.cloudrun.metadata_service import (
     GCP_PLATFORM_INFO_KEY_REGION,
     GCP_PLATFORM_INFO_KEY_SERVICE_NAME,
     GCP_ENV_NAME_SERVICE_NAME,
-    GCP_PLATFORM_INFO_KEY_IMAGE,
 )
 
 # CloudRun specific application that adds support for structured logging
@@ -46,16 +45,10 @@ app = main.app
 
 # set the container platform as GCP for the health endpoint
 main.agent.platform = PLATFORM_GCP
-platform_info = {
+main.agent.platform_info = {
     GCP_PLATFORM_INFO_KEY_SERVICE_NAME: os.getenv(GCP_ENV_NAME_SERVICE_NAME),
     GCP_PLATFORM_INFO_KEY_PROJECT_ID: GcpMetadataService.get_project_id(),
     GCP_PLATFORM_INFO_KEY_REGION: GcpMetadataService.get_instance_region(),
 }
-
-# add the image from service metadata to platform info, if we can get it
-image = CloudRunUpdater.get_service_image(platform_info)
-if image:
-    platform_info[GCP_PLATFORM_INFO_KEY_IMAGE] = image
-main.agent.platform_info = platform_info
 
 main.agent.updater = CloudRunUpdater()


### PR DESCRIPTION
Moved the code that retrieves the image for the current service from service startup to the health endpoint, that gives us a little bit more of time for permissions to be applied on the initial startup.

Also, with the previous approach if we weren't able to retrieve the image when the service started we were not requesting it again and not returning it until a new instance is used.
Now we're requesting it every time the `health` endpoint is invoked.