### PR TITLE
Fix pyright linter failures in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
 
   run-linter:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.8-node
 
     steps:
       - checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
       types_or: [python, pyi]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.329
+    rev: v1.1.337
     hooks:
     - id: pyright

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,5 +2,5 @@
 pytest==7.4.2
 black==23.9.1
 pre-commit==3.5.0
-pyright==1.1.329
+pyright==1.1.337
 python-box==7.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,7 +46,7 @@ pluggy==1.3.0
     # via pytest
 pre-commit==3.5.0
     # via -r requirements-dev.in
-pyright==1.1.329
+pyright==1.1.337
     # via -r requirements-dev.in
 pytest==7.4.2
     # via -r requirements-dev.in


### PR DESCRIPTION
#### What's new?
We were encountering errors like this
```
File "/home/circleci/.pyenv/versions/3.8.18/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/home/circleci/project/.venv/bin/python', '-m', 'nodeenv', '/home/circleci/.cache/pyright-python/nodeenv']' returned non-zero exit status 1.
```
when running pyright in CI. And according to https://github.com/RobertCraigie/pyright-python#how-pyright-for-python-works:
>This project works by first checking if node is in the PATH. If it is not, then we download node at runtime using [nodeenv](https://github.com/ekalinin/nodeenv), then install the pyright npm package using npm and finally, run the downloaded JS with node.

So we are updating the image being used to run the linter job in CircleCI to a python image with node already installed. We've also bumped the version of pyright to the latest v1.1.337 (with some type fixes to the http_proxy_client).
