### PR TITLE
KIL-3578 endpoints to help troubleshooting issues with Azure Durable Functions

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -130,6 +130,13 @@ async def get_async_operation_status(
 async def cleanup_durable_functions_instances(
     req: func.HttpRequest, client: DurableOrchestrationClient
 ):
+    """
+    Endpoint to manually cleanup Durable Functions data, use a POST sending a JSON body with:
+    - created_time_from: the oldest instance to purge, default is 10 years ago
+    - created_time_to: the newest instance to purge, default is 10 minutes ago
+    - include_pending: whether to purge pending instances that were not executed yet,
+        defaults to False
+    """
     body = req.get_json()
     created_time_from_str = body.get("created_time_from")
     created_time_to_str = body.get("created_time_to")


### PR DESCRIPTION
Added two endpoints:
- `/async/api/v1/queue/info` to return the number of `pending` and `completed` task instances in the specified time window
  ```json
  {
    "created_time_from": "2024-04-16T00:00:00Z",
    "created_time_to": "2024-04-16T12:00:00Z"
  }
  ```
  would return:
  ```json
  {
    "pending_instances": 0,
    "completed_instances": 1230
  }
  ```
- `/async/api/v1/cleanup` to purge all task instances in a given time period, optionally can delete `pending` tasks
  ```json
  {
    "created_time_from": "2024-04-16T00:00:00Z",
    "created_time_to": "2024-04-16T12:00:00Z",
    "include_pending": false
  }
  ```
  would return:
  ```json
  {
    "deleted_instances": 1230,
  }
  ```
