### PR TITLE
KIL-2744 Oracle DB proxy client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -112,6 +112,14 @@ def _get_proxy_client_mysql(
     return MysqlProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_oracle(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.oracle_proxy_client import OracleProxyClient
+
+    return OracleProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -130,6 +138,7 @@ _CLIENT_FACTORY_MAPPING = {
     "sql-server": _get_proxy_client_sql_server,
     "snowflake": _get_proxy_client_snowflake,
     "mysql": _get_proxy_client_mysql,
+    "oracle": _get_proxy_client_oracle,
 }
 
 

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -1,5 +1,9 @@
 from abc import ABC
-from typing import Any, Dict, List
+from typing import (
+    Any,
+    Dict,
+    List,
+)
 
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
@@ -18,7 +22,9 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
             if "description" in value:
                 description = value["description"]
                 value["description"] = [
-                    [col[0], col[1], col[2], col[3], col[4], col[5], col[6]]
+                    self._process_description(
+                        [col[0], col[1], col[2], col[3], col[4], col[5], col[6]]
+                    )
                     for col in description
                 ]
             if "all_results" in value:
@@ -30,3 +36,7 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
     @staticmethod
     def _process_row(row: List) -> List:
         return [AgentUtils.serialize_value(v) for v in row]
+
+    @classmethod
+    def _process_description(cls, description: List) -> List:
+        return [AgentUtils.serialize_value(v) for v in description]

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -43,6 +43,9 @@ class OracleProxyClient(BaseDbProxyClient):
             # type_code which we expect. Here we are converting this type to a string of the type
             # so the description can be serialized. So <DbType DB_TYPE_NUMBER> will become just
             # DB_TYPE_NUMBER.
+            # This doesn't use the __type__/__data__ scheme because we don't have enough
+            # information on the client side to reconstruct the type concretely, so instead we're
+            # just returning the form the client expects.
             return value.name
         else:
             return AgentUtils.serialize_value(value)

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -1,0 +1,30 @@
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+import oracledb
+
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class OracleProxyClient(BaseDbProxyClient):
+    """
+    Proxy client for Oracle DB Client. Credentials are expected to be supplied under "connect_args"
+    and will be passed directly to `oracledb.connect`, so only attributes supported as parameters
+    by `oracledb.connect` should be passed.
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Oracle DB agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+        self._connection = oracledb.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+
+    @property
+    def wrapped_client(self):
+        return self._connection

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -1,11 +1,14 @@
 from typing import (
     Any,
     Dict,
+    List,
     Optional,
 )
 
 import oracledb
+from oracledb.base_impl import DbType
 
+from apollo.agent.utils import AgentUtils
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
@@ -28,3 +31,18 @@ class OracleProxyClient(BaseDbProxyClient):
     @property
     def wrapped_client(self):
         return self._connection
+
+    @classmethod
+    def _process_description(cls, description: List) -> List:
+        return [cls._serialize_description(v) for v in description]
+
+    @classmethod
+    def _serialize_description(cls, value: Any) -> Any:
+        if isinstance(value, DbType):
+            # Oracle cursor returns the column type as <DbType DB_TYPE_NUMBER> instead of a
+            # type_code which we expect. Here we are converting this type to a string of the type
+            # so the description can be serialized. So <DbType DB_TYPE_NUMBER> will become just
+            # DB_TYPE_NUMBER.
+            return value.name
+        else:
+            return AgentUtils.serialize_value(value)

--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ google-cloud-storage==2.10.0
 gunicorn==21.2.0
 lambda-git==0.1.1
 looker-sdk==23.16.0
+oracledb>=1.3.1
 psycopg2-binary==2.9.7
 pyarrow==14.0.1  # CVE-2023-47248
 pymssql>=2.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,7 @@ click==8.1.7
 cryptography==41.0.5
     # via
     #   azure-storage-blob
+    #   oracledb
     #   pyopenssl
     #   snowflake-connector-python
 databricks-sql-connector==2.8.0
@@ -139,6 +140,8 @@ oauthlib==3.2.2
     # via databricks-sql-connector
 openpyxl==3.1.2
     # via databricks-sql-connector
+oracledb==1.4.2
+    # via -r requirements.in
 oscrypto==1.3.0
     # via snowflake-connector-python
 packaging==23.1

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -1,0 +1,166 @@
+import datetime
+from typing import (
+    Iterable,
+    List,
+    Any,
+    Optional,
+)
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+from psycopg2.errors import InsufficientPrivilege  # noqa
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_ORACLE_DB_CREDENTIALS = {
+    "dsn": "www.example.com:1521/ORCL",
+    "user": "u",
+    "password": "p",
+}
+
+
+class OracleDbClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+        self.maxDiff = None
+
+    @patch("oracledb.connect")
+    def test_query(self, mock_connect):
+        query = "SELECT name, value FROM table OFFSET :1 ROWS FETCH NEXT :2 ROWS ONLY"  # noqa
+        args = [0, 2]
+        expected_data = [
+            [
+                "name_1",
+                11.1,
+            ],
+            [
+                "name_2",
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["name", "string", None, None, None, None, None],
+            ["value", "float", None, None, None, None, None],
+        ]
+        self._test_run_query(
+            mock_connect, query, args, expected_data, expected_description
+        )
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        query_args: Optional[Iterable[Any]],
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "execute",
+                    "args": [
+                        query,
+                        query_args,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "oracle",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _ORACLE_DB_CREDENTIALS,
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+
+        mock_connect.assert_called_with(**_ORACLE_DB_CREDENTIALS)
+        self._mock_cursor.execute.assert_has_calls(
+            [
+                call(query, query_args),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        self.assertTrue("description" in result)
+        self.assertEqual(description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        else:
+            return value


### PR DESCRIPTION
#### What's new?
- Adds a new `OracleProxyClient` for processing agent executions with connection type `oracle`.
- Adds a `_process_description` hook to the `BaseDbProxyClient` that can be overridden to customize the serialization of the returned description data.
- Overrides `_process_description` in `OracleProxyClient` to handle the presence of the `DbType` values Oracle returns in place of the column type values.