### PR TITLE
Fix: pyodbc client support for datetimeoffset data type

### DIFF
--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -1,3 +1,5 @@
+import struct
+from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict, Any, List
 
 import pyodbc
@@ -14,12 +16,16 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
     'pyodbc` accepts a connection string with the connection details, so "connect_args" will be a string.
     """
 
+    _DATETIMEOFFSET_SQL_TYPE_CODE = -155
+
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Azure database agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+        # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
+        self._connection.add_output_converter(self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset)
 
     @property
     def wrapped_client(self):
@@ -31,3 +37,36 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         # we expect. Here we are converting this type to a string of the type so the description
         # can be serialized. So <class 'str'> will become just 'str'
         return [col[0], col[1].__name__, col[2], col[3], col[4], col[5], col[6]]
+
+    @staticmethod
+    def _handle_datetimeoffset(dto_value: bytes) -> datetime:
+        """
+        Input: a bytes representation of SQL server's 'datetimeoffset' date type (a timezone aware datetime)
+        Output: a timezone-aware datetime object
+
+        Unpacks the binary value into a tuple of (year, month, day, hour, minute, second, microsecond, hour-offset, minute-offset)
+        then uses the tuple to create a datetime() with timezone
+
+        "<6hI2h" is a format string to describe the layout for unpacking (https://docs.python.org/3/library/struct.html#struct-format-strings)
+        What each part does:
+            <: This specifies that the data should be interpreted in little-endian byte order. (least significant byte (LSB) is stored first).
+            6h: This specifies that there should be 6 signed short integers (16-bit) present in the binary data.
+                (year, month, day, hour, minute, second)
+            I: This specifies that there should be 1 unsigned integer (32-bit) present in the binary data.
+                (microsecond)
+            2h: This specifies that there should be 2 signed short integers (16-bit) present in the binary data.
+                (hour and minute of timezone difference)
+        """
+        tup = struct.unpack("<6hI2h", dto_value)
+
+        # Use the tuple to create a datetime() with timezone
+        return datetime(
+            tup[0],
+            tup[1],
+            tup[2],
+            tup[3],
+            tup[4],
+            tup[5],
+            tup[6] // 1000,
+            timezone(timedelta(hours=tup[7], minutes=tup[8])),
+        )

--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -25,7 +25,9 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
-        self._connection.add_output_converter(self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset)
+        self._connection.add_output_converter(
+            self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset
+        )
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -1,3 +1,5 @@
+import struct
+from datetime import datetime, timezone, timedelta
 from typing import (
     Any,
     Dict,
@@ -20,6 +22,8 @@ class SqlServerProxyClient(BaseDbProxyClient):
     the expectation from the DC is that _ATTR_CONNECT_ARGS will be a string.
     """
 
+    _DATETIMEOFFSET_SQL_TYPE_CODE = -155
+
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
@@ -32,6 +36,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
                 f"Connection details format is not supported. Please update your Date Collector to >16294"
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+        # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
+        self._connection.add_output_converter(self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset)
+
 
     @property
     def wrapped_client(self):
@@ -43,3 +50,36 @@ class SqlServerProxyClient(BaseDbProxyClient):
         # we expect. Here we are converting this type to a string of the type so the description
         # can be serialized. So <class 'str'> will become just 'str'
         return [col[0], col[1].__name__, col[2], col[3], col[4], col[5], col[6]]
+
+    @staticmethod
+    def _handle_datetimeoffset(dto_value: bytes) -> datetime:
+        """
+        Input: a bytes representation of SQL server's 'datetimeoffset' date type (a timezone aware datetime)
+        Output: a timezone-aware datetime object
+
+        Unpacks the binary value into a tuple of (year, month, day, hour, minute, second, microsecond, hour-offset, minute-offset)
+        then uses the tuple to create a datetime() with timezone
+
+        "<6hI2h" is a format string to describe the layout for unpacking (https://docs.python.org/3/library/struct.html#struct-format-strings)
+        What each part does:
+            <: This specifies that the data should be interpreted in little-endian byte order. (least significant byte (LSB) is stored first).
+            6h: This specifies that there should be 6 signed short integers (16-bit) present in the binary data.
+                (year, month, day, hour, minute, second)
+            I: This specifies that there should be 1 unsigned integer (32-bit) present in the binary data.
+                (microsecond)
+            2h: This specifies that there should be 2 signed short integers (16-bit) present in the binary data.
+                (hour and minute of timezone difference)
+        """
+        tup = struct.unpack("<6hI2h", dto_value)
+
+        # Use the tuple to create a datetime() with timezone
+        return datetime(
+            tup[0],
+            tup[1],
+            tup[2],
+            tup[3],
+            tup[4],
+            tup[5],
+            tup[6] // 1000,
+            timezone(timedelta(hours=tup[7], minutes=tup[8])),
+        )

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -37,8 +37,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
             )
         self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
-        self._connection.add_output_converter(self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset)
-
+        self._connection.add_output_converter(
+            self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset
+        )
 
     @property
     def wrapped_client(self):

--- a/tests/test_azure_dedicated_sql_pool_client.py
+++ b/tests/test_azure_dedicated_sql_pool_client.py
@@ -16,6 +16,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
 from apollo.agent.logging_utils import LoggingUtils
+from apollo.integrations.db.azure_database_proxy_client import AzureDatabaseProxyClient
 
 _AZURE_DEDICATED_SQL_POOL_CREDENTIALS = (
     f"DRIVER={{ODBC Driver 17 for SQL Server}};"
@@ -179,3 +180,27 @@ class AzureDedicatedSqlPoolClientTests(TestCase):
             }
         else:
             return value
+
+    def test_handle_datetimeoffset(self):
+        # 2025-12-10T12:32:10.000019+01:00 represented as binary
+        datetimeoffset_as_binary = (
+            b"\xe9\x07\x0c\x00\n\x00\x0c\x00 \x00\n\x008J\x00\x00\x01\x00\x00\x00"
+        )
+
+        expected_datetime = datetime.datetime(
+            year=2025,
+            month=12,
+            day=10,
+            hour=12,
+            minute=32,
+            second=10,
+            microsecond=19,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=0)),
+        )
+
+        # Convert it to datetime
+        response = AzureDatabaseProxyClient._handle_datetimeoffset(
+            datetimeoffset_as_binary
+        )
+
+        self.assertEqual(response, expected_datetime)

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -222,8 +222,6 @@ class SqlServerClientTests(TestCase):
         )
 
         # Convert it to datetime
-        response = SqlServerProxyClient._handle_datetimeoffset(
-            datetimeoffset_as_binary
-        )
+        response = SqlServerProxyClient._handle_datetimeoffset(datetimeoffset_as_binary)
 
         self.assertEqual(response, expected_datetime)

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -203,3 +203,27 @@ class SqlServerClientTests(TestCase):
             }
         else:
             return value
+
+    def test_handle_datetimeoffset(self):
+        # 2025-12-10T12:32:10.000019+01:00 represented as binary
+        datetimeoffset_as_binary = (
+            b"\xe9\x07\x0c\x00\n\x00\x0c\x00 \x00\n\x008J\x00\x00\x01\x00\x00\x00"
+        )
+
+        expected_datetime = datetime.datetime(
+            year=2025,
+            month=12,
+            day=10,
+            hour=12,
+            minute=32,
+            second=10,
+            microsecond=19,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=1, minutes=0)),
+        )
+
+        # Convert it to datetime
+        response = SqlServerProxyClient._handle_datetimeoffset(
+            datetimeoffset_as_binary
+        )
+
+        self.assertEqual(response, expected_datetime)


### PR DESCRIPTION
## What's new
- Same fix as this [DC pr](https://github.com/monte-carlo-data/data-collector/pull/1083)
- The `pyodbc` client used by Azure Dedicated SQL pool, Azure SQL DB and SQL Server does not support the data type `datetimeoffset`. 
    - If a SQL Monitor tries to return a datetimeoffset column in the results or uses a `select *` that includes a datetimeoffset, the monitor run fails with: 
         > ('ODBC SQL type -155 is not yet supported. column-index=0 type=-155', 'HY106') (ProgrammingError)
- GitHub [issue](https://github.com/mkleehammer/pyodbc/issues/134#issuecomment-452893948)
    - Purposed [solution](https://github.com/mkleehammer/pyodbc/wiki/Using-an-Output-Converter-function) I am implementing

## Testing
- In dev account `AWS Agent Test`, using aws remote agent, created a Azure SQL DB connection
- Create a sql monitor with a query `select * from <table_that_has_datetimeoffset_column>`
- Run monitor and it fails with the error above
- Update agent with this PR in dev
- Run monitor again and it succeeds
<img width="1570" alt="Screenshot 2024-02-08 at 3 07 19 PM" src="https://github.com/monte-carlo-data/apollo-agent/assets/97194436/0cbd056d-3c99-4a7d-9515-9535d8b7ce9b">

