### PR TITLE
Added support for decimal type serialization

### DIFF
--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -46,6 +46,9 @@ ATTRIBUTE_VALUE_TYPE_DATETIME = "datetime"
 # Value for the attribute __type__ to indicate this is a date
 ATTRIBUTE_VALUE_TYPE_DATE = "date"
 
+# Value for the attribute __type__ to indicate this is a decimal
+ATTRIBUTE_VALUE_TYPE_DECIMAL = "decimal"
+
 # Value for the attribute __type__ to indicate this is a Looker category enum, client side it will be converted to
 # the right type
 ATTRIBUTE_VALUE_TYPE_LOOKER_CATEGORY = "looker.category"

--- a/apollo/agent/serde.py
+++ b/apollo/agent/serde.py
@@ -3,6 +3,7 @@ from datetime import (
     date,
     datetime,
 )
+from decimal import Decimal
 from typing import Any
 
 from apollo.agent.constants import (
@@ -10,6 +11,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_NAME_TYPE,
     ATTRIBUTE_VALUE_TYPE_DATE,
     ATTRIBUTE_VALUE_TYPE_DATETIME,
+    ATTRIBUTE_VALUE_TYPE_DECIMAL,
 )
 
 
@@ -25,6 +27,11 @@ class AgentSerializer(json.JSONEncoder):
             return {
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DATE,
                 ATTRIBUTE_NAME_DATA: value.isoformat(),
+            }
+        elif isinstance(value, Decimal):
+            return {
+                ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DECIMAL,
+                ATTRIBUTE_NAME_DATA: str(value),
             }
         return value
 


### PR DESCRIPTION
We were getting the error: `Object of type Decimal is not JSON serializable` when returning results for `Redshift` queries ([Sentry](https://monte-carlo-data.sentry.io/issues/4633743052/events/latest/?project=3527635&referrer=latest-event)).
We started seeing this now because we're serializing the response to calculate the size, if we don't do that, `Flask` takes care of the serialization and serializes `decimal` values as strings which is wrong, as we need the value client side to be a `decimal`.
