### PR TITLE
Azure: TCP Keep Alive settings for Oracle connections

### DIFF
--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -27,7 +27,14 @@ class OracleProxyClient(BaseDbProxyClient):
             raise ValueError(
                 f"Oracle DB agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
-        self._connection = oracledb.connect(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+
+        connect_args = credentials[_ATTR_CONNECT_ARGS]
+        if "expire_time" not in connect_args:
+            connect_args[
+                "expire_time"
+            ] = 1  # enable keep-alive and send packets every minute
+
+        self._connection = oracledb.connect(**connect_args)  # type: ignore
 
     @property
     def wrapped_client(self):

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -100,7 +100,10 @@ async def get_async_operation_status(
     response_payload = {
         "__mcd_status__": status.runtime_status.name
         if status.runtime_status
-        else "unknown"
+        else "unknown",
+        "__mcd_created_time__": status.created_time.isoformat()
+        if status.created_time
+        else None,
     }
     if status.runtime_status == OrchestrationRuntimeStatus.Completed and status.output:
         if isinstance(status.output, Dict):

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -101,8 +101,11 @@ async def get_async_operation_status(
         "__mcd_status__": status.runtime_status.name
         if status.runtime_status
         else "unknown",
-        "__mcd_created_time__": status.created_time.isoformat()
+        "__mcd_created__": status.created_time.isoformat()
         if status.created_time
+        else None,
+        "__mcd_last_updated__": status.last_updated_time.isoformat()
+        if status.last_updated_time
         else None,
     }
     if status.runtime_status == OrchestrationRuntimeStatus.Completed and status.output:


### PR DESCRIPTION
- Configured Oracle connections to send keep-alive packets every minute
- Added more information to the status for async tasks to help on testing, the status endpoint now returns the `created_time` and `last_updated_time` attributes from the task, we can use to check when it started and when it completed.