### PR TITLE
Ssmith/kil 3258 support adia sql server onboarding and connectivity

### DIFF
--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -17,6 +17,8 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
     """
 
     _DATETIMEOFFSET_SQL_TYPE_CODE = -155
+    _DEFAULT_LOGIN_TIMEOUT_IN_SECONDS = 15
+    _DEFAULT_QUERY_TIMEOUT_IN_SECONDS = 60 * 14  # 14 minutes
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
@@ -26,7 +28,7 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get("login_timeout", 15),
+            timeout=credentials.get("login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -35,7 +37,7 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get("query_timeout_in_seconds", 840)
+        self._connection.timeout = credentials.get("query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS)
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -26,7 +26,7 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get('login_timeout', 15)
+            timeout=credentials.get("login_timeout", 15),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -35,7 +35,7 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get('query_timeout_in_seconds', 840)
+        self._connection.timeout = credentials.get("query_timeout_in_seconds", 840)
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -28,7 +28,9 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get("login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS),
+            timeout=credentials.get(
+                "login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS
+            ),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -37,7 +39,9 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get("query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS)
+        self._connection.timeout = credentials.get(
+            "query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS
+        )
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -35,11 +35,19 @@ class SqlServerProxyClient(BaseDbProxyClient):
             raise AgentError(
                 f"Connection details format is not supported. Please update your Date Collector to >16294"
             )
-        self._connection = pyodbc.connect(credentials[_ATTR_CONNECT_ARGS])  # type: ignore
+        self._connection = pyodbc.connect(
+            credentials[_ATTR_CONNECT_ARGS],
+            # Set timeout for establishing connection to db
+            timeout=credentials.get('login_timeout', 15)
+        )  # type: ignore
+
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
         self._connection.add_output_converter(
             self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset
         )
+
+        # Set timeout for any query executed through this connection
+        self._connection.timeout = credentials.get('query_timeout_in_seconds', 840)
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -38,7 +38,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get('login_timeout', 15)
+            timeout=credentials.get("login_timeout", 15),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -47,7 +47,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get('query_timeout_in_seconds', 840)
+        self._connection.timeout = credentials.get("query_timeout_in_seconds", 840)
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -40,7 +40,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get("login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS),
+            timeout=credentials.get(
+                "login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS
+            ),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -49,7 +51,9 @@ class SqlServerProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get("query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS)
+        self._connection.timeout = credentials.get(
+            "query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS
+        )
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -23,6 +23,8 @@ class SqlServerProxyClient(BaseDbProxyClient):
     """
 
     _DATETIMEOFFSET_SQL_TYPE_CODE = -155
+    _DEFAULT_LOGIN_TIMEOUT_IN_SECONDS = 15
+    _DEFAULT_QUERY_TIMEOUT_IN_SECONDS = 60 * 14  # 14 minutes
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
@@ -38,7 +40,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
         self._connection = pyodbc.connect(
             credentials[_ATTR_CONNECT_ARGS],
             # Set timeout for establishing connection to db
-            timeout=credentials.get("login_timeout", 15),
+            timeout=credentials.get("login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS),
         )  # type: ignore
 
         # Add output converter to handle datetimeoffset data types that are not supported by pyodbc
@@ -47,7 +49,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
         )
 
         # Set timeout for any query executed through this connection
-        self._connection.timeout = credentials.get("query_timeout_in_seconds", 840)
+        self._connection.timeout = credentials.get("query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS)
 
     @property
     def wrapped_client(self):

--- a/tests/test_azure_dedicated_sql_pool_client.py
+++ b/tests/test_azure_dedicated_sql_pool_client.py
@@ -130,7 +130,9 @@ class AzureDedicatedSqlPoolClientTests(TestCase):
         self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
         result = response.result.get(ATTRIBUTE_NAME_RESULT)
 
-        mock_connect.assert_called_with(_AZURE_DEDICATED_SQL_POOL_CREDENTIALS)
+        mock_connect.assert_called_with(
+            _AZURE_DEDICATED_SQL_POOL_CREDENTIALS, timeout=15
+        )
         self._mock_cursor.execute.assert_has_calls(
             [
                 call(query, query_args if query_args else None),

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -153,7 +153,7 @@ class SqlServerClientTests(TestCase):
         self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
         result = response.result.get(ATTRIBUTE_NAME_RESULT)
 
-        mock_connect.assert_called_with(_SQL_SERVER_CREDENTIALS)
+        mock_connect.assert_called_with(_SQL_SERVER_CREDENTIALS, timeout=15)
         self._mock_cursor.execute.assert_has_calls(
             [
                 call(query, query_args if query_args else None),


### PR DESCRIPTION
## What's New
Look for query/timeout parameters in credentials dict for SQL Server and Azure Plugin connections. If found, update connection with the values, otherwise use defaults.

This [DC PR](https://github.com/monte-carlo-data/data-collector/pull/1111) starts sending the parameters to the agent 