### PR TITLE
Azure Agents: fix looker-git

### DIFF
--- a/apollo/integrations/azure_blob/azure_blob_base_reader_writer.py
+++ b/apollo/integrations/azure_blob/azure_blob_base_reader_writer.py
@@ -164,7 +164,7 @@ class AzureBlobBaseReaderWriter(BaseStorageClient):
         :param local_file_path: local path to the file to upload.
         """
         container_client = self._client.get_container_client(self._bucket_name)
-        with open(file=local_file_path, mode="r") as blob:
+        with open(file=local_file_path, mode="rb") as blob:
             container_client.upload_blob(
                 name=self._apply_prefix(key), data=blob, overwrite=True  # type: ignore
             )


### PR DESCRIPTION
- Fixed `upload_file` (that uploads a local file to the storage) for Azure Blob storage as it wasn't opening the file in binary mode and it was raising an `utf-8` encoding error