### PR TITLE
Update infra_details for terraform to match cloudformation

### DIFF
--- a/apollo/interfaces/lambda_function/direct_updater.py
+++ b/apollo/interfaces/lambda_function/direct_updater.py
@@ -143,10 +143,17 @@ class LambdaDirectUpdater(AgentUpdater):
         configuration = function.get("Configuration", {})
         concurrency = function.get("Concurrency", {})
         return {
-            "parameters": {
-                "MemorySize": configuration.get("MemorySize"),
-                "ConcurrentExecutions": concurrency.get("ReservedConcurrentExecutions"),
-            }
+            "template": "",
+            "parameters": [
+                {
+                    "ParameterKey": "MemorySize",
+                    "ParameterValue": configuration.get("MemorySize"),
+                },
+                {
+                    "ParameterKey": "ConcurrentExecutions",
+                    "ParameterValue": concurrency.get("ReservedConcurrentExecutions"),
+                },
+            ],
         }
 
     @staticmethod

--- a/tests/test_aws_platform.py
+++ b/tests/test_aws_platform.py
@@ -80,10 +80,16 @@ class TestAwsPlatform(TestCase):
         result = response.result.get(ATTRIBUTE_NAME_RESULT)
         self.assertIsNone(result.get(ATTRIBUTE_NAME_ERROR))
         self.assertEqual(
-            {
-                "MemorySize": 123,
-                "ConcurrentExecutions": 12,
-            },
+            [
+                {
+                    "ParameterKey": "MemorySize",
+                    "ParameterValue": 123,
+                },
+                {
+                    "ParameterKey": "ConcurrentExecutions",
+                    "ParameterValue": 12,
+                },
+            ],
             result.get("parameters"),
         )
 


### PR DESCRIPTION
Update the values returned for `infra_details` when terraform is in use so the result is consistent with the result for CloudFormation and the `cli` works fine.