### PR TITLE
Fix oscrypto dependency in requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,4 +18,4 @@ retry2==0.9.5
 snowflake-connector-python>=3.1.0
 teradatasql>=17.20.0.31
 urllib3==1.26.18
-git+https://github.com/wbond/oscrypto@master
+oscrypto @ git+https://github.com/wbond/oscrypto@master


### PR DESCRIPTION
Updated the way `oscrypto` is referenced in requirements.in to fix an error when apollo-agent is imported as a dependency in data-collector [here](https://app.circleci.com/pipelines/github/monte-carlo-data/data-collector/6142/workflows/b2809bd1-664f-449c-bd8a-62bc4e9740af/jobs/18383)