### PR TITLE
KIL-3578: terminate pending tasks when cleanup(include_pending=True) is called

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -7,7 +7,11 @@ from typing import Dict
 from azure.monitor.opentelemetry import configure_azure_monitor
 
 from apollo.agent.env_vars import DEBUG_ENV_VAR
-from apollo.interfaces.azure.durable_functions_utils import AzureDurableFunctionsUtils
+from apollo.interfaces.azure.durable_functions_utils import (
+    AzureDurableFunctionsUtils,
+    AzureDurableFunctionsRequest,
+    AzureDurableFunctionsCleanupRequest,
+)
 from apollo.interfaces.azure.log_context import AzureLogContext
 
 # remove default handlers to prevent duplicate log messages
@@ -137,10 +141,9 @@ async def cleanup_durable_functions_instances(
     - include_pending: whether to purge pending instances that were not executed yet,
         defaults to False
     """
-    body = req.get_json()
     deleted_instances = (
         await AzureDurableFunctionsUtils.cleanup_durable_functions_instances(
-            body=body,
+            request=AzureDurableFunctionsCleanupRequest.from_dict(req.get_json()),
             client=client,
         )
     )
@@ -168,10 +171,9 @@ async def get_durable_functions_info(
     - created_time_from: the oldest instance to purge, default is 10 years ago
     - created_time_to: the newest instance to purge, default is 10 minutes ago
     """
-    body = req.get_json()
     pending_instances, completed_instances = (
         await AzureDurableFunctionsUtils.get_durable_functions_info(
-            body=body,
+            request=AzureDurableFunctionsRequest.from_dict(req.get_json()),
             client=client,
         )
     )

--- a/tests/test_azure_platform.py
+++ b/tests/test_azure_platform.py
@@ -14,7 +14,11 @@ from apollo.agent.env_vars import IS_REMOTE_UPGRADABLE_ENV_VAR
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.interfaces.azure.azure_platform import AzurePlatformProvider
 from apollo.interfaces.azure.azure_updater import AzureUpdater
-from apollo.interfaces.azure.durable_functions_utils import AzureDurableFunctionsUtils
+from apollo.interfaces.azure.durable_functions_utils import (
+    AzureDurableFunctionsUtils,
+    AzureDurableFunctionsRequest,
+    AzureDurableFunctionsCleanupRequest,
+)
 
 
 class TestAzurePlatform(TestCase):
@@ -475,7 +479,7 @@ class TestAzurePlatform(TestCase):
         mock_client.get_status_by.side_effect = get_status_by
         pending, completed = asyncio.run(
             AzureDurableFunctionsUtils.get_durable_functions_info(
-                {},
+                AzureDurableFunctionsRequest.from_dict({}),
                 mock_client,
             )
         )
@@ -493,10 +497,12 @@ class TestAzurePlatform(TestCase):
         mock_client.get_status_by.reset_mock()
         asyncio.run(
             AzureDurableFunctionsUtils.get_durable_functions_info(
-                {
-                    "created_time_from": "2022-01-01T00:00:00Z",
-                    "created_time_to": "2022-01-02T00:00:00Z",
-                },
+                AzureDurableFunctionsRequest.from_dict(
+                    {
+                        "created_time_from": "2022-01-01T00:00:00Z",
+                        "created_time_to": "2022-01-02T00:00:00Z",
+                    }
+                ),
                 mock_client,
             )
         )
@@ -518,7 +524,7 @@ class TestAzurePlatform(TestCase):
         mock_client.purge_instance_history_by.side_effect = purge_instance_history_by
         deleted_instances = asyncio.run(
             AzureDurableFunctionsUtils.cleanup_durable_functions_instances(
-                {},
+                AzureDurableFunctionsCleanupRequest.from_dict({}),
                 mock_client,
             )
         )
@@ -554,9 +560,11 @@ class TestAzurePlatform(TestCase):
         mock_client.purge_instance_history_by.reset_mock()
         asyncio.run(
             AzureDurableFunctionsUtils.cleanup_durable_functions_instances(
-                {
-                    "include_pending": True,
-                },
+                AzureDurableFunctionsCleanupRequest.from_dict(
+                    {
+                        "include_pending": True,
+                    }
+                ),
                 mock_client,
             )
         )


### PR DESCRIPTION
- Added code to terminate pending instances when cleanup with `include_pending=true` is called, this is because calling `purge` is not enough to cancel `pending` tasks.
- Switched from the raw dictionary to a data class object for the requests to this class