### PR TITLE
remove image version pinning now that aws has fixed it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,7 @@ RUN apt install git -y
 
 CMD . $VENV_DIR/bin/activate && gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
-# Pinning base docker image to this version so yum commands are still supported
-FROM public.ecr.aws/lambda/python:3.11.2023.11.18.02 AS lambda-builder
+FROM public.ecr.aws/lambda/python:3.11 AS lambda-builder
 
 RUN yum update -y
 # install git as we need it for the direct oscrypto dependency
@@ -77,8 +76,7 @@ COPY requirements.txt ./
 COPY requirements-lambda.txt ./
 RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" -r requirements.txt -r requirements-lambda.txt
 
-# Pinning base docker image to this version so yum commands are still supported
-FROM public.ecr.aws/lambda/python:3.11.2023.11.18.02 AS lambda
+FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
 # VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0


### PR DESCRIPTION
AWS fixed the issue in the 3.11 base image by bringing back support for `yum` so we no longer need to pin to an older version.

There is a possibility in the future they will successfully force users over to `dnf` but after chatting with @mrostan we will cross that bridge if/when it comes