### PR TITLE
Fixed pre-signed urls for regions like af-south-1

### DIFF
--- a/apollo/integrations/s3/s3_base_reader_writer.py
+++ b/apollo/integrations/s3/s3_base_reader_writer.py
@@ -105,6 +105,16 @@ class S3BaseReaderWriter(BaseStorageClient):
 
     @property
     @abstractmethod
+    def s3_regional_client(self):
+        """
+        Needs to be implemented by subclasses to provide a client for S3 initialized with
+        the regional endpoint, required for pre-signed urls, see:
+        https://github.com/boto/boto3/issues/3015
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
     def s3_resource(self):
         """
         Needs to be implemented by subclasses to provide a client for S3, for example: `boto3.resource("s3")`
@@ -277,7 +287,7 @@ class S3BaseReaderWriter(BaseStorageClient):
         :param expiration: time for the generated link to expire, expressed as a timedelta object.
         :return: a pre-signed url to access the specified file.
         """
-        return self.s3_client.generate_presigned_url(
+        return self.s3_regional_client.generate_presigned_url(
             "get_object",
             Params={
                 "Bucket": self._bucket_name,

--- a/apollo/integrations/s3/s3_reader_writer.py
+++ b/apollo/integrations/s3/s3_reader_writer.py
@@ -31,8 +31,18 @@ class S3ReaderWriter(S3BaseReaderWriter):
         return boto3.client("s3")
 
     @cached_property
+    def s3_regional_client(self):
+        """
+        Creates a new S3 client initialized with the regional endpoint and
+        using credentials from the environment, required for pre-signed urls,
+        see: https://github.com/boto/boto3/issues/3015
+        """
+        return boto3.client("s3", endpoint_url=self.s3_client.meta.endpoint_url)
+
+    @cached_property
     def s3_resource(self):
         """
-        Creates a new S3 resource with the default settings and using credentials from the environment
+        Creates a new S3 resource with the default settings and using credentials
+        from the environment.
         """
         return boto3.resource("s3")


### PR DESCRIPTION
For regions created after 3-20-2019 (like `af-south-1`) you need to use the regional endpoint when generating pre-signed URLs, if not the url is invalid and it fails with a `400` error like:
```
The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.
```
One of the available fixes (for more information: https://github.com/boto/boto3/issues/3015) is to create a second client with the regional URL and use it to generate the pre-signed URL.