### PR TITLE
Improve client management to release memory earlier, added connection logs for Redshift

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -480,11 +480,16 @@ class Agent:
             except Exception:  # noqa
                 return AgentUtils.agent_response_for_last_exception(client=client)
             finally:
-                # discard clients that raised exceptions, clients like Redshift keep failing after an error
                 if (response is None or response.is_error) and not operation.skip_cache:
+                    # discard clients that raised exceptions, clients like Redshift keep failing
+                    # after an error
                     ProxyClientFactory.dispose_proxy_client(
                         connection_type, credentials, operation.skip_cache
                     )
+                elif client and operation.skip_cache:
+                    # make sure non-cached clients are closed
+                    logger.info(f"Closing non-cached client: {connection_type}")
+                    client.close()
 
     def _execute_client_operation(
         self,

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -488,7 +488,6 @@ class Agent:
                     )
                 elif client and operation.skip_cache:
                     # make sure non-cached clients are closed
-                    logger.info(f"Closing non-cached client: {connection_type}")
                     client.close()
 
     def _execute_client_operation(
@@ -574,13 +573,16 @@ class Agent:
         }
         context[CONTEXT_VAR_UTILS] = OperationUtils(context)
 
-        return AgentEvaluationUtils.execute(
+        result = AgentEvaluationUtils.execute(
             context,
             self._logging_utils,
             operation_name,
             commands.commands,
             commands.trace_id,
         )
+        # clear cyclic reference involving the client, which delays the release of memory
+        context.clear()
+        return result
 
     def _execute_script(
         self,

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -375,9 +375,15 @@ class ProxyClientFactory:
             not entry
             or (datetime.now() - entry.created_time).seconds > _CACHE_EXPIRATION_SECONDS
         ):
+            # dispose client and connection, so we don't have two connections open at the same time
+            if entry:
+                cls._dispose_cached_client(key)
             return None
         return entry.client
 
     @classmethod
     def _dispose_cached_client(cls, key: str):
-        cls._clients_cache.pop(key, None)
+        entry = cls._clients_cache.pop(key, None)
+        if entry:
+            logger.info("Closing cached client")
+            entry.client.close()

--- a/apollo/integrations/base_proxy_client.py
+++ b/apollo/integrations/base_proxy_client.py
@@ -10,6 +10,12 @@ class BaseProxyClient(ABC):
     def wrapped_client(self):
         pass
 
+    def close(self):
+        """
+        Closes the underlying client if needed.
+        """
+        pass
+
     def get_error_type(self, error: Exception) -> Optional[str]:
         """
         Returns the error type to send to the client based on the given exception, this is optional but

--- a/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
+++ b/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
@@ -15,6 +15,7 @@ class DatabricksSqlWarehouseProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Dict):
+        super().__init__(connection_type="databricks-sql-warehouse")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Databricks agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/azure_database_proxy_client.py
+++ b/apollo/integrations/db/azure_database_proxy_client.py
@@ -21,6 +21,7 @@ class AzureDatabaseProxyClient(BaseDbProxyClient):
     _DEFAULT_QUERY_TIMEOUT_IN_SECONDS = 60 * 14  # 14 minutes
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="azure-database")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Azure database agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -23,8 +23,14 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
 
     # On delete make sure we close the connection
     def __del__(self) -> None:
+        logger.info("Closing DB proxy client on __del__")
+        self.close()
+
+    def close(self):
         if self._connection:
+            logger.info("Closing DB Proxy connection")
             self._connection.close()
+            self._connection = None
 
     def process_result(self, value: Any) -> Any:
         """

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -23,7 +23,6 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
 
     # On delete make sure we close the connection
     def __del__(self) -> None:
-        logger.info("Closing DB proxy client on __del__")
         self.close()
 
     def close(self):

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -18,8 +18,9 @@ logger = logging.getLogger(__name__)
 
 
 class BaseDbProxyClient(BaseProxyClient, ABC):
-    def __init__(self):
+    def __init__(self, connection_type: str):
         self._connection = None
+        self._connection_type = connection_type
 
     # On delete make sure we close the connection
     def __del__(self) -> None:
@@ -27,7 +28,7 @@ class BaseDbProxyClient(BaseProxyClient, ABC):
 
     def close(self):
         if self._connection:
-            logger.info("Closing DB Proxy connection")
+            logger.info(f"Closing connection to {self._connection_type}")
             self._connection.close()
             self._connection = None
 

--- a/apollo/integrations/db/hive_proxy_client.py
+++ b/apollo/integrations/db/hive_proxy_client.py
@@ -61,6 +61,7 @@ class HiveProxyClient(BaseDbProxyClient):
     _MODE_BINARY = "binary"
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):  # noqa
+        super().__init__(connection_type="hive")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Hive agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/motherduck_proxy_client.py
+++ b/apollo/integrations/db/motherduck_proxy_client.py
@@ -19,6 +19,7 @@ class MotherDuckProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="motherduck")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Motherduck agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/mysql_proxy_client.py
+++ b/apollo/integrations/db/mysql_proxy_client.py
@@ -25,6 +25,7 @@ class MysqlProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], platform: str, **kwargs: Any):
+        super().__init__(connection_type="mysql")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Mysql agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -23,6 +23,7 @@ class OracleProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="oracle")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Oracle DB agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/postgres_proxy_client.py
+++ b/apollo/integrations/db/postgres_proxy_client.py
@@ -4,7 +4,7 @@ import psycopg2
 from psycopg2 import DatabaseError
 from psycopg2.errors import QueryCanceled, InsufficientPrivilege  # noqa
 
-from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient, logger
 
 _ATTR_CONNECT_ARGS = "connect_args"
 
@@ -17,6 +17,7 @@ class PostgresProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], client_type: str = "postgres", **kwargs):  # type: ignore
+        super().__init__()
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"{client_type.capitalize()} agent client requires {_ATTR_CONNECT_ARGS} in credentials"
@@ -40,6 +41,12 @@ class PostgresProxyClient(BaseDbProxyClient):
             )
 
         self._connection = psycopg2.connect(**connect_args)
+        self._client_type = client_type
+        logger.info(f"Opened connection to {client_type}")
+
+    def close(self):
+        super().close()
+        logger.info(f"Closed connection to {self._client_type}")
 
     @property
     def wrapped_client(self):

--- a/apollo/integrations/db/postgres_proxy_client.py
+++ b/apollo/integrations/db/postgres_proxy_client.py
@@ -17,7 +17,7 @@ class PostgresProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], client_type: str = "postgres", **kwargs):  # type: ignore
-        super().__init__()
+        super().__init__(connection_type=client_type)
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"{client_type.capitalize()} agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/postgres_proxy_client.py
+++ b/apollo/integrations/db/postgres_proxy_client.py
@@ -44,10 +44,6 @@ class PostgresProxyClient(BaseDbProxyClient):
         self._client_type = client_type
         logger.info(f"Opened connection to {client_type}")
 
-    def close(self):
-        super().close()
-        logger.info(f"Closed connection to {self._client_type}")
-
     @property
     def wrapped_client(self):
         return self._connection

--- a/apollo/integrations/db/presto_proxy_client.py
+++ b/apollo/integrations/db/presto_proxy_client.py
@@ -19,6 +19,7 @@ class PrestoProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], platform: str, **kwargs: Any):
+        super().__init__(connection_type="presto")
         self._platform = platform
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(

--- a/apollo/integrations/db/sap_hana_proxy_client.py
+++ b/apollo/integrations/db/sap_hana_proxy_client.py
@@ -15,6 +15,7 @@ class SAPHanaProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="sap-hana")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"SAP HANA database agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/sql_server_proxy_client.py
+++ b/apollo/integrations/db/sql_server_proxy_client.py
@@ -27,6 +27,7 @@ class SqlServerProxyClient(BaseDbProxyClient):
     _DEFAULT_QUERY_TIMEOUT_IN_SECONDS = 60 * 14  # 14 minutes
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="sql-server")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"SQL Server agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/teradata_proxy_client.py
+++ b/apollo/integrations/db/teradata_proxy_client.py
@@ -20,6 +20,7 @@ class TeradataProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="teradata")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Teradata agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/snowflake/snowflake_proxy_client.py
+++ b/apollo/integrations/snowflake/snowflake_proxy_client.py
@@ -17,6 +17,7 @@ class SnowflakeProxyClient(BaseDbProxyClient):
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs):  # type: ignore
+        super().__init__(connection_type="snowflake")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Snowflake agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/tests/test_redshift_client.py
+++ b/tests/test_redshift_client.py
@@ -171,6 +171,8 @@ class RedshiftClientTests(TestCase):
         self.assertTrue("rowcount" in result)
         self.assertEqual(expected_rows, result["rowcount"])
 
+        self._mock_connection.close.assert_called()
+
     @classmethod
     def _serialized_data(cls, data: List) -> List:
         return [cls._serialized_row(v) for v in data]


### PR DESCRIPTION
- Added code to clear the context, a cyclic reference was causing the context to be retained until the GC runs, causing the client to be retained too and released later than expected.
- Added code to explicitly close the client (if cache is not used) after the operation completes
- Added log messages when Redshift connections are opened/closed