### PR TITLE
KIL-3014 Hive proxy client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -198,6 +198,16 @@ def _get_proxy_client_presto(
     return PrestoProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_hive(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.hive_proxy_client import (
+        HiveProxyClient,
+    )
+
+    return HiveProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -226,6 +236,7 @@ _CLIENT_FACTORY_MAPPING = {
     "glue": _get_proxy_client_glue,
     "athena": _get_proxy_client_athena,
     "presto": _get_proxy_client_presto,
+    "hive": _get_proxy_client_hive,
 }
 
 

--- a/apollo/integrations/db/hive_proxy_client.py
+++ b/apollo/integrations/db/hive_proxy_client.py
@@ -1,0 +1,101 @@
+import time
+from base64 import standard_b64encode
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+from pyhive import hive
+from thrift.transport import THttpClient
+from TCLIService.ttypes import TOperationState
+
+from apollo.agent.models import AgentError
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class HiveProxyCursor(hive.Cursor):
+    def async_execute(self, query: str, timeout: int, **kwargs: Any) -> None:  # noqa
+        start_time = time.time()
+
+        self.execute(query, async_=True)
+
+        pending_states = (
+            TOperationState.INITIALIZED_STATE,
+            TOperationState.PENDING_STATE,
+            TOperationState.RUNNING_STATE,
+        )
+        time_passed = 0
+        while self.poll().operationState in pending_states:
+            time_passed = time.time() - start_time
+            if time_passed > timeout:
+                self.cancel()
+                break
+            time.sleep(10)
+
+        resp = self.poll()
+        if resp.operationState == TOperationState.ERROR_STATE:
+            msg = "Query failed, see cluster logs for details"
+            if time_passed > 0:
+                msg += f" (runtime: {time_passed}s)"
+            raise AgentError(msg, query, resp)
+        elif resp.operationState == TOperationState.CANCELED_STATE:
+            raise AgentError(f"Time out executing query: {time_passed}s", query, resp)
+
+
+class HiveProxyConnection(hive.Connection):
+    def cursor(self, *args: Any, **kwargs: Any):
+        return HiveProxyCursor(self, *args, **kwargs)
+
+
+class HiveProxyClient(BaseDbProxyClient):
+    """
+    Proxy client for Hive. Credentials are expected to be supplied under "connect_args" and
+    will be passed directly to `hive.Connection`, so only attributes supported as parameters by
+    `hive.Connection` should be passed. If "mode" is not set to "binary", then the "connect_args"
+    will be used to create a new thrift transport that will be passed to `hive.Connection`.
+    """
+
+    _MODE_BINARY = "binary"
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):  # noqa
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Hive agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+
+        if credentials.get("mode") != self._MODE_BINARY:
+            self._connection = self._create_http_connection(
+                **credentials[_ATTR_CONNECT_ARGS]
+            )
+        else:
+            self._connection = HiveProxyConnection(**credentials[_ATTR_CONNECT_ARGS])
+
+    @classmethod
+    def _create_http_connection(
+        cls,
+        url: str,
+        username: str,
+        password: str,
+        user_agent: Optional[str] = None,
+        **kwargs: Any,  # noqa
+    ) -> hive.Connection:
+        transport = THttpClient.THttpClient(url)
+
+        auth = standard_b64encode(f"{username}:{password}".encode()).decode()
+        headers = dict(Authorization=f"Basic {auth}")
+        if user_agent:
+            headers["User-Agent"] = user_agent
+
+        transport.setCustomHeaders(headers)
+
+        try:
+            return HiveProxyConnection(thrift_transport=transport)
+        except EOFError or MemoryError:
+            raise AgentError("Error creating connection - credentials might be invalid")
+
+    @property
+    def wrapped_client(self):
+        return self._connection

--- a/requirements.in
+++ b/requirements.in
@@ -32,3 +32,9 @@ tableauserverclient>=0.25 ; python_version < "3.11"
 
 teradatasql>=17.20.0.31
 oscrypto @ git+https://github.com/wbond/oscrypto@master
+
+# Note: 'pyhive[hive]' extras uses sasl that does not support Python 3.11,
+# See https://github.com/cloudera/python-sasl/issues/30. Hence PyHive also supports
+# pure-sasl via additional extras 'pyhive[hive_pure_sasl]' which support Python 3.11.
+pyhive[hive_pure_sasl]==0.7.0 ; python_version >= "3.11"
+pyhive[hive]==0.6.5 ; python_version < "3.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,6 +86,8 @@ flask==2.3.3
     #   flask-compress
 flask-compress==1.14
     # via -r requirements.in
+future==0.18.3
+    # via pyhive
 google-api-core==2.15.0
     # via
     #   google-api-python-client
@@ -196,6 +198,10 @@ protobuf==4.25.1
     #   googleapis-common-protos
 psycopg2-binary==2.9.7
     # via -r requirements.in
+pure-sasl==0.6.2
+    # via
+    #   pyhive
+    #   thrift-sasl
 pyarrow==14.0.1
     # via
     #   -r requirements.in
@@ -212,6 +218,10 @@ pycryptodome==3.19.1
     # via
     #   -r requirements.in
     #   teradatasql
+pyhive[hive-pure-sasl]==0.7.0 ; python_version >= "3.11"
+    # via
+    #   -r requirements.in
+    #   pyhive
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements.in
@@ -229,6 +239,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   pandas
+    #   pyhive
 pytz==2023.3.post1
     # via
     #   pandas
@@ -257,6 +268,7 @@ six==1.16.0
     #   presto-python-client
     #   python-dateutil
     #   thrift
+    #   thrift-sasl
 snowflake-connector-python==3.6.0
     # via -r requirements.in
 sortedcontainers==2.4.0
@@ -270,7 +282,12 @@ tableauserverclient @ git+https://github.com/tableau/server-client-python.git ; 
 teradatasql==20.0.0.2
     # via -r requirements.in
 thrift==0.16.0
-    # via databricks-sql-connector
+    # via
+    #   databricks-sql-connector
+    #   pyhive
+    #   thrift-sasl
+thrift-sasl==0.4.3
+    # via pyhive
 tomlkit==0.12.3
     # via snowflake-connector-python
 typing-extensions==4.9.0

--- a/tests/test_hive_client.py
+++ b/tests/test_hive_client.py
@@ -1,0 +1,166 @@
+import datetime
+from typing import (
+    List,
+    Any,
+    Optional,
+)
+from unittest import TestCase
+from unittest.mock import (
+    Mock,
+    call,
+    patch,
+)
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_HIVE_CREDENTIALS = {
+    "host": "localhost",
+    "port": "10000",
+    "username": "foo",
+    "database": "fizz",
+    "auth": None,
+}
+
+
+class HiveClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+
+    @patch("apollo.integrations.db.hive_proxy_client.HiveProxyConnection")
+    def test_query(self, mock_connect):
+        query = "SELECT idx, value FROM table"  # noqa
+        expected_data = [
+            [
+                "name_1",
+                1,
+            ],
+            [
+                "name_2",
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["idx", "integer", None, None, None, None, None],
+            ["value", "float", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, expected_data, expected_description)
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "async_execute",
+                    "args": [
+                        query,
+                        None,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.async_execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "hive",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _HIVE_CREDENTIALS,
+                "mode": "binary",
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+
+        mock_connect.assert_called_with(**_HIVE_CREDENTIALS)
+        self._mock_cursor.async_execute.assert_has_calls(
+            [
+                call(query, None),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        self.assertTrue("description" in result)
+        self.assertEqual(description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        else:
+            return value


### PR DESCRIPTION
#### What's up?
- Creates a new `HiveProxyClient` that extends the `BaseDbProxyClient` for use with hive connection types.
- Uses a custom extension of `hive.Connection` (`HiveProxyConnection`) in order to use a custom extension of `hive.Cursor` (`HiveProxyCursor`) which adds an `async_execute` method to wait for incomplete queries as well as canceling queries running longer than the specified timeout.