### PR TITLE
chore: update aiohttp

### DIFF
--- a/requirements-azure.in
+++ b/requirements-azure.in
@@ -4,3 +4,4 @@ azure-functions-durable==1.2.9
 azure-mgmt-resource==23.0.1
 azure-monitor-opentelemetry==1.3.0
 azure-monitor-query==1.2.1
+aiohttp==3.9.4

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile requirements-azure.in
 #
-aiohttp==3.9.3
-    # via azure-functions-durable
+aiohttp==3.9.4
+    # via
+    #   -r requirements-azure.in
+    #   azure-functions-durable
 aiosignal==1.3.1
     # via aiohttp
 asgiref==3.8.1


### PR DESCRIPTION
- updates aiohttp to 3.9.4
- I checked and the parent dependency, `azure-functions-durable`, does not have a patch yet resolving this vuln. so we need to update aiohttp directly
- ✔️ merged to dev