### PR TITLE
Close DB Proxy Client's connection on deletion

### DIFF
--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -18,6 +18,14 @@ logger = logging.getLogger(__name__)
 
 
 class BaseDbProxyClient(BaseProxyClient, ABC):
+    def __init__(self):
+        self._connection = None
+
+    # On delete make sure we close the connection
+    def __del__(self) -> None:
+        if self._connection:
+            self._connection.close()
+
     def process_result(self, value: Any) -> Any:
         """
         Converts "Column" objects in the description into a list of objects that can be serialized to JSON.


### PR DESCRIPTION
- Closes the DB Proxy client's connection on deletion of the object
    - FIX: Properly ends Session in Teradata so sessions are not left in `IDLE` state