### PR TITLE
KIL-2779 [Agent] dbt Cloud client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ ENV VENV_DIR .venv
 WORKDIR $APP_HOME
 COPY requirements.txt ./
 
-RUN apt update
-# install git as we need it for the git clone client
-RUN apt install git -y
-
 RUN python -m venv $VENV_DIR
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
 
@@ -43,6 +39,10 @@ FROM base AS cloudrun
 
 COPY requirements-cloudrun.txt ./
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloudrun.txt
+
+RUN apt update
+# install git as we need it for the git clone client
+RUN apt install git -y
 
 CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ENV VENV_DIR .venv
 WORKDIR $APP_HOME
 COPY requirements.txt ./
 
+RUN apt update
+# install git as we need it for the git clone client
+RUN apt install git -y
+
 RUN python -m venv $VENV_DIR
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
 
@@ -39,10 +43,6 @@ FROM base AS cloudrun
 
 COPY requirements-cloudrun.txt ./
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloudrun.txt
-
-RUN apt update
-# install git as we need it for the git clone client
-RUN apt install git -y
 
 CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -167,7 +167,7 @@ class HttpProxyClient(BaseProxyClient):
 
     def get_error_extra_attributes(self, error: Exception) -> Optional[Dict]:
         cause = error.__cause__ or error
-        if isinstance(cause, HTTPError) and cause.response:
+        if isinstance(cause, HTTPError) and cause.response is not None:
             return {
                 "status_code": cause.response.status_code,
                 "reason": cause.response.reason,

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -57,6 +57,7 @@ class HttpProxyClient(BaseProxyClient):
         timeout: Optional[int] = None,
         user_agent: Optional[str] = None,
         additional_headers: Optional[Dict] = None,
+        params: Optional[Dict] = None,
         retry_status_code_ranges: Optional[List[Tuple]] = None,
     ) -> Dict:
         """
@@ -70,6 +71,7 @@ class HttpProxyClient(BaseProxyClient):
         :param timeout: optional timeout in seconds
         :param user_agent: optional value for User-Agent header
         :param additional_headers: optional headers
+        :param params: optional parameters dictionary to include in the query string.
         :param retry_status_code_ranges: optional list of ranges specifying status code to raise `HttpRetryableError`.
             The ranges are expected to be specified in a list of tuples where each tuple includes two elements:
             inclusive from and exclusive to, for example: [(500, 600)] means: `500 <= status_code < 600`.
@@ -81,10 +83,13 @@ class HttpProxyClient(BaseProxyClient):
             request_args["json"] = payload
         if timeout:
             request_args["timeout"] = timeout
+        if params:
+            request_args["params"] = params
 
         headers = {**additional_headers} if additional_headers else {}
         if self._credentials and "token" in self._credentials:
-            headers["Authorization"] = f"Bearer {self._credentials['token']}"
+            auth_type = self._credentials.get("auth_type", "Bearer")
+            headers["Authorization"] = f"{auth_type} {self._credentials['token']}"
         if content_type:
             headers["Content-Type"] = content_type
         if user_agent:
@@ -95,8 +100,8 @@ class HttpProxyClient(BaseProxyClient):
         try:
             response.raise_for_status()
         except HTTPError as err:
-            status_code = err.response.status_code if err.response else 0
-            text = err.response.text if err.response else ""
+            status_code = response.status_code
+            text = response.text or str(err)
             _logger.exception(
                 f"Request failed with {status_code}",
                 extra=dict(error_text=text),
@@ -121,6 +126,7 @@ class HttpProxyClient(BaseProxyClient):
         timeout: Optional[int] = None,
         user_agent: Optional[str] = None,
         additional_headers: Optional[Dict] = None,
+        params: Optional[Dict] = None,
         retry_status_code_ranges: Optional[List[Tuple]] = None,
         retry_args: Optional[Dict] = None,
     ) -> Dict:
@@ -145,11 +151,29 @@ class HttpProxyClient(BaseProxyClient):
                 "timeout": timeout,
                 "user_agent": user_agent,
                 "additional_headers": additional_headers,
+                "params": params,
                 "retry_status_code_ranges": retry_status_code_ranges,
             },
             exceptions=HttpRetryableError,
             **retry_params,  # type: ignore
         )
+
+    def get_error_type(self, error: Exception) -> Optional[str]:
+        cause = error.__cause__ or error
+        if isinstance(cause, HTTPError):
+            return "HTTPError"
+        else:
+            return super().get_error_type(error=error)
+
+    def get_error_extra_attributes(self, error: Exception) -> Optional[Dict]:
+        cause = error.__cause__ or error
+        if isinstance(cause, HTTPError) and cause.response:
+            return {
+                "status_code": cause.response.status_code,
+                "reason": cause.response.reason,
+            }
+        else:
+            return super().get_error_extra_attributes(error=error)
 
     @staticmethod
     def _is_retry_status_code(ranges: List[Tuple], status_code: int) -> bool:

--- a/tests/test_databricks_client.py
+++ b/tests/test_databricks_client.py
@@ -13,26 +13,6 @@ _DATABRICKS_CREDENTIALS = {
     "http_path": "/path",
 }
 
-_HTTP_USER_AGENT = "TestUserAgent"
-
-_HTTP_OPERATION = {
-    "trace_id": "1234",
-    "commands": [
-        {
-            "method": "do_request",
-            "kwargs": {
-                "url": "https://test.com/path",
-                "http_method": "GET",
-                "payload": {},
-                "user_agent": _HTTP_USER_AGENT,
-                "additional_headers": None,
-                "retry_status_code_ranges": None,
-            },
-        }
-    ],
-}
-_HTTP_CREDENTIALS = {"token": "123_token"}
-
 
 class DatabricksClientTests(TestCase):
     def setUp(self) -> None:
@@ -171,67 +151,3 @@ class DatabricksClientTests(TestCase):
 
         self.assertTrue("rowcount" in result)
         self.assertEqual(expected_rows, result["rowcount"])
-
-    @patch("requests.request")
-    def test_http_request(self, mock_request):
-        mock_response = create_autospec(Response)
-        mock_request.return_value = mock_response
-        expected_result = {
-            "ok": True,
-        }
-        mock_response.json.return_value = expected_result
-        response = self._agent.execute_operation(
-            "http",
-            "do_request",
-            _HTTP_OPERATION,
-            _HTTP_CREDENTIALS,
-        )
-        mock_request.assert_called_with(
-            "GET",
-            "https://test.com/path",
-            headers={
-                "Authorization": f"Bearer {_HTTP_CREDENTIALS['token']}",
-                "User-Agent": _HTTP_USER_AGENT,
-            },
-        )
-        mock_response.assert_has_calls(
-            [
-                call.raise_for_status(),
-                call.json(),
-            ]
-        )
-        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
-        self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
-
-    @patch("requests.request")
-    def test_http_request_failed(self, mock_request):
-        mock_response = create_autospec(Response)
-        mock_response.status_code = 404
-        mock_response.text = "not found"
-        mock_request.return_value = mock_response
-        mock_response.raise_for_status.side_effect = HTTPError(
-            "failed",
-            response=mock_response,
-        )
-
-        response = self._agent.execute_operation(
-            "http",
-            "do_request",
-            _HTTP_OPERATION,
-            _HTTP_CREDENTIALS,
-        )
-        mock_request.assert_called_with(
-            "GET",
-            "https://test.com/path",
-            headers={
-                "Authorization": f"Bearer {_HTTP_CREDENTIALS['token']}",
-                "User-Agent": _HTTP_USER_AGENT,
-            },
-        )
-        mock_response.assert_has_calls(
-            [
-                call.raise_for_status(),
-            ]
-        )
-        self.assertIsNotNone(response.result.get(ATTRIBUTE_NAME_ERROR))
-        self.assertEqual(mock_response.text, response.result.get(ATTRIBUTE_NAME_ERROR))

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,142 @@
+from copy import deepcopy
+from unittest import TestCase
+from unittest.mock import create_autospec, patch, call
+
+from requests import Response, HTTPError
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+    ATTRIBUTE_NAME_ERROR_ATTRS,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_HTTP_USER_AGENT = "TestUserAgent"
+
+_HTTP_OPERATION = {
+    "trace_id": "1234",
+    "commands": [
+        {
+            "method": "do_request",
+            "kwargs": {
+                "url": "https://test.com/path",
+                "http_method": "GET",
+                "payload": {},
+                "user_agent": _HTTP_USER_AGENT,
+                "additional_headers": None,
+                "retry_status_code_ranges": None,
+            },
+        }
+    ],
+}
+_HTTP_CREDENTIALS = {"token": "123_token"}
+
+
+class TestHttpClient(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    @patch("requests.request")
+    def test_http_request(self, mock_request):
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = {
+            "ok": True,
+        }
+        mock_response.json.return_value = expected_result
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            _HTTP_OPERATION,
+            _HTTP_CREDENTIALS,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                "Authorization": f"Bearer {_HTTP_CREDENTIALS['token']}",
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+        )
+        mock_response.assert_has_calls(
+            [
+                call.raise_for_status(),
+                call.json(),
+            ]
+        )
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
+
+    @patch("requests.request")
+    def test_http_request_with_params(self, mock_request):
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = {
+            "ok": True,
+        }
+        mock_response.json.return_value = expected_result
+        operation = deepcopy(_HTTP_OPERATION)
+        params = {
+            "int_param": 23,
+            "str_param": "abc",
+        }
+        operation["commands"][0]["kwargs"]["params"] = params
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            operation,
+            _HTTP_CREDENTIALS,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                "Authorization": f"Bearer {_HTTP_CREDENTIALS['token']}",
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+            params=params,
+        )
+
+    @patch("requests.request")
+    def test_http_request_failed(self, mock_request):
+        mock_response = create_autospec(Response)
+        mock_response.status_code = 404
+        mock_response.text = "not found"
+        mock_response.reason = "NOT FOUND"
+        mock_request.return_value = mock_response
+        mock_response.raise_for_status.side_effect = HTTPError(
+            "failed",
+            response=mock_response,
+        )
+
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            _HTTP_OPERATION,
+            _HTTP_CREDENTIALS,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                "Authorization": f"Bearer {_HTTP_CREDENTIALS['token']}",
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+        )
+        mock_response.assert_has_calls(
+            [
+                call.raise_for_status(),
+            ]
+        )
+        self.assertIsNotNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(mock_response.text, response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertEqual("HTTPError", response.result.get(ATTRIBUTE_NAME_ERROR_TYPE))
+        self.assertEqual(
+            {
+                "status_code": 404,
+                "reason": mock_response.reason,
+            },
+            response.result.get(ATTRIBUTE_NAME_ERROR_ATTRS),
+        )


### PR DESCRIPTION
- Minor improvements to `HTTP` client:
  - Support `params` argument that is passed to `requests` to be used as query string parameters
  - Return error type and error attributes so the `HTTPError` can be created client side
  - Support auth type credentials attribute (optional and defaulting to `Bearer`) as `dbt` requires the `Authorization` header to be `Token <token>` instead of `Bearer <token>`