### PR TITLE
Updated pyarrow to resolve CVE-2023-47248

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -8,4 +8,5 @@ google-cloud-storage==2.10.0
 gunicorn==21.2.0
 lambda-git==0.1.1
 looker-sdk==23.16.0
+pyarrow==14.0.1  # CVE-2023-47248
 retry2==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -122,8 +122,10 @@ protobuf==4.24.2
     # via
     #   google-api-core
     #   googleapis-common-protos
-pyarrow==13.0.0
-    # via databricks-sql-connector
+pyarrow==14.0.1
+    # via
+    #   -r requirements.in
+    #   databricks-sql-connector
 pyasn1==0.5.0
     # via
     #   pyasn1-modules


### PR DESCRIPTION
- `pyarrow` updated to 14.0.1 to fix CVE-2023-47248
- verified on our `dev` environment that `databricks-sql` (the package using `pyarrow`) is working fine