### PR TITLE
KIL-2988: Add support for compressing large results

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -1,3 +1,4 @@
+import gzip
 import logging
 import os
 import sys
@@ -448,11 +449,15 @@ class Agent:
             if operation.must_use_pre_signed_url(size):
                 key = f"responses/{operation.trace_id}"
                 storage_client = StorageProxyClient(self.platform)
+                contents = response.serialize_result(
+                    unwrap_result=operation.must_unwrap_result()
+                )
+                if operation.must_compress_response_file():
+                    contents = gzip.compress(contents.encode("utf-8"))
+                    response.compressed = True
                 storage_client.write(
                     key=key,
-                    obj_to_write=response.serialize_result(
-                        unwrap_result=operation.must_unwrap_result()
-                    ),
+                    obj_to_write=contents,
                 )
                 expiration_seconds = int(
                     os.getenv(
@@ -467,7 +472,11 @@ class Agent:
                     extra=self._logging_utils.build_extra(
                         operation.trace_id,
                         operation_name,
-                        dict(key=key, unwrap_result=operation.must_unwrap_result()),
+                        dict(
+                            key=key,
+                            unwrap_result=operation.must_unwrap_result(),
+                            compressed=response.compressed,
+                        ),
                     ),
                 )
         return response

--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -22,6 +22,9 @@ ATTRIBUTE_NAME_RESULT = "__mcd_result__"
 # Name of the attribute used in the operation response to wrap the result location, not included if there was an error
 ATTRIBUTE_NAME_RESULT_LOCATION = "__mcd_result_location__"
 
+# Name of the attribute used in the operation response to indicate if the response is compressed or not
+ATTRIBUTE_NAME_RESULT_COMPRESSED = "__mcd_result_compressed__"
+
 # Name of the attribute used in call arguments to reference a local variable in the context
 ATTRIBUTE_NAME_REFERENCE = "__reference__"
 

--- a/apollo/agent/models.py
+++ b/apollo/agent/models.py
@@ -59,6 +59,7 @@ class AgentOperation(DataClassJsonMixin):
     response_size_limit_bytes: int = 0
     response_type: str = RESPONSE_TYPE_JSON
     skip_cache: bool = False
+    compress_response_file: bool = True
 
     def __post_init__(self):
         if self.response_type not in (RESPONSE_TYPE_URL, RESPONSE_TYPE_JSON):
@@ -76,6 +77,9 @@ class AgentOperation(DataClassJsonMixin):
         return (
             0 < self.response_size_limit_bytes < size
         ) or self.response_type == RESPONSE_TYPE_URL
+
+    def must_compress_response_file(self) -> bool:
+        return self.response_type == RESPONSE_TYPE_JSON and self.compress_response_file
 
     def must_unwrap_result(self) -> bool:
         return self.response_type == RESPONSE_TYPE_URL

--- a/apollo/agent/models.py
+++ b/apollo/agent/models.py
@@ -57,9 +57,7 @@ class AgentOperation(DataClassJsonMixin):
     trace_id: str
     commands: List[AgentCommand]
     response_size_limit_bytes: int = 0
-    compress_response_threshold_bytes: int = (
-        0  # configures the threshold to send compressed responses inline
-    )
+    compress_response_threshold_bytes: int = 0  # configures the threshold to send compressed responses inline, disabled by default
     response_type: str = RESPONSE_TYPE_JSON
     skip_cache: bool = False
     compress_response_file: bool = (

--- a/apollo/agent/models.py
+++ b/apollo/agent/models.py
@@ -59,7 +59,7 @@ class AgentOperation(DataClassJsonMixin):
     response_size_limit_bytes: int = 0
     response_type: str = RESPONSE_TYPE_JSON
     skip_cache: bool = False
-    compress_response_file: bool = True
+    compress_response_file: bool = False
 
     def __post_init__(self):
         if self.response_type not in (RESPONSE_TYPE_URL, RESPONSE_TYPE_JSON):
@@ -79,6 +79,7 @@ class AgentOperation(DataClassJsonMixin):
         ) or self.response_type == RESPONSE_TYPE_URL
 
     def must_compress_response_file(self) -> bool:
+        # RESPONSE_TYPE_URL is used to send results to the UI, compression is not supported
         return self.response_type == RESPONSE_TYPE_JSON and self.compress_response_file
 
     def must_unwrap_result(self) -> bool:

--- a/apollo/agent/models.py
+++ b/apollo/agent/models.py
@@ -57,9 +57,14 @@ class AgentOperation(DataClassJsonMixin):
     trace_id: str
     commands: List[AgentCommand]
     response_size_limit_bytes: int = 0
+    compress_response_threshold_bytes: int = (
+        0  # configures the threshold to send compressed responses inline
+    )
     response_type: str = RESPONSE_TYPE_JSON
     skip_cache: bool = False
-    compress_response_file: bool = False
+    compress_response_file: bool = (
+        False  # indicates if response files should be compressed
+    )
 
     def __post_init__(self):
         if self.response_type not in (RESPONSE_TYPE_URL, RESPONSE_TYPE_JSON):
@@ -84,6 +89,17 @@ class AgentOperation(DataClassJsonMixin):
 
     def must_unwrap_result(self) -> bool:
         return self.response_type == RESPONSE_TYPE_URL
+
+    def can_compress_response(self) -> bool:
+        return (
+            0 < self.compress_response_threshold_bytes
+            and self.response_type == RESPONSE_TYPE_JSON
+        )
+
+    def must_compress_response(self, size: int) -> bool:
+        return (
+            0 < self.compress_response_threshold_bytes < size
+        ) and self.response_type == RESPONSE_TYPE_JSON
 
 
 @dataclass

--- a/apollo/interfaces/agent_response.py
+++ b/apollo/interfaces/agent_response.py
@@ -8,6 +8,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_NAME_RESULT_LOCATION,
     ATTRIBUTE_NAME_TRACE_ID,
     ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_RESULT_COMPRESSED,
 )
 from apollo.agent.serde import AgentSerializer
 
@@ -34,6 +35,14 @@ class AgentResponse:
         self.result[ATTRIBUTE_NAME_RESULT_LOCATION] = location
         if ATTRIBUTE_NAME_RESULT in self.result:
             self.result.pop(ATTRIBUTE_NAME_RESULT)
+
+    @property
+    def compressed(self) -> bool:
+        return self.result.get(ATTRIBUTE_NAME_RESULT_COMPRESSED, False)
+
+    @compressed.setter
+    def compressed(self, compressed: bool):
+        self.result[ATTRIBUTE_NAME_RESULT_COMPRESSED] = compressed
 
     @property
     def is_error(self) -> bool:

--- a/apollo/interfaces/agent_response.py
+++ b/apollo/interfaces/agent_response.py
@@ -22,6 +22,7 @@ class AgentResponse:
     result: Any
     status_code: int
     trace_id: Optional[str] = None
+    _compressed: bool = False
 
     def __post_init__(self):
         if not self._is_binary_response(self.result) and not self._is_error_response(
@@ -38,11 +39,13 @@ class AgentResponse:
 
     @property
     def compressed(self) -> bool:
-        return self.result.get(ATTRIBUTE_NAME_RESULT_COMPRESSED, False)
+        return self._compressed
 
     @compressed.setter
     def compressed(self, compressed: bool):
-        self.result[ATTRIBUTE_NAME_RESULT_COMPRESSED] = compressed
+        self._compressed = compressed
+        if isinstance(self.result, Dict):
+            self.result[ATTRIBUTE_NAME_RESULT_COMPRESSED] = compressed
 
     @property
     def is_error(self) -> bool:

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -41,7 +41,7 @@ from azure.durable_functions import (
     DurableOrchestrationClient,
     OrchestrationRuntimeStatus,
 )
-from azure.functions import WsgiMiddleware, AuthLevel
+from azure.functions import WsgiMiddleware
 
 from apollo.interfaces.azure.azure_platform import AzurePlatformProvider
 from apollo.interfaces.azure import main

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -28,7 +28,9 @@ def _get_response_headers(response: AgentResponse) -> Dict:
         headers[TRACE_ID_HEADER] = response.trace_id
     result = response.result
     if isinstance(result, bytes) or isinstance(result, io.IOBase):
-        headers["Content-Type"] = "application/octet-stream"
+        headers["Content-Type"] = (
+            "application/gzip" if response.compressed else "application/octet-stream"
+        )
     elif isinstance(result, str):
         headers["Content-Type"] = "text/plain"
     return headers

--- a/tests/test_agent_response.py
+++ b/tests/test_agent_response.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import os
 from unittest import TestCase
@@ -89,3 +90,78 @@ class AgentResponseTests(TestCase):
         mock_storage_client.generate_presigned_url.assert_called_once_with(
             f"responses/{self._trace_id}", expected_expiration
         )
+
+    @patch.object(Agent, "_execute")
+    @patch("apollo.agent.agent.StorageProxyClient")
+    def test_use_pre_signed_url_compressed(
+        self, storage_mock: Mock, mock_execute: Mock
+    ):
+        expected_expiration = 50
+        mock_storage_client = create_autospec(StorageProxyClient)
+        storage_mock.return_value = mock_storage_client
+        mock_storage_client.write.return_value = None
+        mock_storage_client.generate_presigned_url.return_value = (
+            "https://example.com/fizz_buzz"
+        )
+        mock_execute.return_value = {"fizz": "buzz"}
+        with patch.dict(
+            os.environ,
+            {
+                PRE_SIGNED_URL_RESPONSE_EXPIRATION_SECONDS_ENV_VAR: str(
+                    expected_expiration
+                ),
+            },
+        ):
+            response = self._agent._execute_client_operation(
+                connection_type="test",
+                client=self._client,
+                operation_name="test",
+                operation=AgentOperation(
+                    trace_id=self._trace_id,
+                    commands=self._commands,
+                    response_size_limit_bytes=5,
+                    compress_response_file=True,
+                ),
+            )
+        self.assertEqual(
+            {
+                "__mcd_result_location__": "https://example.com/fizz_buzz",
+                "__mcd_trace_id__": self._trace_id,
+                "__mcd_result_compressed__": True,
+            },
+            response.result,
+        )
+        expected_result = json.dumps(
+            {"__mcd_result__": {"fizz": "buzz"}, "__mcd_trace_id__": self._trace_id}
+        )
+        mock_storage_client.write.assert_called_once_with(
+            key=f"responses/{self._trace_id}",
+            obj_to_write=gzip.compress(expected_result.encode("utf-8")),
+        )
+        mock_storage_client.generate_presigned_url.assert_called_once_with(
+            f"responses/{self._trace_id}", expected_expiration
+        )
+
+    @patch.object(Agent, "_execute")
+    def test_no_pre_signed_urls_compressed(self, mock_execute: MagicMock):
+        mock_execute.return_value = {"foo": "bar"}
+        response = self._agent._execute_client_operation(
+            connection_type="test",
+            client=self._client,
+            operation_name="test",
+            operation=AgentOperation(
+                trace_id=self._trace_id,
+                commands=self._commands,
+                response_size_limit_bytes=0,
+                compress_response_threshold_bytes=5,
+            ),
+        )
+        expected_result = {
+            "__mcd_result__": {"foo": "bar"},
+            "__mcd_trace_id__": self._trace_id,
+        }
+        self.assertEqual(
+            gzip.compress(json.dumps(expected_result).encode("utf-8")),
+            response.result,
+        )
+        self.assertTrue(response.compressed)


### PR DESCRIPTION
Two new settings are now supported for operations:
- `compress_response_file`: controls whether file saved to the bucket (when a pre-signed url is returned) is compressed or not, defaults to `False`.
- `compress_response_threshold_bytes`: when the size is larger than this threshold and a pre-signed url is not used, the response is compressed and the result is sent with `Content-Type: application/gzip`. Defaults to `0` (disabled).
