### PR TITLE
Support disabling Redshift driver decoding

### DIFF
--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -1,5 +1,5 @@
 from typing import Dict, Optional
-
+from psycopg2.extensions import register_type, BYTES, BYTESARRAY
 from apollo.integrations.db.postgres_proxy_client import PostgresProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
@@ -19,3 +19,11 @@ class RedshiftProxyClient(PostgresProxyClient):
         )
         if credentials and credentials.get("autocommit", False):
             self._connection.autocommit = True
+
+    def disable_decoding_in_driver(self):
+        """
+        Used when Redshift tables have mixed or unusual encodings. The effect is that string
+        columns are returned as bytes, so decoding needs to happen in custom code instead of psycopg2.
+        """
+        register_type(BYTES, self._connection)
+        register_type(BYTESARRAY, self._connection)

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Dict, Optional
 from psycopg2.extensions import register_type, BYTES, BYTESARRAY
 from apollo.integrations.db.postgres_proxy_client import PostgresProxyClient
 
 _ATTR_CONNECT_ARGS = "connect_args"
+
+logger = logging.getLogger(__name__)
 
 
 class RedshiftProxyClient(PostgresProxyClient):
@@ -25,5 +28,7 @@ class RedshiftProxyClient(PostgresProxyClient):
         Used when Redshift tables have mixed or unusual encodings. The effect is that string
         columns are returned as bytes, so decoding needs to happen in custom code instead of psycopg2.
         """
+        logger.info("redshift_driver_decoding disabled")
+
         register_type(BYTES, self._connection)
         register_type(BYTESARRAY, self._connection)

--- a/apollo/integrations/redshift/redshift_proxy_client.py
+++ b/apollo/integrations/redshift/redshift_proxy_client.py
@@ -28,7 +28,7 @@ class RedshiftProxyClient(PostgresProxyClient):
         Used when Redshift tables have mixed or unusual encodings. The effect is that string
         columns are returned as bytes, so decoding needs to happen in custom code instead of psycopg2.
         """
-        logger.info("redshift_driver_decoding disabled")
+        logger.info("redshift_driver_decoding_disabled")
 
         register_type(BYTES, self._connection)
         register_type(BYTESARRAY, self._connection)


### PR DESCRIPTION
This feature was added as a workaround for the query to retrieve Redshift query logs failing due to UTF decoding errors.
It basically disables the string decoding in the driver and allow us to decode it later.