### PR TITLE
KIL-2910: update HTTP proxy client to support custom auth headers

### DIFF
--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -92,8 +92,11 @@ class HttpProxyClient(BaseProxyClient):
 
         headers = {**additional_headers} if additional_headers else {}
         if self._credentials and "token" in self._credentials:
-            auth_type = self._credentials.get("auth_type", "Bearer")
-            headers["Authorization"] = f"{auth_type} {self._credentials['token']}"
+            auth_header = self._credentials.get("auth_header", "Authorization")
+            auth_header_value = self._credentials["token"]
+            if auth_type := self._credentials.get("auth_type", "Bearer"):
+                auth_header_value = f"{auth_type} {auth_header_value}"
+            headers[auth_header] = auth_header_value
         if content_type:
             headers["Content-Type"] = content_type
         if user_agent:

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -71,6 +71,107 @@ class TestHttpClient(TestCase):
         self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
 
     @patch("requests.request")
+    def test_http_request_with_custom_auth_type(self, mock_request):
+        credentials = {
+            "auth_type": "Token",
+            "token": "1234",
+        }
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = {
+            "ok": True,
+        }
+        mock_response.json.return_value = expected_result
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            _HTTP_OPERATION,
+            credentials,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                "Authorization": f"{credentials['auth_type']} {credentials['token']}",
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+        )
+        mock_response.assert_has_calls(
+            [
+                call.raise_for_status(),
+                call.json(),
+            ]
+        )
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
+
+    @patch("requests.request")
+    def test_http_request_with_custom_auth_header(self, mock_request):
+        credentials = {
+            "auth_header": "Api-Key",
+            "auth_type": None,
+            "token": "1234",
+        }
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = {
+            "ok": True,
+        }
+        mock_response.json.return_value = expected_result
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            _HTTP_OPERATION,
+            credentials,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                credentials["auth_header"]: credentials["token"],
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+        )
+        mock_response.assert_has_calls(
+            [
+                call.raise_for_status(),
+                call.json(),
+            ]
+        )
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
+
+    @patch("requests.request")
+    def test_http_request_with_no_auth(self, mock_request):
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = {
+            "ok": True,
+        }
+        mock_response.json.return_value = expected_result
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            _HTTP_OPERATION,
+            None,
+        )
+        mock_request.assert_called_with(
+            "GET",
+            "https://test.com/path",
+            headers={
+                "User-Agent": _HTTP_USER_AGENT,
+            },
+        )
+        mock_response.assert_has_calls(
+            [
+                call.raise_for_status(),
+                call.json(),
+            ]
+        )
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
+
+    @patch("requests.request")
     def test_http_request_with_params(self, mock_request):
         mock_response = create_autospec(Response)
         mock_request.return_value = mock_response


### PR DESCRIPTION
This PR updates the `HttpProxyClient` to support custom authentication headers. 

For example, [authentication for the Pinecone API](https://docs.pinecone.io/docs/authentication#add-a-header-to-an-http-request) requires an API token be passed in an `Api-Key` header.