### PR TITLE
KIL-2629: Logging improvements

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -1,15 +1,20 @@
 import logging
 import os
 import sys
+import time
+from contextlib import contextmanager
 from typing import Any, Dict, Optional
 
 from apollo.agent.env_vars import HEALTH_ENV_VARS, IS_REMOTE_UPGRADABLE_ENV_VAR
 from apollo.agent.evaluation_utils import AgentEvaluationUtils
+from apollo.agent.log_context import AgentLogContext
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.agent.constants import (
     CONTEXT_VAR_UTILS,
     CONTEXT_VAR_CLIENT,
     PLATFORM_GENERIC,
+    LOG_ATTRIBUTE_TRACE_ID,
+    LOG_ATTRIBUTE_OPERATION_NAME,
 )
 from apollo.agent.operation_utils import OperationUtils
 from apollo.agent.models import (
@@ -35,6 +40,7 @@ class Agent:
         self._platform = PLATFORM_GENERIC
         self._platform_info = {}
         self._updater: Optional[AgentUpdater] = None
+        self._log_context: Optional[AgentLogContext] = None
 
     @property
     def platform(self) -> str:
@@ -67,6 +73,14 @@ class Agent:
     def updater(self, updater: Optional[AgentUpdater]):
         self._updater = updater
 
+    @property
+    def log_context(self) -> Optional[AgentLogContext]:
+        return self._log_context
+
+    @log_context.setter
+    def log_context(self, log_context: Optional[AgentLogContext]):
+        self._log_context = log_context
+
     def health_information(self, trace_id: Optional[str]) -> AgentHealthInformation:
         """
         Returns platform and environment information about the agent:
@@ -78,19 +92,20 @@ class Agent:
         - the received value for `trace_id` if any
         :return: an `AgentHealthInformation` object that can be converted to JSON.
         """
-        logger.info(
-            "Health information request received",
-            extra=self._logging_utils.build_extra(
-                trace_id=trace_id,
-                operation_name="health_information",
-            ),
-        )
-        if self._updater:
-            if self._platform_info is None:
-                self._platform_info = {}
-            self._platform_info[
-                GCP_PLATFORM_INFO_KEY_IMAGE
-            ] = self._updater.get_current_image(self._platform_info)
+        with self._inject_log_context("health_information", trace_id):
+            logger.info(
+                "Health information request received",
+                extra=self._logging_utils.build_extra(
+                    trace_id=trace_id,
+                    operation_name="health_information",
+                ),
+            )
+            if self._updater:
+                if self._platform_info is None:
+                    self._platform_info = {}
+                self._platform_info[
+                    GCP_PLATFORM_INFO_KEY_IMAGE
+                ] = self._updater.get_current_image(self._platform_info)
 
         return AgentHealthInformation(
             version=VERSION,
@@ -117,21 +132,22 @@ class Agent:
             if non-numeric. Defaults to 5 seconds.
         :param trace_id: Optional trace ID received from the client that will be included in the response, if present.
         """
-        logger.info(
-            "Validate TCP Open request received",
-            extra=self._logging_utils.build_extra(
-                trace_id=trace_id,
-                operation_name="test_network_open",
-                extra=dict(
-                    host=host,
-                    port=port_str,
-                    timeout=timeout_str,
+        with self._inject_log_context("test_network_open", trace_id):
+            logger.info(
+                "Validate TCP Open request received",
+                extra=self._logging_utils.build_extra(
+                    trace_id=trace_id,
+                    operation_name="test_network_open",
+                    extra=dict(
+                        host=host,
+                        port=port_str,
+                        timeout=timeout_str,
+                    ),
                 ),
-            ),
-        )
-        return ValidateNetwork.validate_tcp_open_connection(
-            host, port_str, timeout_str, trace_id
-        )
+            )
+            return ValidateNetwork.validate_tcp_open_connection(
+                host, port_str, timeout_str, trace_id
+            )
 
     def validate_telnet_connection(
         self,
@@ -149,21 +165,22 @@ class Agent:
             if non-numeric. Defaults to 5 seconds.
         :param trace_id: Optional trace ID received from the client that will be included in the response, if present.
         """
-        logger.info(
-            "Validate Telnet connection request received",
-            extra=self._logging_utils.build_extra(
-                trace_id=trace_id,
-                operation_name="test_network_telnet",
-                extra=dict(
-                    host=host,
-                    port=port_str,
-                    timeout=timeout_str,
+        with self._inject_log_context("test_network_telnet", trace_id):
+            logger.info(
+                "Validate Telnet connection request received",
+                extra=self._logging_utils.build_extra(
+                    trace_id=trace_id,
+                    operation_name="test_network_telnet",
+                    extra=dict(
+                        host=host,
+                        port=port_str,
+                        timeout=timeout_str,
+                    ),
                 ),
-            ),
-        )
-        return ValidateNetwork.validate_telnet_connection(
-            host, port_str, timeout_str, trace_id
-        )
+            )
+            return ValidateNetwork.validate_telnet_connection(
+                host, port_str, timeout_str, trace_id
+            )
 
     def update(
         self,
@@ -179,16 +196,17 @@ class Agent:
         the env var `MCD_AGENT_IS_REMOTE_UPGRADABLE` is set to `true`.
         The returned response is a dictionary returned by the agent updater implementation.
         """
-        try:
-            result = self._perform_update(
-                trace_id=trace_id,
-                image=image,
-                timeout_seconds=timeout_seconds,
-                **kwargs,
-            )
-            return AgentUtils.agent_ok_response(result, trace_id)
-        except Exception:
-            return AgentUtils.agent_response_for_last_exception("Update failed:")
+        with self._inject_log_context("update", trace_id):
+            try:
+                result = self._perform_update(
+                    trace_id=trace_id,
+                    image=image,
+                    timeout_seconds=timeout_seconds,
+                    **kwargs,
+                )
+                return AgentUtils.agent_ok_response(result, trace_id)
+            except Exception:
+                return AgentUtils.agent_response_for_last_exception("Update failed:")
 
     def _perform_update(
         self,
@@ -290,15 +308,30 @@ class Agent:
         operation_name: str,
         operation: AgentOperation,
     ) -> AgentResponse:
-        logger.info(
-            f"Executing operation: {connection_type}/{operation_name}",
-            extra=self._logging_utils.build_extra(
-                operation.trace_id,
-                operation_name,
-                client.log_payload(operation),
-            ),
-        )
-        result = self._execute(client, self._logging_utils, operation_name, operation)
+        start_time = time.time()
+        with self._inject_log_context(
+            f"{connection_type}/{operation_name}", operation.trace_id
+        ):
+            logger.info(
+                f"Executing operation: {connection_type}/{operation_name}",
+                extra=self._logging_utils.build_extra(
+                    operation.trace_id,
+                    operation_name,
+                    client.log_payload(operation),
+                ),
+            )
+
+            result = self._execute(
+                client, self._logging_utils, operation_name, operation
+            )
+            logger.debug(
+                f"Operation executed: {connection_type}/{operation_name}",
+                extra=self._logging_utils.build_extra(
+                    operation.trace_id,
+                    operation_name,
+                    dict(elapsed_time=time.time() - start_time),
+                ),
+            )
         return AgentResponse(result or {}, 200, operation.trace_id)
 
     @staticmethod
@@ -320,3 +353,19 @@ class Agent:
             operation.commands,
             operation.trace_id,
         )
+
+    @contextmanager
+    def _inject_log_context(self, operation_name: str, trace_id: Optional[str]):
+        if self._log_context:
+            context = {
+                LOG_ATTRIBUTE_OPERATION_NAME: operation_name,
+            }
+            if trace_id:
+                context[LOG_ATTRIBUTE_TRACE_ID] = trace_id
+
+            self._log_context.set_agent_context(context)
+        try:
+            yield None
+        finally:
+            if self._log_context:
+                self._log_context.set_agent_context({})

--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -44,6 +44,12 @@ ATTRIBUTE_VALUE_TYPE_LOOKER_CATEGORY = "looker.category"
 # Value to use when redacting sensitive data in log messages
 ATTRIBUTE_VALUE_REDACTED = "__redacted__"
 
+# Attribute name for trace id in log messages
+LOG_ATTRIBUTE_TRACE_ID = "mcd_trace_id"
+
+# Attribute name for operation name in log messages
+LOG_ATTRIBUTE_OPERATION_NAME = "mcd_operation_name"
+
 # Name of the client variable in the evaluation context, this is the default value for `target` in calls
 CONTEXT_VAR_CLIENT = "_client"
 

--- a/apollo/agent/env_vars.py
+++ b/apollo/agent/env_vars.py
@@ -30,6 +30,7 @@ STORAGE_BUCKET_NAME_ENV_VAR = "MCD_STORAGE_BUCKET_NAME"
 # Environment variable used to initialize Flask application with debug=True and to set log level to debug
 # Used only by the generic interface when `interfaces/generic/main.py` is executed.
 DEBUG_ENV_VAR = "MCD_DEBUG"
+DEBUG_LOG_ENV_VAR = "MCD_DEBUG_LOG"
 
 TEMP_PATH_ENV_VAR = "MCD_TEMP_FOLDER"
 DEFAULT_TEMP_PATH = "/tmp"

--- a/apollo/agent/log_context.py
+++ b/apollo/agent/log_context.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class AgentLogContext(ABC):
+    """
+    Base abstract class representing an object where the agent sets the log context for the current operation.
+    Before an operation is executed the agent will call `set_agent_context` with information to be included in log
+    messages like trace id and operation name.
+    How this information is used is platform dependent, for example GCP stores it and then uses it in `logging.Filter`
+    implementation.
+    """
+
+    @abstractmethod
+    def set_agent_context(self, context: Dict):
+        """
+        Set the context information for the current operation.
+        :param context: a dictionary including information that should be logged with each request.
+        """
+        pass

--- a/apollo/agent/logging_utils.py
+++ b/apollo/agent/logging_utils.py
@@ -1,15 +1,17 @@
 from typing import Dict, Optional
 
+from apollo.agent.constants import LOG_ATTRIBUTE_TRACE_ID, LOG_ATTRIBUTE_OPERATION_NAME
+
 
 class LoggingUtils:
     def __init__(self):
         def builder(trace_id: Optional[str], operation_name: str, extra: Dict):
             extra = {
-                "operation_name": operation_name,
+                LOG_ATTRIBUTE_OPERATION_NAME: operation_name,
                 **extra,
             }
             if trace_id:
-                extra["trace_id"] = trace_id
+                extra[LOG_ATTRIBUTE_TRACE_ID] = trace_id
             return extra
 
         self.extra_builder = builder

--- a/apollo/integrations/base_proxy_client.py
+++ b/apollo/integrations/base_proxy_client.py
@@ -26,7 +26,12 @@ class BaseProxyClient(ABC):
         :return: The `extra` payload to include in the log message, by default `operation.to_dict()` but sub classes
             can override to return more or less data (for example to trim/redact sensitive data).
         """
-        return operation.to_dict()
+        extra = operation.to_dict()
+
+        # we're already logging trace_id as mcd_trace_id, avoid the duplicated attribute
+        extra.pop("trace_id", None)
+
+        return extra
 
     def process_result(self, value: Any) -> Any:
         """

--- a/apollo/interfaces/cloudrun/cloudrun_log_context.py
+++ b/apollo/interfaces/cloudrun/cloudrun_log_context.py
@@ -1,0 +1,29 @@
+from copy import deepcopy
+from typing import Dict, Any
+
+from apollo.agent.log_context import AgentLogContext
+
+
+class CloudRunLogContext(AgentLogContext):
+    """
+    Implements AgentLogContext, stores the context information and uses it in the filter method by appending it
+    to the `json_fields` information in the log record.
+    """
+
+    def __init__(self):
+        self._context: Dict = {}
+
+    def set_agent_context(self, context: Dict):
+        self._context = deepcopy(context)
+
+    def filter(self, record: Any) -> Any:
+        """
+        Updates the log record with the agent context
+        """
+        if not self._context:
+            return record
+
+        json_fields: Dict = getattr(record, "json_fields", {})
+        json_fields.update(self._context)
+        record.json_fields = json_fields
+        return record

--- a/tests/test_agent_commands.py
+++ b/tests/test_agent_commands.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+from unittest.mock import create_autospec, call
 
 from apollo.agent.agent import Agent
+from apollo.agent.log_context import AgentLogContext
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.agent.models import AgentOperation
 from sample_proxy_client import SampleProxyClient
@@ -126,3 +128,23 @@ class AgentCommandsTests(TestCase):
             ),
         )
         self.assertEqual(self._expected_result, result)
+
+    def test_log_context(self):
+        agent = Agent(LoggingUtils())
+        log_context = create_autospec(AgentLogContext)
+        agent.log_context = log_context
+
+        trace_id = "135"
+        agent.health_information(trace_id)
+
+        log_context.set_agent_context.assert_has_calls(
+            [
+                call(
+                    {
+                        "mcd_operation_name": "health_information",
+                        "mcd_trace_id": trace_id,
+                    }
+                ),
+                call({}),
+            ]
+        )


### PR DESCRIPTION
- Provides a way to enable debug logging by setting env var `MCD_DEBUG_LOG` to `true`
- Includes a debug message when an operation completes, including the elapsed time
- Updates the names of the attributes in log messages used for trace_id and operation_name to `mcd_trace_id` and `mcd_operation_name`
- Uses `logging.Filter` feature to update the logging context including `trace_id` and `operation_name` for all requests, this ends up including this information in all logs, including those from other libraries, helping to get all logs related to a single operation when filtering by `mcd_trace_id`.
