### PR TITLE
[Agent] added support for bytes data type

### DIFF
--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -37,7 +37,7 @@ ATTRIBUTE_NAME_DATA = "__data__"
 # of args for `method_a`.
 ATTRIBUTE_VALUE_TYPE_CALL = "call"
 
-# Value for the attribute __type__ to indicate this is a bytes array
+# Value for the attribute __type__ to indicate this is a bytes array, data is encoded in base64
 ATTRIBUTE_VALUE_TYPE_BYTES = "bytes"
 
 # Value for the attribute __type__ to indicate this is a datetime

--- a/apollo/agent/serde.py
+++ b/apollo/agent/serde.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from datetime import (
     date,
@@ -12,6 +13,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_VALUE_TYPE_DATE,
     ATTRIBUTE_VALUE_TYPE_DATETIME,
     ATTRIBUTE_VALUE_TYPE_DECIMAL,
+    ATTRIBUTE_VALUE_TYPE_BYTES,
 )
 
 
@@ -33,6 +35,12 @@ class AgentSerializer(json.JSONEncoder):
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DECIMAL,
                 ATTRIBUTE_NAME_DATA: str(value),
             }
+        elif isinstance(value, bytes):
+            return {
+                ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_BYTES,
+                ATTRIBUTE_NAME_DATA: base64.b64encode(value).decode("utf-8"),
+            }
+
         return value
 
     def default(self, obj: Any):

--- a/tests/test_mysql_client.py
+++ b/tests/test_mysql_client.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 from typing import (
     Iterable,
@@ -56,19 +57,21 @@ class MySqlClientTests(TestCase):
         )
 
     @patch("pymysql.connect")
-    def test_datetime_query(self, mock_connect):
+    def test_datatypes_query(self, mock_connect):
         query = "SELECT name, created_date, updated_datetime FROM table"  # noqa
         data = [
             [
                 "name_1",
                 datetime.date.fromisoformat("2023-11-01"),
                 datetime.datetime.fromisoformat("2023-11-01T10:59:00"),
+                b"\x01",
             ],
         ]
         description = [
             ["name", "string", None, None, None, None, None],
             ["created_date", "date", None, None, None, None, None],
             ["updated_datetime", "date", None, None, None, None, None],
+            ["active", "bit", None, None, None, None, None],
         ]
         self._test_run_query(mock_connect, query, None, data, description)
 
@@ -179,6 +182,11 @@ class MySqlClientTests(TestCase):
             return {
                 "__type__": "date",
                 "__data__": value.isoformat(),
+            }
+        elif isinstance(value, bytes):
+            return {
+                "__type__": "bytes",
+                "__data__": base64.b64encode(value).decode("utf-8"),
             }
         else:
             return value


### PR DESCRIPTION
Adds support for `bytes` data types, including support for MySQL's `bit` data type that is returned by the connector as a `bytes` object