### PR TITLE
KIL-2772 Build lambda image for ECR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@4.0.0
+  aws-ecr: circleci/aws-ecr@8.1.3
   docker: circleci/docker@2.2.0
 
 commands:
@@ -101,12 +103,22 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     parameters:
+      aws_ecr_repository:
+        type: string
       docker_hub_repository:
         type: string
       code_version:
         type: string
     steps:
       - checkout
+      - aws-ecr/build-and-push-image:
+          repo: << parameters.aws_ecr_repository >>
+          tag: << parameters.code_version >>
+          extra-build-args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
+      - aws-ecr/tag-image:
+          repo: << parameters.aws_ecr_repository >>
+          source-tag: << parameters.code_version >>
+          target-tag: latest
       - docker/check:
           use-docker-credentials-store: true
       - docker/build:
@@ -145,6 +157,7 @@ workflows:
               only: /.*/
       - build-and-push:
           name: build-and-push-dev
+          aws_ecr_repository: 404798114945.dkr.ecr.us-east-1.amazonaws.com/mcd-pre-release-agent
           docker_hub_repository: pre-release-agent
           code_version: ${NEXT_VERSION}
           pre-steps:
@@ -157,6 +170,7 @@ workflows:
                   echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
                   source $BASH_ENV
           context:
+            - aws-dev
             - docker
           requires:
             - run-linter
@@ -168,6 +182,7 @@ workflows:
                 - dev
       - build-and-push:
           name: build-and-push-prod
+          aws_ecr_repository: 752656882040.dkr.ecr.us-east-1.amazonaws.com/mcd-agent
           docker_hub_repository: agent
           code_version: ${VERSION_TAG}
           pre-steps:
@@ -178,6 +193,7 @@ workflows:
                   echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
                   source $BASH_ENV
           context:
+            - aws-prod
             - docker
           requires:
             - run-linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ commands:
     - run:
         name: Verify version in Docker image
         command: |
-          image_version=$(docker run --rm << parameters.image >> python apollo/agent/settings.py) 
+          image_version=$(docker run --rm --entrypoint python << parameters.image >> apollo/agent/settings.py)
           if [ $image_version = "<< parameters.version >>" ]
             then exit 0
             else echo "Failed to find expected version, found: $image_version"; exit 1
@@ -103,22 +103,12 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     parameters:
-      aws_ecr_repository:
-        type: string
       docker_hub_repository:
         type: string
       code_version:
         type: string
     steps:
       - checkout
-      - aws-ecr/build-and-push-image:
-          repo: << parameters.aws_ecr_repository >>
-          tag: << parameters.code_version >>
-          extra-build-args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-      - aws-ecr/tag-image:
-          repo: << parameters.aws_ecr_repository >>
-          source-tag: << parameters.code_version >>
-          target-tag: latest
       - docker/check:
           use-docker-credentials-store: true
       - docker/build:
@@ -143,6 +133,28 @@ jobs:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-generic,<< parameters.code_version >>-generic,latest-cloudrun,<< parameters.code_version >>-cloudrun
 
+  build-and-push-lambda:
+    machine:
+      image: ubuntu-2004:202201-02
+    parameters:
+      aws_ecr_repository:
+        type: string
+      code_version:
+        type: string
+    steps:
+      - checkout
+      - aws-ecr/build-and-push-image:
+          checkout: false
+          repo: << parameters.aws_ecr_repository >>
+          tag: << parameters.code_version >>
+          extra-build-args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
+      - verify-version-in-docker-image:
+          image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
+          version: << parameters.code_version >>,<< pipeline.number >>
+      - aws-ecr/tag-image:
+          repo: << parameters.aws_ecr_repository >>
+          source-tag: << parameters.code_version >>
+
 workflows:
   version: 2
 
@@ -157,7 +169,6 @@ workflows:
               only: /.*/
       - build-and-push:
           name: build-and-push-dev
-          aws_ecr_repository: 404798114945.dkr.ecr.us-east-1.amazonaws.com/mcd-pre-release-agent
           docker_hub_repository: pre-release-agent
           code_version: ${NEXT_VERSION}
           pre-steps:
@@ -170,8 +181,30 @@ workflows:
                   echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
                   source $BASH_ENV
           context:
-            - aws-dev
             - docker
+          requires:
+            - run-linter
+            - run-trufflehog-scan
+            - run-test-docker
+          filters:
+            branches:
+              only:
+                - dev
+      - build-and-push-lambda:
+          name: build-and-push-lambda-dev
+          aws_ecr_repository: mcd-pre-release-agent
+          code_version: ${NEXT_VERSION}
+          pre-steps:
+            - checkout
+            - run:
+                command: |
+                  PIPELINE_NUMBER=<< pipeline.number >>
+                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+                  VERSION=${TAG#v}
+                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
+                  source $BASH_ENV
+          context:
+            - aws-dev
           requires:
             - run-linter
             - run-trufflehog-scan
@@ -182,7 +215,6 @@ workflows:
                 - dev
       - build-and-push:
           name: build-and-push-prod
-          aws_ecr_repository: 752656882040.dkr.ecr.us-east-1.amazonaws.com/mcd-agent
           docker_hub_repository: agent
           code_version: ${VERSION_TAG}
           pre-steps:
@@ -193,8 +225,29 @@ workflows:
                   echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
                   source $BASH_ENV
           context:
-            - aws-prod
             - docker
+          requires:
+            - run-linter
+            - run-trufflehog-scan
+            - run-test-docker
+          filters: # run only for tags starting with v, don't run for branches
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - build-and-push-lambda:
+          name: build-and-push-lambda-prod
+          aws_ecr_repository: mcd-agent
+          code_version: ${VERSION_TAG}
+          pre-steps:
+            - checkout
+            - run:
+                command: |
+                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
+                  source $BASH_ENV
+          context:
+            - aws-prod
           requires:
             - run-linter
             - run-trufflehog-scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,10 @@ CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.inte
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
+RUN yum update -y
+# install git as we need it for the git clone client
+RUN yum install git -y
+
 # VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,10 +48,6 @@ CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.inte
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
-RUN yum update -y
-# install git as we need it for the git clone client
-RUN yum install git -y
-
 # VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0
 


### PR DESCRIPTION
#### What's new?
- Adds a new `build-and-push-lambda` command that runs on the dev branch to publish the `mcd-pre-release-agent` to ECR, and and on the main branch to publish the `mcd-agent` image to ECR. Runs in parallel with the pre-existing `build-and-push` command so the overall build doesn't increase.
- Updates the `verify-version-in-docker-image` command to run with `python` as the entrypoint to override the default entrypoint of lambda-based images.

#### Preview
<img width="1018" alt="Screenshot 2023-11-29 at 8 51 08 AM" src="https://github.com/monte-carlo-data/apollo-agent/assets/5182637/41696518-7e99-471b-af93-c383fe027db6">

#### Related issues and PRs
- https://github.com/monte-carlo-data/infrastructure/pull/645

