### PR TITLE
add support for Azure SQL Database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
 # CVE-2022-40897
 RUN . $VENV_DIR/bin/activate && pip install setuptools==65.5.1
 
-# Azure Dedicated SQL Pools uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
+# Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -88,7 +88,7 @@ ARG code_version="local"
 ARG build_number="0"
 RUN echo $code_version,$build_number > ./apollo/agent/version
 
-# install unixodbc and 'ODBC Driver 17 for SQL Server', needed for Azure Dedicated SQL Pools
+# install unixodbc and 'ODBC Driver 17 for SQL Server', needed for Azure database client
 RUN yum -y update \
     && yum -y install \
     unixODBC \

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -128,14 +128,14 @@ def _get_proxy_client_teradata(
     return TeradataProxyClient(credentials=credentials, platform=platform)
 
 
-def _get_proxy_client_azure_dedicated_sql_pool(
+def _get_proxy_client_azure_database(
     credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
-    from apollo.integrations.db.azure_dedicated_sql_pool_proxy_client import (
-        AzureDedicatedSqlPoolProxyClient,
+    from apollo.integrations.db.azure_database_proxy_client import (
+        AzureDatabaseProxyClient,
     )
 
-    return AzureDedicatedSqlPoolProxyClient(credentials=credentials, platform=platform)
+    return AzureDatabaseProxyClient(credentials=credentials, platform=platform)
 
 
 @dataclass
@@ -158,7 +158,8 @@ _CLIENT_FACTORY_MAPPING = {
     "mysql": _get_proxy_client_mysql,
     "oracle": _get_proxy_client_oracle,
     "teradata": _get_proxy_client_teradata,
-    "azure-dedicated-sql-pool": _get_proxy_client_azure_dedicated_sql_pool,
+    "azure-dedicated-sql-pool": _get_proxy_client_azure_database,
+    "azure-sql-database": _get_proxy_client_azure_database,
 }
 
 

--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -7,17 +7,17 @@ from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 _ATTR_CONNECT_ARGS = "connect_args"
 
 
-class AzureDedicatedSqlPoolProxyClient(BaseDbProxyClient):
+class AzureDatabaseProxyClient(BaseDbProxyClient):
     """
-    Proxy client for Azure Dedicated SQL Pool Client. Credentials are expected to be supplied under "connect_args"
-    and will be passed directly to `pyodbc.connect`. 'pyodbc` accepts a connection string with the connection details,
-    so "connect_args" will be a string.
+    Proxy client for Azure "database" Client which is used by the Azure Dedicated SQL Pool and Azure SQL Database connections.
+    Credentials are expected to be supplied under "connect_args" and will be passed directly to `pyodbc.connect`.
+    'pyodbc` accepts a connection string with the connection details, so "connect_args" will be a string.
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
-                f"Azure Dedicated SQL Pool agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+                f"Azure database agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 


### PR DESCRIPTION
Azure Dedicated SQL Pool and Azure SQL Database connection types can use the exact same client. This PR renames the Azure client to be more generic and maps both connection types to the same client

Tested in dev using the test-lambda-dev account and adding a sql pool and SQL Database connection + sql monitor to confirm they work