### PR TITLE
add support for RestrictedPython _apply_

### DIFF
--- a/apollo/agent/scripts.py
+++ b/apollo/agent/scripts.py
@@ -93,6 +93,7 @@ def execute_script(
         "_iter_unpack_sequence_": guarded_iter_unpack_sequence,
         "_unpack_sequence_": guarded_unpack_sequence,
         "_write_": lambda o: o,
+        "_apply_": lambda f, *a, **args: f(*a, **args),
     }
 
     # additional helpers

--- a/tests/sample_scripts/script_builtins_valid.py
+++ b/tests/sample_scripts/script_builtins_valid.py
@@ -196,3 +196,14 @@ str.format_map("Hello {foo.__dict__}", {"foo": str})
 
 def execute_script_handler(*args, **kwargs):
     return "all is good"
+
+
+# ensure we have a replacement for _apply_
+f = {"b": "b_v"}
+
+
+def foo(a, b=None):
+    return a + b
+
+
+assert foo("1", **f) == "1b_v"


### PR DESCRIPTION
RestrictedPython requires an `_apply_` builtin to be available to use constructions like `func(**({"a": 1}))`.

Allow these constructions when running agent scripts.