### PR TITLE
Upload AWS image to CaaS agent repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
-      - aws-ecr/login
+      - aws-ecr/ecr_login
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
           tag: << parameters.code_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  aws-cli: circleci/aws-cli@4.0.0
+  aws-cli: circleci/aws-cli@4.1.3
   aws-ecr: circleci/aws-ecr@9.0.4
   docker: circleci/docker@2.2.0
 
@@ -129,6 +129,32 @@ jobs:
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
+      - aws-cli/setup:
+          role_arn: "${AWS_ROLE_ARN}"
+      - aws-ecr/ecr_login
+      - aws-ecr/push_image:
+          repo: << parameters.aws_ecr_repository >>
+          tag: latest,<< parameters.code_version >>
+  push-lambda-legacy-repo:
+    machine:
+      image: ubuntu-2004:202201-02
+    parameters:
+      docker_hub_repository:
+        type: string
+      aws_ecr_repository:
+        type: string
+      code_version:
+        type: string
+    steps:
+      - checkout
+      - docker/pull:
+          image: montecarlodata/<< parameters.docker_hub_repository >>
+          tag: latest-lambda,<< parameters.code_version >>-lambda
+      - run:
+          name: Tag lambda image
+          command: |
+            docker tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
+            docker tag montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:latest
       - aws-ecr/ecr_login
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
@@ -201,11 +227,34 @@ workflows:
                   echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
                   source $BASH_ENV
           context:
-            - aws-dev
+            - aether-dev
             - docker
           requires:
             - run-linter
             - run-test-docker
+          filters:
+            branches:
+              only:
+                - dev
+      - push-lambda-legacy-repo:
+          name: push-lambda-aws-dev
+          docker_hub_repository: pre-release-agent
+          aws_ecr_repository: mcd-pre-release-agent
+          code_version: ${NEXT_VERSION}
+          pre-steps:
+            - checkout
+            - run:
+                command: |
+                  PIPELINE_NUMBER=<< pipeline.number >>
+                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+                  VERSION=${TAG#v}
+                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
+                  source $BASH_ENV
+          context:
+            - aws-dev
+            - docker
+          requires:
+            - build-and-push-lambda-dev
           filters:
             branches:
               only:
@@ -244,11 +293,33 @@ workflows:
                   echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
                   source $BASH_ENV
           context:
-            - aws-prod
+            - aether-prod
             - docker
           requires:
             - run-linter
             - run-test-docker
+          filters: # run only for tags starting with v, don't run for branches
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - push-lambda-legacy-repo:
+          name: push-lambda-aws-prod
+          docker_hub_repository: agent
+          aws_ecr_repository: mcd-agent
+          code_version: ${VERSION_TAG}
+          pre-steps:
+            - checkout
+            - run:
+                command: |
+                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
+                  source $BASH_ENV
+          context:
+            - aws-prod
+            - docker
+          requires:
+            - build-and-push-lambda-prod
           filters: # run only for tags starting with v, don't run for branches
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,10 +131,7 @@ jobs:
       - aws-ecr/ecr_login
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
-          tag: << parameters.code_version >>
-      - aws-ecr/tag_image:
-          repo: << parameters.aws_ecr_repository >>
-          source_tag: << parameters.code_version >>
+          tag: latest,<< parameters.code_version >>
 
   build-and-push-docs:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,17 +111,18 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     parameters:
+      docker_hub_repository:
+        type: string
       aws_ecr_repository:
         type: string
       code_version:
         type: string
     steps:
       - checkout
-      - aws-ecr/build-and-push-image:
-          checkout: false
-          repo: << parameters.aws_ecr_repository >>
-          tag: << parameters.code_version >>
-          extra-build-args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
+      - run:
+          name: Tag lambda image
+          command: |
+            docker tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
       - verify-version-in-docker-image:
           image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
           version: << parameters.code_version >>,<< pipeline.number >>
@@ -183,6 +184,7 @@ workflows:
                 - dev
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
+          docker_hub_repository: pre-release-agent
           aws_ecr_repository: mcd-pre-release-agent
           code_version: ${NEXT_VERSION}
           pre-steps:
@@ -199,6 +201,7 @@ workflows:
           requires:
             - run-linter
             - run-test-docker
+            - build-and-push-dev
           filters:
             branches:
               only:
@@ -226,6 +229,7 @@ workflows:
               ignore: /.*/
       - build-and-push-lambda:
           name: build-and-push-lambda-prod
+          docker_hub_repository: agent
           aws_ecr_repository: mcd-agent
           code_version: ${VERSION_TAG}
           pre-steps:
@@ -240,6 +244,7 @@ workflows:
           requires:
             - run-linter
             - run-test-docker
+            - build-and-push-prod
           filters: # run only for tags starting with v, don't run for branches
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,6 +128,7 @@ jobs:
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
+      - aws-ecr/login
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
           tag: << parameters.code_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,8 @@ jobs:
         type: string
     steps:
       - checkout
+      - docker/check:
+          use-docker-credentials-store: true
       - docker/build:
           step-name: Build lambda image
           use-buildkit: true # to build only the required stages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
           name: Tag lambda image
           command: |
             docker tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
+            docker tag montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:latest
       - verify-version-in-docker-image:
           image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
           version: << parameters.code_version >>,<< pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@4.0.0
-  aws-ecr: circleci/aws-ecr@8.1.3
+  aws-ecr: circleci/aws-ecr@9.0.4
   docker: circleci/docker@2.2.0
 
 commands:
@@ -126,10 +126,10 @@ jobs:
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
-      - aws-ecr/push-image:
+      - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
           source-tag: << parameters.code_version >>
-      - aws-ecr/tag-image:
+      - aws-ecr/tag_image:
           repo: << parameters.aws_ecr_repository >>
           source-tag: << parameters.code_version >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,6 @@ workflows:
           requires:
             - run-linter
             - run-test-docker
-            - build-and-push-dev
           filters:
             branches:
               only:
@@ -249,7 +248,6 @@ workflows:
           requires:
             - run-linter
             - run-test-docker
-            - build-and-push-prod
           filters: # run only for tags starting with v, don't run for branches
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
   run-test-docker:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - checkout
       - docker/build:
@@ -57,7 +57,7 @@ jobs:
 
   build-and-push:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     parameters:
       docker_hub_repository:
         type: string
@@ -100,7 +100,7 @@ jobs:
 
   build-and-push-lambda:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     parameters:
       docker_hub_repository:
         type: string
@@ -137,7 +137,7 @@ jobs:
           tag: latest,<< parameters.code_version >>
   push-lambda-legacy-repo:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     parameters:
       docker_hub_repository:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,7 @@ jobs:
     steps:
       - checkout
       - docker/pull:
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-lambda,<< parameters.code_version >>-lambda
+          images: montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda,montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda
       - run:
           name: Tag lambda image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,12 +80,6 @@ jobs:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-cloudrun,<< parameters.code_version >>-cloudrun
       - docker/build:
-          step-name: Build lambda image
-          use-buildkit: true # to build only the required stages
-          extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-lambda,<< parameters.code_version >>-lambda
-      - docker/build:
           step-name: Build azure image
           use-buildkit: true # to build only the required stages
           extra_build_args: --target azure --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
@@ -98,14 +92,11 @@ jobs:
           image: montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun
           version: << parameters.code_version >>,<< pipeline.number >>
       - verify-version-in-docker-image:
-          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda
-          version: << parameters.code_version >>,<< pipeline.number >>
-      - verify-version-in-docker-image:
           image: montecarlodata/<< parameters.docker_hub_repository >>:latest-azure
           version: << parameters.code_version >>,<< pipeline.number >>
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-generic,<< parameters.code_version >>-generic,latest-cloudrun,<< parameters.code_version >>-cloudrun,latest-lambda,<< parameters.code_version >>-lambda,latest-azure,<< parameters.code_version >>-azure
+          tag: latest-generic,<< parameters.code_version >>-generic,latest-cloudrun,<< parameters.code_version >>-cloudrun,latest-azure,<< parameters.code_version >>-azure
 
   build-and-push-lambda:
     machine:
@@ -119,6 +110,12 @@ jobs:
         type: string
     steps:
       - checkout
+      - docker/build:
+          step-name: Build lambda image
+          use-buildkit: true # to build only the required stages
+          extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
+          image: montecarlodata/<< parameters.docker_hub_repository >>
+          tag: latest-lambda,<< parameters.code_version >>-lambda
       - run:
           name: Tag lambda image
           command: |
@@ -126,6 +123,12 @@ jobs:
       - verify-version-in-docker-image:
           image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
           version: << parameters.code_version >>,<< pipeline.number >>
+      - docker/push:
+          image: montecarlodata/<< parameters.docker_hub_repository >>
+          tag: latest-lambda,<< parameters.code_version >>-lambda
+      - aws-ecr/push-image:
+          repo: << parameters.aws_ecr_repository >>
+          source-tag: << parameters.code_version >>
       - aws-ecr/tag-image:
           repo: << parameters.aws_ecr_repository >>
           source-tag: << parameters.code_version >>
@@ -198,6 +201,7 @@ workflows:
                   source $BASH_ENV
           context:
             - aws-dev
+            - docker
           requires:
             - run-linter
             - run-test-docker
@@ -241,6 +245,7 @@ workflows:
                   source $BASH_ENV
           context:
             - aws-prod
+            - docker
           requires:
             - run-linter
             - run-test-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,10 +128,10 @@ jobs:
           tag: latest-lambda,<< parameters.code_version >>-lambda
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>
-          source-tag: << parameters.code_version >>
+          tag: << parameters.code_version >>
       - aws-ecr/tag_image:
           repo: << parameters.aws_ecr_repository >>
-          source-tag: << parameters.code_version >>
+          source_tag: << parameters.code_version >>
 
   build-and-push-docs:
     docker:


### PR DESCRIPTION
Build updated to:
- Move the building of the AWS image to a new step that first builds the image and then uploads it to Docker Hub first and then to ECR (before we were building it first to upload it to Docker and then building it again to upload it to ECR)
- The AWS image is uploaded now to the new ECR repo in the corresponding CaaS account
- Then it is uploaded to the previous ECR repo in dev/prod account, for compatibility reasons, this step will be removed eventually
- Ubuntu images (from circleci) updated to `current` as the previous image we were using is now deprecated