### PR TITLE
Fix versions in requirements.in introduced by PR 72

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ google-api-python-client==2.98.0
 google-cloud-storage==2.10.0
 gunicorn==21.2.0
 hdbcli==2.18.27
-jinja2==3.1.3
+jinja2>=3.1.2
 lambda-git==0.1.1
 looker-sdk==23.16.0
 msal==1.24.1
@@ -18,7 +18,7 @@ oracledb>=1.3.1
 presto-python-client==0.8.3
 psycopg2-binary==2.9.7
 pyarrow==14.0.1  # CVE-2023-47248
-pycryptodome==3.19.1
+pycryptodome>=3.14.1
 pyjwt>=2.8.0
 PyMySQL>=1.1.0
 pyodbc==5.0.1

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ oracledb>=1.3.1
 presto-python-client==0.8.3
 psycopg2-binary==2.9.7
 pyarrow==14.0.1  # CVE-2023-47248
-pycryptodome>=3.14.1
+pycryptodome>=3.19.0
 pyjwt>=2.8.0
 PyMySQL>=1.1.0
 pyodbc==5.0.1


### PR DESCRIPTION
https://github.com/monte-carlo-data/apollo-agent/pull/72 upgraded a few libraries, specifically `jinja2` and `pycryptodome` had to keep the previous version as the minimum to prevent breaking the data-collector build