### PR TITLE
pins base docker image version to older version to keep support for yum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ RUN apt install git -y
 
 CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
-FROM public.ecr.aws/lambda/python:3.11 AS lambda-builder
+# Pinning base docker image to this version so yum commands are still supported
+FROM public.ecr.aws/lambda/python:3.11.2023.11.18.02 AS lambda-builder
 
 RUN yum update -y
 # install git as we need it for the direct oscrypto dependency
@@ -76,7 +77,8 @@ COPY requirements.txt ./
 COPY requirements-lambda.txt ./
 RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" -r requirements.txt -r requirements-lambda.txt
 
-FROM public.ecr.aws/lambda/python:3.11 AS lambda
+# Pinning base docker image to this version so yum commands are still supported
+FROM public.ecr.aws/lambda/python:3.11.2023.11.18.02 AS lambda
 
 # VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0


### PR DESCRIPTION
### What's New
With this new AWS release to their Docker images, `yum` is being replaced with `dnf`.
@mrostan and I's testing unfortunately proved this will not be a straight forward switch

This PR pins the base docker version to before this release so that `yum` is still supported. Will investigate switching over to `dnf` in a future ticket