### PR TITLE
KIL-3085: Support direct upgrades when CF Template is used

### DIFF
--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -79,6 +79,7 @@ class LambdaCFUpdater(AgentUpdater):
         )
         template_url = (parameters or {}).pop(_TEMPLATE_URL_PARAMETER_NAME, None)
         if use_direct_update:
+            logger.info("Updating Agent using direct update")
             return LambdaDirectUpdater().update(
                 image=image,
                 timeout_seconds=timeout_seconds,

--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -6,6 +6,7 @@ from botocore.exceptions import WaiterError
 
 from apollo.agent.updater import AgentUpdater
 from apollo.interfaces.lambda_function.cf_utils import CloudFormationUtils
+from apollo.interfaces.lambda_function.direct_updater import LambdaDirectUpdater
 
 _CF_UPDATE_WAITER = "stack_update_complete"
 _STACK_SUCCESSFUL_UPDATE_STATE = "UPDATE_COMPLETE"
@@ -20,9 +21,6 @@ _PARAMETER_VALUE_ATTR_NAME = "ParameterValue"
 _PARAMETER_USE_PREVIOUS_VALUE_ATTR_NAME = "UsePreviousValue"
 
 _IMAGE_URI_TEMPLATE_PARAMETER_NAME = "ImageUri"
-
-_NEW_PARAMETERS_ARG_NAME = "parameters"
-_TEMPLATE_URL_ARG_NAME = "template_url"
 
 logger = logging.getLogger(__name__)
 
@@ -54,38 +52,54 @@ class LambdaCFUpdater(AgentUpdater):
         self,
         image: Optional[str],
         timeout_seconds: Optional[int],
+        wait_for_completion: bool = False,
+        parameters: Optional[Dict] = None,
+        template_url: Optional[str] = None,
+        use_direct_update: bool = False,
         **kwargs,  # type: ignore
     ) -> Dict:
         """
-        Updates the CF Stack, image is expected to have this format:
+        Updates the CF Stack using a CF update or a direct Lambda update depending on the value of `use_direct_update`.
+
+        :param image: image URI, it is expected to have this format:
             <account_number>.dkr.ecr.<region>>.amazonaws.com/<repo_name>>:<image_tag>
-        Optional parameters supported through kwargs:
-        - 'parameters': a dictionary with new values for the template parameters
-        - 'wait_for_completion': a bool indicating if this method should wait for the update to complete,
+        :param timeout_seconds: Ignored by this updater
+        :param parameters: an optional dictionary with new values for the template parameters
+        :param wait_for_completion: a bool indicating if this method should wait for the update to complete,
             defaults to False
-        - 'template_url': a new value for "TemplateURL", defaults to None and triggers the update with
+        :param template_url: a new value for "TemplateURL", defaults to None and triggers the update with
             UsePreviousTemplate=true
+        :param use_direct_update: if `True` it uses an instance of `LambdaDirectUpdater` to update
+            the Lambda function directly instead of using CF.
         """
+        if use_direct_update:
+            return LambdaDirectUpdater().update(
+                image=image,
+                timeout_seconds=timeout_seconds,
+                wait_for_completion=wait_for_completion,
+                parameters=parameters,
+                **kwargs,
+            )
+
         client = CloudFormationUtils.get_cloudformation_client()
-        template_url = kwargs.get(_TEMPLATE_URL_ARG_NAME)
 
         stack_id = CloudFormationUtils.get_stack_id()
         logger.info(
-            f"Update CF stack requested", extra=dict(stack_id=stack_id, image=image)
+            "Update CF stack requested", extra=dict(stack_id=stack_id, image=image)
         )
         # force region to be "*" in the new ImageUri, the template will replace it with the right region
         new_image_uri = self._get_new_image_uri(image, "*") if image else None
 
-        parameters = self._merge_parameters(
+        stack_parameters = self._merge_parameters(
             client=client,
             stack_id=stack_id,
             new_image_uri=new_image_uri,
-            new_parameters=kwargs.get(_NEW_PARAMETERS_ARG_NAME) or {},
+            new_parameters=parameters or {},
         )
 
         update_stack_args: Dict[str, Any] = dict(
             StackName=stack_id,
-            Parameters=parameters,
+            Parameters=stack_parameters,
             Capabilities=[_DEFAULT_CAPABILITIES],
         )
         if template_url:
@@ -95,7 +109,7 @@ class LambdaCFUpdater(AgentUpdater):
         start_time = datetime.now(timezone.utc)
         client.update_stack(**update_stack_args)
 
-        if kwargs.get("wait_for_completion", False):
+        if wait_for_completion:
             error_message = self._wait_for_stack_update(
                 client=client, stack_id=stack_id
             )
@@ -179,7 +193,7 @@ class LambdaCFUpdater(AgentUpdater):
             for param in parameters
         }
         logger.info(
-            f"Updating stack",
+            "Updating stack",
             extra=dict(stack_id=stack_id, parameters=parameter_log_values),
         )
         return parameters

--- a/tests/test_cf_updater.py
+++ b/tests/test_cf_updater.py
@@ -3,10 +3,7 @@ from datetime import datetime, timezone, timedelta
 from unittest import TestCase
 from unittest.mock import patch, Mock, ANY
 
-from apollo.agent.env_vars import (
-    CLOUDFORMATION_STACK_ID_ENV_VAR,
-    AWS_LAMBDA_FUNCTION_NAME_ENV_VAR,
-)
+from apollo.agent.env_vars import CLOUDFORMATION_STACK_ID_ENV_VAR
 from apollo.interfaces.lambda_function.cf_updater import LambdaCFUpdater
 from apollo.interfaces.lambda_function.direct_updater import LambdaDirectUpdater
 
@@ -145,35 +142,41 @@ class TestCFUpdater(TestCase):
         new_image_uri = (
             "123_account.dkr.ecr.us-east-1.amazonaws.com/repo-name:new-tag-name"
         )
-        parameters = {"MemorySize": 128}
         updater = LambdaCFUpdater()
+
+        # update with no parameters
         updater.update(
             image=new_image_uri,
             timeout_seconds=10,
             wait_for_completion=True,
-            use_direct_update=True,
-            parameters=parameters,
+            parameters={
+                "UseDirectUpdate": True,
+            },
         )
         mock_direct_update.assert_called_once_with(
             image=new_image_uri,
             timeout_seconds=10,
             wait_for_completion=True,
-            parameters=parameters,
+            parameters={},
         )
 
-        # update no parameters
+        # update with parameters
         mock_direct_update.reset_mock()
+        parameters = {"MemorySize": 128}
         updater.update(
             image=new_image_uri,
             timeout_seconds=10,
             wait_for_completion=True,
-            use_direct_update=True,
+            parameters={
+                **parameters,
+                "UseDirectUpdate": True,
+            },
         )
         mock_direct_update.assert_called_once_with(
             image=new_image_uri,
             timeout_seconds=10,
             wait_for_completion=True,
-            parameters=None,
+            parameters=parameters,
         )
 
     @patch.dict(


### PR DESCRIPTION
- Added a new parameter to the upgrade operation for AWS Agents that can be used to force the upgrade to be performed using a "direct upgrade" that updates the `ImageUri` attribute directly in the Lambda function instead of performing a CF Stack update.
- Intended to be used only in cases where the CF update is not working properly
- To use it, pass the `UseDirectUpdate` parameter in the CLI:
  ```shell
  montecarlo agents upgrade --agent-id <AGENT_ID> --params '{"UseDirectUpdate": true}'
  ```
- Improved the code in `CFUpdater` by declaring args in the `update` method instead of getting them from `kwargs`