### PR TITLE
add sap hana proxy client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -138,6 +138,16 @@ def _get_proxy_client_azure_database(
     return AzureDatabaseProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_sap_hana(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.sap_hana_proxy_client import (
+        SAPHanaProxyClient,
+    )
+
+    return SAPHanaProxyClient(credentials=credentials, platform=platform)
+
+
 def _get_proxy_client_tableau(
     credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
@@ -171,6 +181,7 @@ _CLIENT_FACTORY_MAPPING = {
     "azure-dedicated-sql-pool": _get_proxy_client_azure_database,
     "azure-sql-database": _get_proxy_client_azure_database,
     "tableau": _get_proxy_client_tableau,
+    "sap-hana": _get_proxy_client_sap_hana,
 }
 
 

--- a/apollo/integrations/db/sap_hana_proxy_client.py
+++ b/apollo/integrations/db/sap_hana_proxy_client.py
@@ -1,0 +1,26 @@
+from typing import Optional, Dict, Any
+
+from hdbcli import dbapi
+
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class SAPHanaProxyClient(BaseDbProxyClient):
+    """
+    Proxy client for SAP Hana. Credentials are expected to be supplied under "connect_args" and
+    will be passed directly to `dbapi.connect`, so only attributes supported as parameters by
+    `dbapi.connect` should be passed.
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"SAP HANA database agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+        self._connection = dbapi.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+
+    @property
+    def wrapped_client(self):
+        return self._connection

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ flask-compress==1.14
 google-api-python-client==2.98.0
 google-cloud-storage==2.10.0
 gunicorn==21.2.0
+hdbcli==2.18.27
 lambda-git==0.1.1
 looker-sdk==23.16.0
 oracledb>=1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,6 +98,8 @@ googleapis-common-protos==1.60.0
     # via google-api-core
 gunicorn==21.2.0
     # via -r requirements.in
+hdbcli==2.18.27
+    # via -r requirements.in
 httplib2==0.22.0
     # via
     #   google-api-python-client

--- a/tests/test_sap_hana_client.py
+++ b/tests/test_sap_hana_client.py
@@ -1,0 +1,178 @@
+import datetime
+from typing import (
+    Iterable,
+    List,
+    Any,
+    Optional,
+)
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_SAP_HANA_CREDENTIALS = {
+    "address": "1234",
+    "port": "39015",
+    "user": "bob",
+    "password": "supersecure",
+    "databaseName": "HXE",
+    "connectionTimeout": 1000000,
+    "communicationTimeout": 100000,
+}
+
+
+class SAPHanaClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+        self.maxDiff = None
+
+    @patch("hdbcli.dbapi.connect")
+    def test_query(self, mock_connect):
+        query = "SELECT name, value FROM table LIMIT ? OFFSET ?"  # noqa
+        args = [0, 2]
+        expected_data = [
+            [
+                "name_1",
+                11.1,
+            ],
+            [
+                "name_2",
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["name", 1, None, None, None, None, None],
+            ["value", 1, None, None, None, None, None],
+        ]
+        self._test_run_query(
+            mock_connect, query, args, expected_data, expected_description
+        )
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        query_args: Optional[Iterable[Any]],
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "execute",
+                    "args": [
+                        query,
+                        query_args,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "sap-hana",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _SAP_HANA_CREDENTIALS,
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+
+        mock_connect.assert_called_with(**_SAP_HANA_CREDENTIALS)
+        self._mock_cursor.execute.assert_has_calls(
+            [
+                call(query, query_args),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        expected_description = self._serialized_description(description)
+        self.assertTrue("description" in result)
+        self.assertEqual(expected_description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_description(cls, description: List) -> List:
+        return [cls._serialized_col(v) for v in description]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_col(cls, col: List) -> List:
+        return [cls._serialized_value(v) for v in col]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        else:
+            return value


### PR DESCRIPTION
Adds proxy client for SAP HANA and unit tests

Tested in `test.aws_agent` with the AWS remote agent, was able to create integration and run SQL monitor