### PR TITLE
[Azure Agent] Cleanup Durable Functions history periodically

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict
 
 from azure.monitor.opentelemetry import configure_azure_monitor
@@ -154,10 +154,10 @@ def agent_api(req: func.HttpRequest, context: func.Context):
 async def cleanup_durable_functions_data(
     timer: func.TimerRequest, client: DurableOrchestrationClient
 ) -> None:
-    created_time_from = datetime.today() - timedelta(
+    created_time_from = datetime.now(timezone.utc) - timedelta(
         days=365 * 10
     )  # datetime.min or None not supported
-    created_time_to = datetime.today() - timedelta(days=1)
+    created_time_to = datetime.now(timezone.utc) - timedelta(days=1)
     runtime_statuses = [
         OrchestrationRuntimeStatus.Canceled,
         OrchestrationRuntimeStatus.Completed,
@@ -166,7 +166,8 @@ async def cleanup_durable_functions_data(
     ]
 
     logging.info(
-        f"cleanup_durable_functions_data triggered, purging instances older than {created_time_to.isoformat()}"
+        f"cleanup_durable_functions_data triggered, purging instances older than "
+        f'{created_time_to.isoformat(timespec="seconds")}'
     )
 
     try:

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -147,7 +147,9 @@ def agent_api(req: func.HttpRequest, context: func.Context):
 
 
 @app.function_name(name="cleanup_df_data")
-@app.schedule(schedule="0 */5 * * * *", arg_name="timer", run_on_startup=False)
+@app.schedule(
+    schedule="0 0 3,15 * * *", arg_name="timer", run_on_startup=False
+)  # run every day at 3 AM/PM
 @app.durable_client_input(client_name="client")
 async def cleanup_durable_functions_data(
     timer: func.TimerRequest, client: DurableOrchestrationClient


### PR DESCRIPTION
- Azure Durable Functions store data for all requests (input and output data) forever, and as discussed [here](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-instance-management?tabs=python#purge-instance-history) we can use the `Orchestration Client API` to manually purge the history for a given instance or all instances created in a given period.
- This PR introduces a timer-triggered function that executes every 12 hours (hard-coded at 3 AM and 3 PM) and deletes the history for all completed (failed or succeeded) instances that were executed more than 1 day ago.