### PR TITLE
Add support for bytearray result type

### DIFF
--- a/apollo/agent/serde.py
+++ b/apollo/agent/serde.py
@@ -40,7 +40,7 @@ class AgentSerializer(json.JSONEncoder):
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DECIMAL,
                 ATTRIBUTE_NAME_DATA: str(value),
             }
-        elif isinstance(value, bytes):
+        elif isinstance(value, bytes) or isinstance(value, bytearray):
             return {
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_BYTES,
                 ATTRIBUTE_NAME_DATA: base64.b64encode(value).decode("utf-8"),

--- a/tests/test_snowflake_client.py
+++ b/tests/test_snowflake_client.py
@@ -1,3 +1,4 @@
+import base64
 import datetime
 from typing import List, Any, Optional, Dict
 from unittest import TestCase
@@ -38,6 +39,25 @@ class SnowflakeClientTests(TestCase):
         ]
         expected_description = [
             ["name", "string", None, None, None, None, None],
+            ["value", "float", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, expected_data, expected_description)
+
+    @patch("snowflake.connector.connect")
+    def test_query_bytearray(self, mock_connect):
+        query = "SELECT name, value FROM table"  # noqa
+        expected_data = [
+            [
+                bytearray(b"name_1"),
+                11.1,
+            ],
+            [
+                bytearray(b"name_1"),
+                22.2,
+            ],
+        ]
+        expected_description = [
+            ["name", "binary", None, None, None, None, None],
             ["value", "float", None, None, None, None, None],
         ]
         self._test_run_query(mock_connect, query, expected_data, expected_description)
@@ -170,6 +190,11 @@ class SnowflakeClientTests(TestCase):
             return {
                 "__type__": "date",
                 "__data__": value.isoformat(),
+            }
+        elif isinstance(value, bytes) or isinstance(value, bytearray):
+            return {
+                "__type__": "bytes",
+                "__data__": base64.b64encode(value).decode("utf-8"),
             }
         else:
             return value


### PR DESCRIPTION
Snowflake queries returning binary data are returning instances of `bytearray` instead of `bytes`, this PR fixes the serialization to support it and serialize it using Base 64 encoding as we do for `bytes`.