### PR TITLE
Added unit tests for Azure Durable functions related operations

### DIFF
--- a/apollo/interfaces/azure/durable_functions_utils.py
+++ b/apollo/interfaces/azure/durable_functions_utils.py
@@ -1,0 +1,124 @@
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Dict, Tuple, cast
+
+from azure.durable_functions.models import (
+    DurableOrchestrationClient,
+    OrchestrationRuntimeStatus,
+)
+
+from apollo.interfaces.generic.utils import AgentPlatformUtils
+
+
+class AzureDurableFunctionsUtils:
+    @classmethod
+    async def cleanup_durable_functions_instances(
+        cls, body: Dict, client: DurableOrchestrationClient
+    ) -> int:
+        """
+        Cleanup Durable Functions data, body supports the following attributes:
+        - created_time_from: the oldest instance to purge, default is 10 years ago
+        - created_time_to: the newest instance to purge, default is 10 minutes ago
+        - include_pending: whether to purge pending instances that were not executed yet,
+            defaults to False
+        Returns the number of deleted instances.
+        """
+        include_pending = body.get("include_pending", False)
+        created_time_from, created_time_to = cls._parse_created_times(
+            body,
+            default_created_from=datetime.now(timezone.utc) - timedelta(days=365 * 10),
+            default_created_to=datetime.now(timezone.utc) - timedelta(minutes=10),
+        )
+        return await cls.purge_instances(
+            client=client,
+            created_time_from=created_time_from,
+            created_time_to=created_time_to,
+            include_pending=include_pending,
+        )
+
+    @classmethod
+    async def get_durable_functions_info(
+        cls,
+        body: Dict,
+        client: DurableOrchestrationClient,
+    ) -> Tuple[int, int]:
+        created_time_from, created_time_to = cls._parse_created_times(
+            body,
+            default_created_from=datetime.now(timezone.utc) - timedelta(days=1),
+            default_created_to=datetime.now(timezone.utc),
+        )
+        instances = await client.get_status_by(
+            created_time_from=created_time_from,
+            created_time_to=created_time_to,
+            runtime_status=[
+                OrchestrationRuntimeStatus.Completed,
+                OrchestrationRuntimeStatus.Pending,
+            ],
+        )
+        pending_instances = [
+            i
+            for i in instances
+            if i.runtime_status == OrchestrationRuntimeStatus.Pending
+        ]
+        completed_instances = [
+            i
+            for i in instances
+            if i.runtime_status == OrchestrationRuntimeStatus.Completed
+        ]
+        return len(pending_instances), len(completed_instances)
+
+    @staticmethod
+    async def purge_instances(
+        client: DurableOrchestrationClient,
+        created_time_from: datetime,
+        created_time_to: datetime,
+        include_pending: bool,
+    ) -> int:
+        runtime_statuses = [
+            OrchestrationRuntimeStatus.Canceled,
+            OrchestrationRuntimeStatus.Completed,
+            OrchestrationRuntimeStatus.Failed,
+            OrchestrationRuntimeStatus.Terminated,
+        ]
+        if include_pending:
+            runtime_statuses.append(OrchestrationRuntimeStatus.Pending)
+
+        logging.info(
+            f'Purging instances older than {created_time_to.isoformat(timespec="seconds")}'
+            f", including pending: {include_pending}"
+        )
+
+        try:
+            result = await client.purge_instance_history_by(
+                created_time_from=created_time_from,
+                created_time_to=created_time_to,
+                runtime_status=runtime_statuses,
+            )
+            logging.info(
+                f"Purge completed, deleted instances: {result.instances_deleted}"
+            )
+            return result.instances_deleted
+        except Exception as ex:
+            logging.error(f"Failed to purge Durable Functions data: {ex}")
+            return -1
+
+    @staticmethod
+    def _parse_created_times(
+        body: Dict,
+        default_created_from: datetime,
+        default_created_to: datetime,
+    ) -> Tuple[datetime, datetime]:
+        created_time_from_str = body.get("created_time_from")
+        created_time_to_str = body.get("created_time_to")
+
+        created_time_from = cast(
+            datetime,
+            AgentPlatformUtils.parse_datetime(
+                created_time_from_str, default_created_from
+            ),
+        )
+        created_time_to = cast(
+            datetime,
+            AgentPlatformUtils.parse_datetime(created_time_to_str, default_created_to),
+        )
+        return created_time_from, created_time_to

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -2,13 +2,13 @@ import json
 import logging
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Dict, cast, Tuple
+from typing import Dict
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 
 from apollo.agent.env_vars import DEBUG_ENV_VAR
+from apollo.interfaces.azure.durable_functions_utils import AzureDurableFunctionsUtils
 from apollo.interfaces.azure.log_context import AzureLogContext
-from apollo.interfaces.generic.utils import AgentPlatformUtils
 
 # remove default handlers to prevent duplicate log messages
 # https://learn.microsoft.com/en-us/python/api/overview/azure/monitor-opentelemetry-readme?view=azure-python#logging-issues
@@ -138,17 +138,11 @@ async def cleanup_durable_functions_instances(
         defaults to False
     """
     body = req.get_json()
-    include_pending = body.get("include_pending", False)
-    created_time_from, created_time_to = _parse_created_times(
-        body,
-        default_created_from=datetime.now(timezone.utc) - timedelta(days=365 * 10),
-        default_created_to=datetime.now(timezone.utc) - timedelta(minutes=10),
-    )
-    deleted_instances = await _purge_instances(
-        client=client,
-        created_time_from=created_time_from,
-        created_time_to=created_time_to,
-        include_pending=include_pending,
+    deleted_instances = (
+        await AzureDurableFunctionsUtils.cleanup_durable_functions_instances(
+            body=body,
+            client=client,
+        )
     )
     return func.HttpResponse(
         status_code=200,
@@ -175,31 +169,18 @@ async def get_durable_functions_info(
     - created_time_to: the newest instance to purge, default is 10 minutes ago
     """
     body = req.get_json()
-    created_time_from, created_time_to = _parse_created_times(
-        body,
-        default_created_from=datetime.now(timezone.utc) - timedelta(days=1),
-        default_created_to=datetime.now(timezone.utc),
+    pending_instances, completed_instances = (
+        await AzureDurableFunctionsUtils.get_durable_functions_info(
+            body=body,
+            client=client,
+        )
     )
-    instances = await client.get_status_by(
-        created_time_from=created_time_from,
-        created_time_to=created_time_to,
-        runtime_status=[
-            OrchestrationRuntimeStatus.Completed,
-            OrchestrationRuntimeStatus.Pending,
-        ],
-    )
-    pending_instances = [
-        i for i in instances if i.runtime_status == OrchestrationRuntimeStatus.Pending
-    ]
-    completed_instances = [
-        i for i in instances if i.runtime_status == OrchestrationRuntimeStatus.Completed
-    ]
     return func.HttpResponse(
         status_code=200,
         body=json.dumps(
             {
-                "pending_instances": len(pending_instances),
-                "completed_instances": len(completed_instances),
+                "pending_instances": pending_instances,
+                "completed_instances": completed_instances,
             }
         ),
         headers={
@@ -248,58 +229,6 @@ async def cleanup_durable_functions_data(
         days=365 * 10
     )  # datetime.min or None not supported
     created_time_to = datetime.now(timezone.utc) - timedelta(days=1)
-    await _purge_instances(
+    await AzureDurableFunctionsUtils.purge_instances(
         client, created_time_from, created_time_to, include_pending=False
     )
-
-
-async def _purge_instances(
-    client: DurableOrchestrationClient,
-    created_time_from: datetime,
-    created_time_to: datetime,
-    include_pending: bool,
-) -> int:
-    runtime_statuses = [
-        OrchestrationRuntimeStatus.Canceled,
-        OrchestrationRuntimeStatus.Completed,
-        OrchestrationRuntimeStatus.Failed,
-        OrchestrationRuntimeStatus.Terminated,
-    ]
-    if include_pending:
-        runtime_statuses.append(OrchestrationRuntimeStatus.Pending)
-
-    logging.info(
-        f'Purging instances older than {created_time_to.isoformat(timespec="seconds")}'
-        f", including pending: {include_pending}"
-    )
-
-    try:
-        result = await client.purge_instance_history_by(
-            created_time_from=created_time_from,
-            created_time_to=created_time_to,
-            runtime_status=runtime_statuses,
-        )
-        logging.info(f"Purge completed, deleted instances: {result.instances_deleted}")
-        return result.instances_deleted
-    except Exception as ex:
-        logging.error(f"Failed to purge Durable Functions data: {ex}")
-        return -1
-
-
-def _parse_created_times(
-    body: Dict,
-    default_created_from: datetime,
-    default_created_to: datetime,
-) -> Tuple[datetime, datetime]:
-    created_time_from_str = body.get("created_time_from")
-    created_time_to_str = body.get("created_time_to")
-
-    created_time_from = cast(
-        datetime,
-        AgentPlatformUtils.parse_datetime(created_time_from_str, default_created_from),
-    )
-    created_time_to = cast(
-        datetime,
-        AgentPlatformUtils.parse_datetime(created_time_to_str, default_created_to),
-    )
-    return created_time_from, created_time_to


### PR DESCRIPTION
- Moved Azure Durable Functions specific code to its own class so it can be tested
- Added unit tests for the recently added operations (https://github.com/monte-carlo-data/apollo-agent/pull/105)