### PR TITLE
AWS agent: timeout earlier when getting current image in health endpoint

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -5,7 +5,7 @@ import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, List
 
 from apollo.agent.env_vars import (
     HEALTH_ENV_VARS,
@@ -115,12 +115,16 @@ class Agent:
                     operation_name="health_information",
                 ),
             )
+            warnings: List[str] = []
             platform_info = {**(self.platform_info or {})}
             if self.updater:
-                platform_info[PLATFORM_INFO_KEY_IMAGE] = (
-                    self.updater.get_current_image()
-                )
-
+                try:
+                    platform_info[PLATFORM_INFO_KEY_IMAGE] = (
+                        self.updater.get_current_image()
+                    )
+                except Exception as exc:
+                    platform_info[PLATFORM_INFO_KEY_IMAGE] = None
+                    warnings.append(f"Failed to retrieve current image: {exc}")
         return AgentHealthInformation(
             version=VERSION,
             build=BUILD_NUMBER,
@@ -129,6 +133,7 @@ class Agent:
             platform_info=platform_info,
             trace_id=trace_id,
             extra=self._extra_health_information() if full else None,
+            warnings=warnings if warnings else None,
         )
 
     @staticmethod

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -123,6 +123,7 @@ class Agent:
                         self.updater.get_current_image()
                     )
                 except Exception as exc:
+                    logger.warning(f"Failed to retrieve current image: {exc}")
                     platform_info[PLATFORM_INFO_KEY_IMAGE] = None
                     warnings.append(f"Failed to retrieve current image: {exc}")
         return AgentHealthInformation(

--- a/apollo/agent/models.py
+++ b/apollo/agent/models.py
@@ -134,6 +134,9 @@ class AgentHealthInformation(DataClassJsonMixin):
     extra: Optional[Dict] = field(
         metadata=config(exclude=exclude_none_values), default=None
     )
+    warnings: Optional[List[str]] = field(
+        metadata=config(exclude=exclude_none_values), default=None
+    )
 
 
 @dataclass

--- a/apollo/interfaces/lambda_function/aws_utils.py
+++ b/apollo/interfaces/lambda_function/aws_utils.py
@@ -3,9 +3,11 @@ from botocore.config import Config
 
 def get_retrieve_current_image_boto_config(connection_timeout: int) -> Config:
     """
-    Configured the boto3 client (lambda or cloudformation) used to retrieve the current image
-    with 10 seconds timeout and a single retry, so it would take 20 seconds to fail instead
-    of 5 minutes (with the default settings).
+    Returns a boto3 client configuration with the specified connection timeout and a single
+    retry in standard mode.
+    By default, connect_timeout is 60 seconds and legacy retry mode uses 4 attempts, so it takes
+    around 5 minutes to fail if connectivity is not allowed (for example Lambda function configured
+    with no external network access and no VPC endpoints).
     """
     return Config(
         connect_timeout=connection_timeout,

--- a/apollo/interfaces/lambda_function/aws_utils.py
+++ b/apollo/interfaces/lambda_function/aws_utils.py
@@ -1,14 +1,14 @@
 from botocore.config import Config
 
 
-def get_retrieve_current_image_boto_config() -> Config:
+def get_retrieve_current_image_boto_config(connection_timeout: int) -> Config:
     """
     Configured the boto3 client (lambda or cloudformation) used to retrieve the current image
     with 10 seconds timeout and a single retry, so it would take 20 seconds to fail instead
     of 5 minutes (with the default settings).
     """
     return Config(
-        connect_timeout=10,
+        connect_timeout=connection_timeout,
         retries=dict(
             mode="standard",
             max_attempts=1,

--- a/apollo/interfaces/lambda_function/aws_utils.py
+++ b/apollo/interfaces/lambda_function/aws_utils.py
@@ -1,7 +1,7 @@
 from botocore.config import Config
 
 
-def get_retrieve_current_image_boto_config(connection_timeout: int) -> Config:
+def get_boto_config(connect_timeout: int, max_attempts: int = 3) -> Config:
     """
     Returns a boto3 client configuration with the specified connection timeout and a single
     retry in standard mode.
@@ -10,9 +10,9 @@ def get_retrieve_current_image_boto_config(connection_timeout: int) -> Config:
     with no external network access and no VPC endpoints).
     """
     return Config(
-        connect_timeout=connection_timeout,
+        connect_timeout=connect_timeout,
         retries=dict(
             mode="standard",
-            max_attempts=1,
+            max_attempts=max_attempts,
         ),
     )

--- a/apollo/interfaces/lambda_function/aws_utils.py
+++ b/apollo/interfaces/lambda_function/aws_utils.py
@@ -1,0 +1,16 @@
+from botocore.config import Config
+
+
+def get_retrieve_current_image_boto_config() -> Config:
+    """
+    Configured the boto3 client (lambda or cloudformation) used to retrieve the current image
+    with 10 seconds timeout and a single retry, so it would take 20 seconds to fail instead
+    of 5 minutes (with the default settings).
+    """
+    return Config(
+        connect_timeout=10,
+        retries=dict(
+            mode="standard",
+            max_attempts=1,
+        ),
+    )

--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -5,6 +5,9 @@ from botocore.client import BaseClient
 from botocore.exceptions import WaiterError
 
 from apollo.agent.updater import AgentUpdater
+from apollo.interfaces.lambda_function.aws_utils import (
+    get_retrieve_current_image_boto_config,
+)
 from apollo.interfaces.lambda_function.cf_utils import CloudFormationUtils
 from apollo.interfaces.lambda_function.direct_updater import LambdaDirectUpdater
 
@@ -37,9 +40,10 @@ class LambdaCFUpdater(AgentUpdater):
         """
         Returns the current value for the "ImageUri" template parameter.
         """
-        return None
-        # client = CloudFormationUtils.get_cloudformation_client()
-        # return self._get_image_uri_parameter(client=client)
+        client = CloudFormationUtils.get_cloudformation_client(
+            config=get_retrieve_current_image_boto_config()
+        )
+        return self._get_image_uri_parameter(client=client)
 
     def get_update_logs(self, start_time: datetime, limit: int) -> List[Dict]:
         """

--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -5,9 +5,7 @@ from botocore.client import BaseClient
 from botocore.exceptions import WaiterError
 
 from apollo.agent.updater import AgentUpdater
-from apollo.interfaces.lambda_function.aws_utils import (
-    get_retrieve_current_image_boto_config,
-)
+from apollo.interfaces.lambda_function.aws_utils import get_boto_config
 from apollo.interfaces.lambda_function.cf_utils import CloudFormationUtils
 from apollo.interfaces.lambda_function.direct_updater import LambdaDirectUpdater
 
@@ -41,7 +39,7 @@ class LambdaCFUpdater(AgentUpdater):
         Returns the current value for the "ImageUri" template parameter.
         """
         client = CloudFormationUtils.get_cloudformation_client(
-            config=get_retrieve_current_image_boto_config(connection_timeout=10)
+            config=get_boto_config(connect_timeout=10, max_attempts=1)
         )
         return self._get_image_uri_parameter(client=client)
 

--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -41,7 +41,7 @@ class LambdaCFUpdater(AgentUpdater):
         Returns the current value for the "ImageUri" template parameter.
         """
         client = CloudFormationUtils.get_cloudformation_client(
-            config=get_retrieve_current_image_boto_config()
+            config=get_retrieve_current_image_boto_config(connection_timeout=10)
         )
         return self._get_image_uri_parameter(client=client)
 

--- a/apollo/interfaces/lambda_function/cf_updater.py
+++ b/apollo/interfaces/lambda_function/cf_updater.py
@@ -37,8 +37,9 @@ class LambdaCFUpdater(AgentUpdater):
         """
         Returns the current value for the "ImageUri" template parameter.
         """
-        client = CloudFormationUtils.get_cloudformation_client()
-        return self._get_image_uri_parameter(client=client)
+        return None
+        # client = CloudFormationUtils.get_cloudformation_client()
+        # return self._get_image_uri_parameter(client=client)
 
     def get_update_logs(self, start_time: datetime, limit: int) -> List[Dict]:
         """

--- a/apollo/interfaces/lambda_function/cf_utils.py
+++ b/apollo/interfaces/lambda_function/cf_utils.py
@@ -15,8 +15,8 @@ class CloudFormationUtils:
     """
 
     @staticmethod
-    def get_cloudformation_client() -> BaseClient:
-        return cast(BaseClient, boto3.client("cloudformation"))
+    def get_cloudformation_client(**kwargs) -> BaseClient:  # type: ignore
+        return cast(BaseClient, boto3.client("cloudformation", **kwargs))
 
     @staticmethod
     def get_stack_id() -> str:

--- a/apollo/interfaces/lambda_function/direct_updater.py
+++ b/apollo/interfaces/lambda_function/direct_updater.py
@@ -128,9 +128,9 @@ class LambdaDirectUpdater(AgentUpdater):
         """
         Returns the current value for `ImageUri` in the function.
         """
-        client = self._get_lambda_client()
-        #     config=get_retrieve_current_image_boto_config()
-        # )
+        client = self._get_lambda_client(
+            config=get_retrieve_current_image_boto_config()
+        )
         function = client.get_function(FunctionName=self._get_function_name())
         return function.get("Code", {}).get("ImageUri")
 

--- a/apollo/interfaces/lambda_function/direct_updater.py
+++ b/apollo/interfaces/lambda_function/direct_updater.py
@@ -128,9 +128,9 @@ class LambdaDirectUpdater(AgentUpdater):
         """
         Returns the current value for `ImageUri` in the function.
         """
-        client = self._get_lambda_client(
-            config=get_retrieve_current_image_boto_config()
-        )
+        client = self._get_lambda_client()
+        #     config=get_retrieve_current_image_boto_config()
+        # )
         function = client.get_function(FunctionName=self._get_function_name())
         return function.get("Code", {}).get("ImageUri")
 

--- a/apollo/interfaces/lambda_function/direct_updater.py
+++ b/apollo/interfaces/lambda_function/direct_updater.py
@@ -128,8 +128,11 @@ class LambdaDirectUpdater(AgentUpdater):
         """
         Returns the current value for `ImageUri` in the function.
         """
+        # in practice, the connect_timeout specified for lambda clients is multiplied by 16
+        # it's not clear why, it could be related to data type conversion when calling
+        # sock.settimeout, so we're setting 1 here to have a 16 seconds timeout.
         client = self._get_lambda_client(
-            config=get_retrieve_current_image_boto_config()
+            config=get_retrieve_current_image_boto_config(connection_timeout=1)
         )
         function = client.get_function(FunctionName=self._get_function_name())
         return function.get("Code", {}).get("ImageUri")

--- a/apollo/interfaces/lambda_function/direct_updater.py
+++ b/apollo/interfaces/lambda_function/direct_updater.py
@@ -10,9 +10,7 @@ from botocore.exceptions import WaiterError
 from apollo.agent.env_vars import AWS_LAMBDA_FUNCTION_NAME_ENV_VAR
 from apollo.agent.models import AgentConfigurationError
 from apollo.agent.updater import AgentUpdater
-from apollo.interfaces.lambda_function.aws_utils import (
-    get_retrieve_current_image_boto_config,
-)
+from apollo.interfaces.lambda_function.aws_utils import get_boto_config
 
 logger = logging.getLogger(__name__)
 
@@ -128,11 +126,11 @@ class LambdaDirectUpdater(AgentUpdater):
         """
         Returns the current value for `ImageUri` in the function.
         """
-        # in practice, the connect_timeout specified for lambda clients is multiplied by 16
+        # in practice, the connect_timeout setting specified for lambda clients is multiplied by 16
         # it's not clear why, it could be related to data type conversion when calling
         # sock.settimeout, so we're setting 1 here to have a 16 seconds timeout.
         client = self._get_lambda_client(
-            config=get_retrieve_current_image_boto_config(connection_timeout=1)
+            config=get_boto_config(connect_timeout=1, max_attempts=1)
         )
         function = client.get_function(FunctionName=self._get_function_name())
         return function.get("Code", {}).get("ImageUri")

--- a/tests/test_cf_updater.py
+++ b/tests/test_cf_updater.py
@@ -37,7 +37,7 @@ class TestCFUpdater(TestCase):
         updater = LambdaCFUpdater()
         uri = updater.get_current_image()
         mock_client.describe_stacks.assert_called_once_with(StackName="cf_stack_id")
-        self.assertEqual(expected_image_uri, uri)
+        # self.assertEqual(expected_image_uri, uri)
 
     @patch.dict(
         os.environ,

--- a/tests/test_cf_updater.py
+++ b/tests/test_cf_updater.py
@@ -36,7 +36,7 @@ class TestCFUpdater(TestCase):
         }
         updater = LambdaCFUpdater()
         uri = updater.get_current_image()
-        mock_client.describe_stacks.assert_called_once_with(StackName="cf_stack_id")
+        # mock_client.describe_stacks.assert_called_once_with(StackName="cf_stack_id")
         # self.assertEqual(expected_image_uri, uri)
 
     @patch.dict(

--- a/tests/test_cf_updater.py
+++ b/tests/test_cf_updater.py
@@ -36,8 +36,8 @@ class TestCFUpdater(TestCase):
         }
         updater = LambdaCFUpdater()
         uri = updater.get_current_image()
-        # mock_client.describe_stacks.assert_called_once_with(StackName="cf_stack_id")
-        # self.assertEqual(expected_image_uri, uri)
+        mock_client.describe_stacks.assert_called_once_with(StackName="cf_stack_id")
+        self.assertEqual(expected_image_uri, uri)
 
     @patch.dict(
         os.environ,


### PR DESCRIPTION
- As part of the health endpoint we're getting the current image (we get it from CloudFormation or directly from the Lambda if Terraform is being used)
- This operation can take a long time to execute if connections to CloudFormation or Lambda endpoints are not allowed, as the default timeout and retry policies will take between 4 or 5 minutes to fail.
- This PR reduces the timeout used when getting the current image to `10` seconds and a single retry, meaning it would take around 20 seconds to fail. It also updates the health endpoint to succeed even if we weren't able to get the current image, it just includes a new warning message with the error received and a `null` value in the image.
- *Note*: for `lambda` clients the `connect_timeout` setting is not working as expected, and setting `connect_timeout=10` is actually timing out after `160` seconds, that seems to be the case for other values (it times out after value*16), couldn't find this issue reported but I think it might be related to a data type conversion when calling the native `sock.settimeout` function