### PR TITLE
Ssmith/kil 2795 investigate using pyodbc for sql server plugin

### DIFF
--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -1,44 +1,22 @@
 from typing import (
     Any,
     Dict,
-    Iterable,
+    List,
     Optional,
 )
 
-import pymssql
+import pyodbc
 
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
 
 
-class SqlServerProxyClientCursor:
-    def __init__(self, wrapped_cursor: Any):
-        self._wrapped_cursor = wrapped_cursor
-
-    @property
-    def description(self) -> Any:
-        return self._wrapped_cursor.description
-
-    def execute(self, query: str, params: Optional[Iterable] = None, **kwargs: Any):
-        self._wrapped_cursor.execute(query, tuple(params) if params else None, **kwargs)
-
-    def fetchall(self) -> Any:
-        return self._wrapped_cursor.fetchall()
-
-    def fetchmany(self, size: int) -> Any:
-        return self._wrapped_cursor.fetchmany(size)
-
-    @property
-    def rowcount(self) -> Any:
-        return self._wrapped_cursor.rowcount
-
-
 class SqlServerProxyClient(BaseDbProxyClient):
     """
     Proxy client for SQL Server Client. Credentials are expected to be supplied under "connect_args"
-    and will be passed directly to `pymssql.connect`, so only attributes supported as parameters
-    by `pymssql.connect` should be passed.
+    and will be passed directly to `pyodbc.connect`. 'pyodbc' accepts a connection string contained the connection details,
+    the expectation from the DC is that _ATTR_CONNECT_ARGS will be a string.
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
@@ -46,16 +24,15 @@ class SqlServerProxyClient(BaseDbProxyClient):
             raise ValueError(
                 f"SQL Server agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
-        self._connection = pymssql.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+        self._connection = pyodbc.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 
     @property
     def wrapped_client(self):
         return self._connection
 
-    def cursor(self) -> Any:
-        """
-        This is necessary because unlike other db proxy clients, MSSQL requires the query
-        arguments being passed into the execute function to be of type tuple.
-        So we override the cursor object in order to properly cast the params object.
-        """
-        return SqlServerProxyClientCursor(self.wrapped_client.cursor())
+    @classmethod
+    def _process_description(cls, col: List) -> List:
+        # pyodbc cursor returns the column type as <class 'str'> instead of a type_code which
+        # we expect. Here we are converting this type to a string of the type so the description
+        # can be serialized. So <class 'str'> will become just 'str'
+        return [col[0], col[1].__name__, col[2], col[3], col[4], col[5], col[6]]

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -26,11 +26,10 @@ class SqlServerProxyClient(BaseDbProxyClient):
                 f"SQL Server agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
         if isinstance(credentials[_ATTR_CONNECT_ARGS], dict):
-            # TODO: update the min DC version before merging this PR
             # Older DC versions will send the credentials as a dictionary instead of a string. Gracefully catch these
             # cases and tell the user to update their DC.
             raise AgentError(
-                f"Connection details format is not supported. Please update your Date Collector to >=xxxxx"
+                f"Connection details format is not supported. Please update your Date Collector to >16294"
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -29,7 +29,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
             # TODO: update the min DC version before merging this PR
             # Older DC versions will send the credentials as a dictionary instead of a string. Gracefully catch these
             # cases and tell the user to update their DC.
-            raise AgentError(f"Connection details format is not supported. Please update your Date Collector to >=xxxxx")
+            raise AgentError(
+                f"Connection details format is not supported. Please update your Date Collector to >=xxxxx"
+            )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 
     @property

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -7,6 +7,7 @@ from typing import (
 
 import pyodbc
 
+from apollo.agent.models import AgentError
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
@@ -24,6 +25,11 @@ class SqlServerProxyClient(BaseDbProxyClient):
             raise ValueError(
                 f"SQL Server agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
+        if isinstance(credentials[_ATTR_CONNECT_ARGS], dict):
+            # TODO: update the min DC version before merging this PR
+            # Older DC versions will send the credentials as a dictionary instead of a string. Gracefully catch these
+            # cases and tell the user to update their DC.
+            raise AgentError(f"Connection details format is not supported. Please update your Date Collector to >=xxxxx")
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 
     @property

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -24,7 +24,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
             raise ValueError(
                 f"SQL Server agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
-        self._connection = pyodbc.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+        self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
 
     @property
     def wrapped_client(self):

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,6 @@ looker-sdk==23.16.0
 oracledb>=1.3.1
 psycopg2-binary==2.9.7
 pyarrow==14.0.1  # CVE-2023-47248
-pymssql>=2.2.8
 PyMySQL>=1.1.0
 pyodbc==5.0.1
 retry2==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -179,8 +179,6 @@ pycryptodomex==3.19.0
     # via snowflake-connector-python
 pyjwt==2.8.0
     # via snowflake-connector-python
-pymssql==2.2.8
-    # via -r requirements.in
 pymysql==1.1.0
     # via -r requirements.in
 pyodbc==5.0.1

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -16,6 +16,8 @@ from apollo.agent.constants import (
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
 from apollo.agent.logging_utils import LoggingUtils
+from apollo.agent.models import AgentError
+from apollo.integrations.db.sql_server_proxy_client import SqlServerProxyClient
 
 _SQL_SERVER_CREDENTIALS = (
     f"DRIVER={{ODBC Driver 17 for SQL Server}};"
@@ -34,6 +36,12 @@ class SqlServerClientTests(TestCase):
         self._mock_cursor = Mock()
         self._mock_connection.cursor.return_value = self._mock_cursor
         self.maxDiff = None
+
+    def test_wrong_connection_detail_datatype(self):
+        # Older DC versions will send the credentials as a dictionary instead of a string. Testing to make sure we
+        # gracefully handle these cases
+        with self.assertRaises(AgentError):
+            SqlServerProxyClient(credentials={"connect_args": {"a": "dictionary"}})
 
     @patch("pyodbc.connect")
     def test_query(self, mock_connect):

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -17,12 +17,14 @@ from apollo.agent.constants import (
 )
 from apollo.agent.logging_utils import LoggingUtils
 
-_SQL_SERVER_CREDENTIALS = {
-    "host": "www.test.com",
-    "user": "u",
-    "password": "p",
-    "port": "1433",
-}
+_SQL_SERVER_CREDENTIALS = (
+    f"DRIVER={{ODBC Driver 17 for SQL Server}};"
+    f"SERVER=tcp:www.fake.com;"
+    f"PORT=1433;"
+    f"DATABASE=my_db;"
+    f"UID=user;"
+    f"PWD=password"
+)
 
 
 class SqlServerClientTests(TestCase):
@@ -35,7 +37,9 @@ class SqlServerClientTests(TestCase):
 
     @patch("pymssql.connect")
     def test_query(self, mock_connect):
-        query = "SELECT name, value FROM table OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"  # noqa
+        query = (
+            "SELECT name, value FROM table OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"  # noqa
+        )
         args = [0, 2]
         expected_data = [
             [

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -35,7 +35,7 @@ class SqlServerClientTests(TestCase):
 
     @patch("pymssql.connect")
     def test_query(self, mock_connect):
-        query = "SELECT name, value FROM table OFFSET %s ROWS FETCH NEXT %s ROWS ONLY"  # noqa
+        query = "SELECT name, value FROM table OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"  # noqa
         args = [0, 2]
         expected_data = [
             [
@@ -48,8 +48,8 @@ class SqlServerClientTests(TestCase):
             ],
         ]
         expected_description = [
-            ["name", "string", None, None, None, None, None],
-            ["value", "float", None, None, None, None, None],
+            ["name", str.__class__, None, None, None, None, None],
+            ["value", float.__class__, None, None, None, None, None],
         ]
         self._test_run_query(
             mock_connect, query, args, expected_data, expected_description
@@ -66,8 +66,8 @@ class SqlServerClientTests(TestCase):
             ],
         ]
         description = [
-            ["name", "string", None, None, None, None, None],
-            ["created_date", "date", None, None, None, None, None],
+            ["name", str.__class__, None, None, None, None, None],
+            ["created_date", str.__class__, None, None, None, None, None],
             ["updated_datetime", "date", None, None, None, None, None],
         ]
         self._test_run_query(mock_connect, query, None, data, description)


### PR DESCRIPTION
### What's new
- use `pyodbc` instead of `pymssql` for sql-server connection. Reason is that azure connections need `pyodbc` and we are trying to reduce number of imports
- If the DC sends a request to the agent for sql-server and the connection details are a dictionary, it means the DC thinks this agent is using `pymssql` still. Catch these cases and raise error telling user to update the DC and try againg

Used test.aws_agent@montecarlodata.com account to test that the collection and queries still work:
<img width="1696" alt="Screenshot 2023-12-12 at 12 25 06 PM" src="https://github.com/monte-carlo-data/apollo-agent/assets/97194436/c9593975-0451-4a08-8b20-e80fc2846dc0">

And that requests from an outdated DC will raise an error:

<img width="1068" alt="Screenshot 2023-12-12 at 11 44 32 AM" src="https://github.com/monte-carlo-data/apollo-agent/assets/97194436/d4897b55-7f78-4485-b632-fdb093dc2106">

then using updated DC:
<img width="1215" alt="Screenshot 2023-12-12 at 12 16 34 PM" src="https://github.com/monte-carlo-data/apollo-agent/assets/97194436/a936ea43-ab2f-4767-be1e-ee209344ac2a">

