### PR TITLE
KIL-2744 Teradata proxy client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -120,6 +120,14 @@ def _get_proxy_client_oracle(
     return OracleProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_teradata(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.teradata_proxy_client import TeradataProxyClient
+
+    return TeradataProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -139,6 +147,7 @@ _CLIENT_FACTORY_MAPPING = {
     "snowflake": _get_proxy_client_snowflake,
     "mysql": _get_proxy_client_mysql,
     "oracle": _get_proxy_client_oracle,
+    "teradata": _get_proxy_client_teradata,
 }
 
 

--- a/apollo/integrations/db/teradata_proxy_client.py
+++ b/apollo/integrations/db/teradata_proxy_client.py
@@ -1,0 +1,38 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
+
+import teradatasql
+
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class TeradataProxyClient(BaseDbProxyClient):
+    """
+    Proxy client for Teradata Client. Credentials are expected to be supplied under "connect_args"
+    and will be passed directly to `teradatasql.connect`, so only attributes supported as parameters
+    by `teradatasql.connect` should be passed.
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Teradata agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+        self._connection = teradatasql.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+
+    @property
+    def wrapped_client(self):
+        return self._connection
+
+    @classmethod
+    def _process_description(cls, col: List) -> List:
+        # Teradata cursor returns the column type as <class 'str'> instead of a type_code which
+        # we expect. Here we are converting this type to a string of the type so the description
+        # can be serialized. So <class 'str'> will become just 'str'
+        return [col[0], col[1].__name__, col[2], col[3], col[4], col[5], col[6]]

--- a/requirements.in
+++ b/requirements.in
@@ -16,4 +16,5 @@ pymssql>=2.2.8
 PyMySQL>=1.1.0
 retry2==0.9.5
 snowflake-connector-python>=3.1.0
+teradatasql>=17.20.0.31
 urllib3==1.26.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -171,6 +171,8 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
+pycryptodome==3.19.0
+    # via teradatasql
 pycryptodomex==3.19.0
     # via snowflake-connector-python
 pyjwt==2.8.0
@@ -221,6 +223,8 @@ sqlalchemy==1.4.49
     # via
     #   alembic
     #   databricks-sql-connector
+teradatasql==20.0.0.1
+    # via -r requirements.in
 thrift==0.16.0
     # via databricks-sql-connector
 tomlkit==0.12.3

--- a/tests/test_teradata_client.py
+++ b/tests/test_teradata_client.py
@@ -1,0 +1,175 @@
+import datetime
+from typing import (
+    Iterable,
+    List,
+    Any,
+    Optional,
+)
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_TERADATA_CREDENTIALS = {
+    "host": "www.example.com",
+    "port": "3306",
+    "user": "u",
+    "password": "p",
+}
+
+
+class TeradataClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+        self.maxDiff = None
+
+    @patch("teradatasql.connect")
+    def test_query(self, mock_connect):
+        query = "SELECT name, value FROM table WHERE value > %s"  # noqa
+        args = [10]
+        expected_data = [
+            [
+                "name_1",
+                11.1,
+            ],
+            [
+                "name_2",
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["name", str.__class__, None, None, None, None, None],
+            ["value", float.__class__, None, None, None, None, None],
+        ]
+        self._test_run_query(
+            mock_connect, query, args, expected_data, expected_description
+        )
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        query_args: Optional[Iterable[Any]],
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "execute",
+                    "args": [
+                        query,
+                        query_args,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "teradata",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _TERADATA_CREDENTIALS,
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+
+        mock_connect.assert_called_with(**_TERADATA_CREDENTIALS)
+        self._mock_cursor.execute.assert_has_calls(
+            [
+                call(query, query_args),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        expected_description = self._serialized_description(description)
+        self.assertTrue("description" in result)
+        self.assertEqual(expected_description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_description(cls, description: List) -> List:
+        return [cls._serialized_col(v) for v in description]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_col(cls, col: List) -> List:
+        return [col[0], col[1].__name__, col[2], col[3], col[4], col[5], col[6]]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        else:
+            return value


### PR DESCRIPTION
#### What's new?
- Adds a new `TeradataProxyClient` for processing agent executions with connection type teradata.
- Overrides `_process_description` in `TeradataProxyClient` to convert the column type property to a string of the type name instead of an object of the class type.