### PR TITLE
Enable upgrade logs even if remote upgrades are disabled

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -276,7 +276,7 @@ class Agent:
                         },
                     ),
                 )
-                updater = self._check_updates_enabled()
+                updater = self._check_updater()
                 events = updater.get_update_logs(
                     start_time=start_time,
                     limit=limit,
@@ -309,12 +309,9 @@ class Agent:
                     "get_infra_details failed:"
                 )
 
-    def _check_updates_enabled(self) -> AgentUpdater:
+    def _check_updater(self) -> AgentUpdater:
         if not self.updater:
             raise AgentConfigurationError("No updater configured")
-        upgradable = os.getenv(IS_REMOTE_UPGRADABLE_ENV_VAR, "false").lower() == "true"
-        if not upgradable:
-            raise AgentConfigurationError("Remote upgrades are disabled for this agent")
         return self.updater
 
     def _perform_update(
@@ -324,7 +321,11 @@ class Agent:
         timeout_seconds: Optional[int],
         **kwargs,  # type: ignore
     ) -> Dict:
-        updater = self._check_updates_enabled()
+        updater = self._check_updater()
+        upgradable = os.getenv(IS_REMOTE_UPGRADABLE_ENV_VAR, "false").lower() == "true"
+        if not upgradable:
+            raise AgentConfigurationError("Remote upgrades are disabled for this agent")
+
         log_payload = self._logging_utils.build_extra(
             trace_id=trace_id,
             operation_name="update",


### PR DESCRIPTION
Before, `get_update_logs` operation was checking for upgrades enabled, but that's wrong as disabling remote upgrades shouldn't prevent us from performing read-only operations like getting CF events.