### PR TITLE
KIL-2744 Fix invalid execute params type for SQL Server proxy client

### DIFF
--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Dict,
+    Iterable,
     Optional,
 )
 
@@ -9,6 +10,28 @@ import pymssql
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
+
+
+class SqlServerProxyClientCursor:
+    def __init__(self, wrapped_cursor: Any):
+        self._wrapped_cursor = wrapped_cursor
+
+    @property
+    def description(self) -> Any:
+        return self._wrapped_cursor.description
+
+    def execute(self, query: str, params: Optional[Iterable] = None, **kwargs: Any):
+        self._wrapped_cursor.execute(query, tuple(params) if params else None, **kwargs)
+
+    def fetchall(self) -> Any:
+        return self._wrapped_cursor.fetchall()
+
+    def fetchmany(self, size: int) -> Any:
+        return self._wrapped_cursor.fetchmany(size)
+
+    @property
+    def rowcount(self) -> Any:
+        return self._wrapped_cursor.rowcount
 
 
 class SqlServerProxyClient(BaseDbProxyClient):
@@ -28,3 +51,6 @@ class SqlServerProxyClient(BaseDbProxyClient):
     @property
     def wrapped_client(self):
         return self._connection
+
+    def cursor(self) -> Any:
+        return SqlServerProxyClientCursor(self.wrapped_client.cursor())

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -53,4 +53,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
         return self._connection
 
     def cursor(self) -> Any:
+        """
+        This is necessary because unlike other db proxy clients, MSSQL requires the query
+        arguments being passed into the execute function to be of type tuple.
+        So we override the cursor object in order to properly cast the params object.
+        """
         return SqlServerProxyClientCursor(self.wrapped_client.cursor())


### PR DESCRIPTION
- Uses a custom cursor class `SqlServerProxyClientCursor` to override the query parameters and provided them as a tuple instead of a list for SQL Server's client
- Fixes the [sentry error](https://monte-carlo-data.sentry.io/issues/4643357426/?alert_rule_id=11714577&alert_type=issue&environment=dev&notification_uuid=4153e0de-851e-4d12-895c-3bed8cfdcf0f&project=3527635&referrer=slack): `'params' arg (<class 'list'>) can be only a tuple or a dictionary.`