### PR TITLE
Fix results serialization for Databricks

### DIFF
--- a/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
+++ b/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
@@ -2,7 +2,6 @@ from typing import Dict, Optional
 
 from databricks import sql
 
-from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"

--- a/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
+++ b/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
@@ -3,11 +3,12 @@ from typing import Dict, Optional
 from databricks import sql
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
 
 
-class DatabricksSqlWarehouseProxyClient(BaseProxyClient):
+class DatabricksSqlWarehouseProxyClient(BaseDbProxyClient):
     """
     Proxy client for Databricks SQL Warehouse Client.
     Credentials are expected to be supplied under "connect_args" and will be passed directly to `sql.connect`, so


### PR DESCRIPTION
Updated `DatabricksSqlWarehouseProxyClient` client to extend `BaseDbProxyClient` and implement the right pre-serialization processing for results, as for example dates were not being serialized in the right way (and failed to be serialized when using Azure durable functions)