### PR TITLE
KIL-3109: add boto3 proxy clients for AWS MSK

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -209,6 +209,22 @@ def _get_proxy_client_hive(
     return HiveProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_msk_connect(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.aws.msk_proxy_client import MskConnectProxyClient
+
+    return MskConnectProxyClient(credentials=credentials, platform=platform)
+
+
+def _get_proxy_client_msk_kafka(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.aws.msk_proxy_client import MskKafkaProxyClient
+
+    return MskKafkaProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -238,6 +254,8 @@ _CLIENT_FACTORY_MAPPING = {
     "athena": _get_proxy_client_athena,
     "presto": _get_proxy_client_presto,
     "hive": _get_proxy_client_hive,
+    "msk-connect": _get_proxy_client_msk_connect,
+    "msk-kafka": _get_proxy_client_msk_kafka,
 }
 
 

--- a/apollo/integrations/aws/msk_proxy_client.py
+++ b/apollo/integrations/aws/msk_proxy_client.py
@@ -1,0 +1,15 @@
+from typing import Any, Dict, Optional
+
+from apollo.integrations.aws.base_aws_proxy_client import BaseAwsProxyClient
+
+
+class MskConnectProxyClient(BaseAwsProxyClient):
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        BaseAwsProxyClient.__init__(
+            self, service_type="kafkaconnect", credentials=credentials
+        )
+
+
+class MskKafkaProxyClient(BaseAwsProxyClient):
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        BaseAwsProxyClient.__init__(self, service_type="kafka", credentials=credentials)

--- a/tests/test_msk_client.py
+++ b/tests/test_msk_client.py
@@ -1,0 +1,94 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from apollo.agent import constants
+from apollo.agent.agent import Agent
+from apollo.agent.logging_utils import LoggingUtils
+from apollo.integrations.aws.base_aws_proxy_client import BaseAwsProxyClient
+
+
+class MskConnectClientTests(TestCase):
+    _CREDENTIALS = {
+        "assumable_role": "arn:aws:iam::account_id:role/test",
+        "aws_region": "us-east-1",
+        "external_id": "foo",
+    }
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_client = Mock()
+
+    @patch.object(BaseAwsProxyClient, "create_boto_client")
+    def test_operation(self, mock_boto_client: Mock):
+        # given
+        mock_boto_client.return_value = self._mock_client
+        operation_result = {"foo": "bar"}
+        self._mock_client.list_connectors.return_value = operation_result
+
+        # when
+        response = self._agent.execute_operation(
+            "msk-connect",
+            "list_connectors",
+            {
+                "trace_id": "1234",
+                "skip_cache": True,
+                "commands": [
+                    {"method": "list_connectors", "kwargs": {"maxResults": 10}}
+                ],
+            },
+            credentials=self._CREDENTIALS,
+        )
+
+        # then
+        self.assertIsNone(response.result.get(constants.ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(
+            operation_result, response.result.get(constants.ATTRIBUTE_NAME_RESULT)
+        )
+        self._mock_client.list_connectors.assert_called_once_with(maxResults=10)
+
+
+class MskKafkaClientTests(TestCase):
+    _CREDENTIALS = {
+        "assumable_role": "arn:aws:iam::account_id:role/test",
+        "aws_region": "us-east-1",
+        "external_id": "foo",
+    }
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_client = Mock()
+
+    @patch.object(BaseAwsProxyClient, "create_boto_client")
+    def test_operation(self, mock_boto_client: Mock):
+        # given
+        mock_boto_client.return_value = self._mock_client
+        operation_result = {"foo": "bar"}
+        self._mock_client.get_bootstrap_brokers.return_value = operation_result
+
+        # when
+        response = self._agent.execute_operation(
+            "msk-kafka",
+            "get_bootstrap_brokers",
+            {
+                "trace_id": "1234",
+                "skip_cache": True,
+                "commands": [
+                    {
+                        "method": "get_bootstrap_brokers",
+                        "kwargs": {
+                            "ClusterArn": "arn:aws:kafka:us-east-1:1234567890:cluster/test-cluster/5d0bddae-a77f-48de-be47-d79145c9dfec-20"
+                        },
+                    }
+                ],
+            },
+            credentials=self._CREDENTIALS,
+        )
+
+        # then
+        self.assertIsNone(response.result.get(constants.ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(
+            operation_result, response.result.get(constants.ATTRIBUTE_NAME_RESULT)
+        )
+        self._mock_client.get_bootstrap_brokers.assert_called_once_with(
+            ClusterArn="arn:aws:kafka:us-east-1:1234567890:cluster/test-cluster/5d0bddae-a77f-48de-be47-d79145c9dfec-20"
+        )


### PR DESCRIPTION
This PR adds `boto3` proxy clients for MSK [Kafka](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kafka.html) and [Kafka Connect](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/kafkaconnect.html).