### PR TITLE
KIL-2794 [Agent] Snowflake error detecting the version of libcrypto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,13 +54,13 @@ CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.inte
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
-RUN apt update
+RUN yum update
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
 # please note we don't need git for the git connector as lambda-git takes care of installing it if
 # not present in the lambda environment
-RUN apt install git -y
+RUN yum install git -y
 
 # VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.inte
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
-RUN yum update
+RUN yum update -y
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,4 +60,12 @@ ARG code_version="local"
 ARG build_number="0"
 RUN echo $code_version,$build_number > ./apollo/agent/version
 
+RUN apt update
+# install git as we need it for the direct oscrypto dependency
+# this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
+# see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
+# please note we don't need git for the git connector as lambda-git takes care of installing it if
+# not present in the lambda environment
+RUN apt install git -y
+
 CMD [ "apollo.interfaces.lambda.handler.lambda_handler" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,12 @@ ENV VENV_DIR .venv
 WORKDIR $APP_HOME
 COPY requirements.txt ./
 
+RUN apt update
+# install git as we need it for the direct oscrypto dependency
+# this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
+# see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
+RUN apt install git -y
+
 RUN python -m venv $VENV_DIR
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
 

--- a/requirements.in
+++ b/requirements.in
@@ -18,3 +18,4 @@ retry2==0.9.5
 snowflake-connector-python>=3.1.0
 teradatasql>=17.20.0.31
 urllib3==1.26.18
+git+https://github.com/wbond/oscrypto@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,8 +142,10 @@ openpyxl==3.1.2
     # via databricks-sql-connector
 oracledb==1.4.2
     # via -r requirements.in
-oscrypto==1.3.0
-    # via snowflake-connector-python
+oscrypto @ git+https://github.com/wbond/oscrypto@master
+    # via
+    #   -r requirements.in
+    #   snowflake-connector-python
 packaging==23.1
     # via
     #   gunicorn


### PR DESCRIPTION
We're getting the error described [here](https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto).
As a workaround, we're adding a direct dependency to `oscrypto`'s GitHub repository, this also requires installing `git` in the images so it's available when Python dependencies are installed using `pip`.