### PR TITLE
set Azure function timeout to 15 min

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,8 @@ CMD [ "apollo.interfaces.lambda_function.handler.lambda_handler" ]
 FROM mcr.microsoft.com/azure-functions/python:4-python3.11 AS azure
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
-    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
+    AzureFunctionsJobHost__functionTimeout="00:15:00"
 
 RUN apt update
 # install git as we need it for the direct oscrypto dependency


### PR DESCRIPTION
- Azure Function App is defaulting to a 30 min runtime. This is overkill because The lambda function from the DC envoking the request has a 15 min timeout. This PR changes the Azure Function timeout to 15 min.

## Testing
- Push changed to dev and update Azure agent in dev.apollo.agent
- Create a SQL monitor on Redshift that uses a py_sleep() function to create a long running query. The monitor is set up to sleep for 1020 seconds (17 min) https://app.dev.getmontecarlo.com/monitors/466bab2d-a905-4c28-af6c-069aa6d79330/run-history
- Ran the monitor, which time-out