### PR TITLE
KIL-3013 Add ssl support to MySQL proxy client

### DIFF
--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -1,13 +1,20 @@
+import logging
 from abc import ABC
 from typing import (
     Any,
     Dict,
     List,
+    Optional,
 )
+from urllib.request import urlretrieve
 
 from apollo.agent.serde import AgentSerializer
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.storage.base_storage_client import BaseStorageClient
+from apollo.integrations.storage.storage_proxy_client import StorageProxyClient
+
+logger = logging.getLogger(__name__)
 
 
 class BaseDbProxyClient(BaseProxyClient, ABC):
@@ -41,3 +48,25 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
     @classmethod
     def _process_description(cls, description: List) -> List:
         return [AgentSerializer.serialize(v) for v in description]
+
+    @classmethod
+    def get_cert_path(
+        cls,
+        platform: str,
+        remote_location: str,
+        retrieval_mechanism: str = "url",
+        sub_folder: Optional[str] = None,
+    ) -> Optional[str]:
+        download_path = AgentUtils.temp_file_path(sub_folder)
+        if retrieval_mechanism == "url":
+            urlretrieve(url=remote_location, filename=download_path)
+        else:
+            storage_client = StorageProxyClient(platform).wrapped_client
+            try:
+                storage_client.download_file(
+                    key=remote_location, download_path=download_path
+                )
+            except BaseStorageClient.NotFoundError as exc:
+                logger.warning("Certificate not found in storage bucket", exc_info=exc)
+                return None
+        return download_path

--- a/apollo/integrations/db/presto_proxy_client.py
+++ b/apollo/integrations/db/presto_proxy_client.py
@@ -1,16 +1,11 @@
 import logging
 from typing import Optional, Dict, Any
-from urllib.request import urlretrieve
 
 import prestodb
 
-from apollo.agent.utils import AgentUtils
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
-from apollo.integrations.storage.base_storage_client import BaseStorageClient
-from apollo.integrations.storage.storage_proxy_client import StorageProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
-_CERT_RETRIEVAL_METHOD_URL = "url"
 _PRESTO_DIRECTORY = "presto/certs"
 
 logger = logging.getLogger(__name__)
@@ -41,8 +36,11 @@ class PrestoProxyClient(BaseDbProxyClient):
             logger.info("Skipping certificate validation")
             self._connection._http_session.verify = False
         elif ssl_options.get("mechanism") and ssl_options.get("cert"):
-            cert_path = self._get_cert_path(
-                ssl_options["mechanism"], ssl_options["cert"]
+            cert_path = self.get_cert_path(
+                platform=platform,
+                remote_location=ssl_options["cert"],
+                retrieval_mechanism=ssl_options["mechanism"],
+                sub_folder=_PRESTO_DIRECTORY,
             )
             if cert_path:
                 self._connection._http_session.verify = cert_path
@@ -50,20 +48,3 @@ class PrestoProxyClient(BaseDbProxyClient):
     @property
     def wrapped_client(self):
         return self._connection
-
-    def _get_cert_path(
-        self, retrieval_mechanism: str, remote_location: str
-    ) -> Optional[str]:
-        download_path = AgentUtils.temp_file_path(sub_folder=_PRESTO_DIRECTORY)
-        if retrieval_mechanism == _CERT_RETRIEVAL_METHOD_URL:
-            urlretrieve(url=remote_location, filename=download_path)
-        else:
-            storage_client = StorageProxyClient(self._platform).wrapped_client
-            try:
-                storage_client.download_file(
-                    key=remote_location, download_path=download_path
-                )
-            except BaseStorageClient.NotFoundError as exc:
-                logger.warning("Certificate not found in storage bucket", exc_info=exc)
-                return None
-        return download_path


### PR DESCRIPTION
#### What's up?
Updates the `MysqlProxyClient` to handle ssl certificate options similarly to how we handle it for `PrestoProxyClient`. This allows us to use the same mysql proxy client for both MySQL transactional databases and Hive MySQL metastores.