### PR TITLE
Update aiohttp version to fix CVE-2024-23334

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -18,7 +18,8 @@ for handler in root_logger.handlers[:]:
 is_debug = os.getenv(DEBUG_ENV_VAR, "false").lower() == "true"
 root_logger.setLevel(logging.DEBUG if is_debug else logging.INFO)
 
-# configure the Azure Log Monitor, it gets the Instrumentation Key from APPINSIGHTS_INSTRUMENTATIONKEY env var
+# configure the Azure Log Monitor, it gets the Instrumentation Key
+# from APPINSIGHTS_INSTRUMENTATIONKEY env var
 configure_azure_monitor()
 
 # configure the log context to include the agent context in all log messages
@@ -152,7 +153,6 @@ def agent_api(req: func.HttpRequest, context: func.Context):
     return wsgi_middleware.handle(req, context)
 
 
-@app.function_name(name="cleanup_df_data")
 @app.schedule(
     schedule="0 0 3,15 * * *", arg_name="timer", run_on_startup=False
 )  # run every day at 3 AM/PM

--- a/requirements-azure.in
+++ b/requirements-azure.in
@@ -1,6 +1,6 @@
 -c requirements.txt
-azure-functions==1.17.0
-azure-functions-durable==1.2.8
+azure-functions==1.18.0
+azure-functions-durable==1.2.9
 azure-mgmt-resource==23.0.1
-azure-monitor-opentelemetry==1.2.0
-azure-monitor-query==1.2.0
+azure-monitor-opentelemetry==1.3.0
+azure-monitor-query==1.2.1

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements-azure.in
 #
-aiohttp==3.9.1
+aiohttp==3.9.3
     # via azure-functions-durable
 aiosignal==1.3.1
     # via aiohttp
-asgiref==3.7.2
+asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
 attrs==23.1.0
     # via
@@ -29,11 +29,11 @@ azure-core==1.29.5
     #   msrest
 azure-core-tracing-opentelemetry==1.0.0b11
     # via azure-monitor-opentelemetry
-azure-functions==1.17.0
+azure-functions==1.18.0
     # via
     #   -r requirements-azure.in
     #   azure-functions-durable
-azure-functions-durable==1.2.8
+azure-functions-durable==1.2.9
     # via -r requirements-azure.in
 azure-mgmt-core==1.4.0
     # via
@@ -41,11 +41,11 @@ azure-mgmt-core==1.4.0
     #   azure-mgmt-resource
 azure-mgmt-resource==23.0.1
     # via -r requirements-azure.in
-azure-monitor-opentelemetry==1.2.0
+azure-monitor-opentelemetry==1.3.0
     # via -r requirements-azure.in
-azure-monitor-opentelemetry-exporter==1.0.0b21
+azure-monitor-opentelemetry-exporter==1.0.0b23
     # via azure-monitor-opentelemetry
-azure-monitor-query==1.2.0
+azure-monitor-query==1.2.1
     # via -r requirements-azure.in
 certifi==2023.11.17
     # via
@@ -81,7 +81,7 @@ isodate==0.6.1
     #   msrest
 msrest==0.7.1
     # via azure-monitor-opentelemetry-exporter
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
@@ -89,7 +89,7 @@ oauthlib==3.2.2
     # via
     #   -c requirements.txt
     #   requests-oauthlib
-opentelemetry-api==1.22.0
+opentelemetry-api==1.23.0
     # via
     #   azure-core-tracing-opentelemetry
     #   azure-monitor-opentelemetry-exporter
@@ -105,7 +105,7 @@ opentelemetry-api==1.22.0
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-instrumentation==0.43b0
+opentelemetry-instrumentation==0.44b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-dbapi
@@ -117,35 +117,35 @@ opentelemetry-instrumentation==0.43b0
     #   opentelemetry-instrumentation-urllib
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-asgi==0.43b0
+opentelemetry-instrumentation-asgi==0.44b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-dbapi==0.43b0
+opentelemetry-instrumentation-dbapi==0.44b0
     # via opentelemetry-instrumentation-psycopg2
-opentelemetry-instrumentation-django==0.43b0
+opentelemetry-instrumentation-django==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-fastapi==0.43b0
+opentelemetry-instrumentation-fastapi==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-flask==0.43b0
+opentelemetry-instrumentation-flask==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-psycopg2==0.43b0
+opentelemetry-instrumentation-psycopg2==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-requests==0.43b0
+opentelemetry-instrumentation-requests==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-urllib==0.43b0
+opentelemetry-instrumentation-urllib==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-urllib3==0.43b0
+opentelemetry-instrumentation-urllib3==0.44b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-wsgi==0.43b0
+opentelemetry-instrumentation-wsgi==0.44b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-flask
-opentelemetry-resource-detector-azure==0.1.1
+opentelemetry-resource-detector-azure==0.1.3
     # via azure-monitor-opentelemetry
-opentelemetry-sdk==1.22.0
+opentelemetry-sdk==1.23.0
     # via
     #   azure-monitor-opentelemetry-exporter
     #   opentelemetry-resource-detector-azure
-opentelemetry-semantic-conventions==0.43b0
+opentelemetry-semantic-conventions==0.44b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-dbapi
@@ -157,7 +157,7 @@ opentelemetry-semantic-conventions==0.43b0
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.43b0
+opentelemetry-util-http==0.44b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-django
@@ -184,7 +184,7 @@ requests==2.31.0
     #   azure-functions-durable
     #   msrest
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via msrest
 six==1.16.0
     # via
@@ -212,7 +212,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-urllib3
 yarl==1.9.4
     # via aiohttp
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
- Updated all azure specific packages to latest available version, which includes upgrading `aiohttp` to `3.9.3` and fixing https://github.com/monte-carlo-data/apollo-agent/security/dependabot/17
- `function_app` decorator is no longer supported for durable functions, so decoration to set the name for the cleanup function was removed