### PR TITLE
Add support for bytes data type in credentials

### DIFF
--- a/apollo/agent/evaluation_utils.py
+++ b/apollo/agent/evaluation_utils.py
@@ -15,6 +15,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_VALUE_TYPE_BYTES,
     ATTRIBUTE_NAME_DATA,
 )
+from apollo.agent.serde import decode_dict_value
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
 
@@ -186,8 +187,8 @@ class AgentEvaluationUtils:
                 return cls._execute_single_command(
                     AgentCommand.from_dict(value), context
                 )
-            elif value.get(ATTRIBUTE_NAME_TYPE) == ATTRIBUTE_VALUE_TYPE_BYTES:
-                return base64.b64decode(value.get(ATTRIBUTE_NAME_DATA))  # type: ignore
+            elif ATTRIBUTE_NAME_TYPE in value:
+                return decode_dict_value(value)
         return value
 
     @staticmethod

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -8,6 +8,7 @@ from typing import Optional, Dict
 
 from apollo.agent.env_vars import CLIENT_CACHE_EXPIRATION_SECONDS_ENV_VAR
 from apollo.agent.models import AgentError
+from apollo.agent.serde import decode_dictionary
 from apollo.integrations.base_proxy_client import BaseProxyClient
 
 logger = logging.getLogger(__name__)
@@ -305,6 +306,8 @@ class ProxyClientFactory:
     ) -> BaseProxyClient:
         factory_method = _CLIENT_FACTORY_MAPPING.get(connection_type)
         if factory_method:
+            if credentials:
+                credentials = decode_dictionary(credentials)
             return factory_method(credentials, platform=platform)
         else:
             raise AgentError(

--- a/apollo/agent/serde.py
+++ b/apollo/agent/serde.py
@@ -81,3 +81,23 @@ def rows_encoder(
     rows: Union[List[List[Any]], List[Tuple], List[Dict]]
 ) -> List[List[Any]]:
     return [[row_value_encoder(value) for value in row] for row in rows]
+
+
+def decode_dict_value(value: Dict) -> Any:
+    if value.get(ATTRIBUTE_NAME_TYPE) == ATTRIBUTE_VALUE_TYPE_BYTES:
+        return base64.b64decode(value.get(ATTRIBUTE_NAME_DATA))  # type: ignore
+    return value
+
+
+def decode_dictionary(dict_value: Dict) -> Dict:
+    def decode_deep(value: Any) -> Any:
+        if isinstance(value, Dict):
+            return (
+                decode_dict_value(value)
+                if ATTRIBUTE_NAME_TYPE in value
+                else decode_dictionary(value)
+            )
+        else:
+            return value
+
+    return {key: decode_deep(value) for key, value in dict_value.items()}

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -128,7 +128,7 @@ class OracleDbClientTests(TestCase):
         self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
         result = response.result.get(ATTRIBUTE_NAME_RESULT)
 
-        mock_connect.assert_called_with(**_ORACLE_DB_CREDENTIALS)
+        mock_connect.assert_called_with(expire_time=1, **_ORACLE_DB_CREDENTIALS)
         self._mock_cursor.execute.assert_has_calls(
             [
                 call(query, query_args),


### PR DESCRIPTION
- Added support for bytes in credentials, for example for Snowflake private key, bytes are sent using the same encoding used for non-serializable data types in the operation itself.