### PR TITLE
Update azure-monitor-opentelemetry to fix the startup issue using a VNet

### DIFF
--- a/requirements-azure.in
+++ b/requirements-azure.in
@@ -2,5 +2,5 @@
 azure-functions==1.17.0
 azure-functions-durable==1.2.8
 azure-mgmt-resource==23.0.1
-azure-monitor-opentelemetry==1.1.1
+azure-monitor-opentelemetry==1.2.0
 azure-monitor-query==1.2.0

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -41,9 +41,9 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-resource
 azure-mgmt-resource==23.0.1
     # via -r requirements-azure.in
-azure-monitor-opentelemetry==1.1.1
+azure-monitor-opentelemetry==1.2.0
     # via -r requirements-azure.in
-azure-monitor-opentelemetry-exporter==1.0.0b19
+azure-monitor-opentelemetry-exporter==1.0.0b21
     # via azure-monitor-opentelemetry
 azure-monitor-query==1.2.0
     # via -r requirements-azure.in
@@ -60,7 +60,7 @@ deprecated==1.2.14
     # via opentelemetry-api
 fixedint==0.1.6
     # via azure-monitor-opentelemetry-exporter
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
@@ -139,7 +139,7 @@ opentelemetry-instrumentation-wsgi==0.43b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-flask
-opentelemetry-resource-detector-azure==0.1.0
+opentelemetry-resource-detector-azure==0.1.1
     # via azure-monitor-opentelemetry
 opentelemetry-sdk==1.22.0
     # via


### PR DESCRIPTION
We were experiencing an issue with Azure Functions when a VNet was enabled.
The startup process was never ending, after some research we found that the call to `configure_azure_monitor` that initializes OpenTelemetry was hanging up and never ending, that was causing the Azure Function startup process to timeout and to keep restarting itself, making the function not available.

The issue gets fixed updating `azure-monitor-opentelemetry` to `1.2.0`.
There's a similar but reported [here](https://github.com/Azure/azure-sdk-for-python/issues/33289) but with no mention to VNet.