### PR TITLE
Azure Agent improvements: logging, restart and time outs

### DIFF
--- a/apollo/agent/env_vars.py
+++ b/apollo/agent/env_vars.py
@@ -63,10 +63,10 @@ ORCHESTRATION_ACTIVITY_TIMEOUT_DEFAULT_VALUE = 60 * 14 + 45  # 14:45 minutes
 LAST_UPDATE_TS_ENV_VAR = "MCD_LAST_UPDATE_TS"
 
 AZURE_MAX_ACTIVITY_FUNCTIONS_ENV_VAR = (
-    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions",
+    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions"
 )
 AZURE_MAX_ORCHESTRATOR_FUNCTIONS_ENV_VAR = (
-    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions",
+    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions"
 )
 
 HEALTH_ENV_VARS = [

--- a/apollo/agent/env_vars.py
+++ b/apollo/agent/env_vars.py
@@ -62,6 +62,13 @@ ORCHESTRATION_ACTIVITY_TIMEOUT_DEFAULT_VALUE = 60 * 14 + 45  # 14:45 minutes
 # used to mark last time the agent was updated, used to restart without updating the image
 LAST_UPDATE_TS_ENV_VAR = "MCD_LAST_UPDATE_TS"
 
+AZURE_MAX_ACTIVITY_FUNCTIONS_ENV_VAR = (
+    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions",
+)
+AZURE_MAX_ORCHESTRATOR_FUNCTIONS_ENV_VAR = (
+    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions",
+)
+
 HEALTH_ENV_VARS = [
     "PYTHON_VERSION",
     "SERVER_SOFTWARE",
@@ -81,6 +88,7 @@ HEALTH_ENV_VARS = [
     STORAGE_ACCOUNT_NAME_ENV_VAR,
     "FUNCTIONS_WORKER_PROCESS_COUNT",
     "PYTHON_THREADPOOL_THREAD_COUNT",
-    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions",
-    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions",
+    AZURE_MAX_ACTIVITY_FUNCTIONS_ENV_VAR,
+    AZURE_MAX_ORCHESTRATOR_FUNCTIONS_ENV_VAR,
+    LAST_UPDATE_TS_ENV_VAR,
 ]

--- a/apollo/agent/env_vars.py
+++ b/apollo/agent/env_vars.py
@@ -54,6 +54,14 @@ DEFAULT_TEMP_PATH = "/tmp"
 CHECK_OUTBOUND_IP_ADDRESS_URL_ENV_VAR = "MCD_CHECK_OUTBOUND_IP_URL"
 CHECK_OUTBOUND_IP_ADDRESS_URL_DEFAULT_VALUE = "https://checkip.amazonaws.com"
 
+# Orchestration activity timeout in seconds, should be less than 15 minutes to timeout
+# before the function times out
+ORCHESTRATION_ACTIVITY_TIMEOUT_ENV_VAR = "MCD_ORCHESTRATION_ACTIVITY_TIMEOUT"
+ORCHESTRATION_ACTIVITY_TIMEOUT_DEFAULT_VALUE = 60 * 14 + 45  # 14:45 minutes
+
+# used to mark last time the agent was updated, used to restart without updating the image
+LAST_UPDATE_TS_ENV_VAR = "MCD_LAST_UPDATE_TS"
+
 HEALTH_ENV_VARS = [
     "PYTHON_VERSION",
     "SERVER_SOFTWARE",
@@ -74,4 +82,5 @@ HEALTH_ENV_VARS = [
     "FUNCTIONS_WORKER_PROCESS_COUNT",
     "PYTHON_THREADPOOL_THREAD_COUNT",
     "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions",
+    "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions",
 ]

--- a/apollo/interfaces/azure/azure_updater.py
+++ b/apollo/interfaces/azure/azure_updater.py
@@ -6,7 +6,11 @@ from typing import List, Dict, Optional
 
 from azure.mgmt.resource import ResourceManagementClient
 
-from apollo.agent.env_vars import LAST_UPDATE_TS_ENV_VAR
+from apollo.agent.env_vars import (
+    LAST_UPDATE_TS_ENV_VAR,
+    AZURE_MAX_ACTIVITY_FUNCTIONS_ENV_VAR,
+    AZURE_MAX_ORCHESTRATOR_FUNCTIONS_ENV_VAR,
+)
 from apollo.agent.models import AgentError
 from apollo.agent.updater import AgentUpdater
 from apollo.integrations.azure_blob.utils import AzureUtils
@@ -17,8 +21,8 @@ logger = logging.getLogger(__name__)
 _PARAMETERS_ENV_VARS = {
     "WorkerProcessCount": "FUNCTIONS_WORKER_PROCESS_COUNT",
     "ThreadCount": "PYTHON_THREADPOOL_THREAD_COUNT",
-    "MaxConcurrentActivities": "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentActivityFunctions",
-    "MaxConcurrentOrchestratorFunctions": "AzureFunctionsJobHost__extensions__durableTask__maxConcurrentOrchestratorFunctions",
+    "MaxConcurrentActivities": AZURE_MAX_ACTIVITY_FUNCTIONS_ENV_VAR,
+    "MaxConcurrentOrchestratorFunctions": AZURE_MAX_ORCHESTRATOR_FUNCTIONS_ENV_VAR,
 }
 
 # any other parameter prefixed with "env." will be mapped to an env var, for example

--- a/apollo/interfaces/azure/azure_updater.py
+++ b/apollo/interfaces/azure/azure_updater.py
@@ -50,8 +50,8 @@ class AzureUpdater(AgentUpdater):
     ) -> Dict:
         parameters = parameters or {}
         update_args = {
-            "image": image,
-            "parameters": parameters,
+            "image": image or "",  # open telemetry shows a warning when logging None
+            "parameters": parameters or {},
         }
         logger.info("Update requested", extra=update_args)
 

--- a/apollo/interfaces/azure/azure_updater.py
+++ b/apollo/interfaces/azure/azure_updater.py
@@ -48,13 +48,12 @@ class AzureUpdater(AgentUpdater):
         parameters: Optional[Dict] = None,
         **kwargs,  # type: ignore
     ) -> Dict:
+        parameters = parameters or {}
         update_args = {
             "image": image,
             "parameters": parameters,
         }
         logger.info("Update requested", extra=update_args)
-        if not image and not parameters:
-            raise AgentError("Either image or parameters must be provided")
 
         client = self._get_resource_management_client()
         if image:
@@ -68,7 +67,7 @@ class AzureUpdater(AgentUpdater):
                 parameters=serialized_parameters,  # type: ignore
             )
         update_appsettings_parameters = {
-            "properties": self._get_update_env_vars(parameters or {})
+            "properties": self._get_update_env_vars(parameters)
         }
         serialized_parameters = json.dumps(update_appsettings_parameters).encode(
             "utf-8"
@@ -84,6 +83,7 @@ class AzureUpdater(AgentUpdater):
         update_args_list = [
             f"{key}: {value}" for key, value in update_args.items() if value
         ]
+        update_args_list.append("function_restart")
         return {"message": f"Update in progress, {', '.join(update_args_list)}"}
 
     def get_current_image(self) -> Optional[str]:

--- a/apollo/interfaces/azure/azure_updater.py
+++ b/apollo/interfaces/azure/azure_updater.py
@@ -148,6 +148,8 @@ class AzureUpdater(AgentUpdater):
                 if key.startswith(_ENV_PREFIX)
             }
         )
+        # we're always updating at least this env var, this forces the function to be restarted
+        # and also keeps track of the last update time, so we can confirm it was restarted
         env_vars[LAST_UPDATE_TS_ENV_VAR] = datetime.now(timezone.utc).isoformat()
         logger.info(f"Updating env vars: {env_vars}")
         return env_vars

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -224,10 +224,10 @@ def agent_operation_orchestrator(context: DurableOrchestrationContext):
     else:
         log_extra = {}
     log_extra["instance_id"] = context.instance_id
+    log_extra["timeout"] = _ACTIVITY_TIMEOUT_SECONDS
 
     root_logger.info(
-        f"Starting orchestrator activity with timeout={_ACTIVITY_TIMEOUT_SECONDS}",
-        extra=log_extra,
+        f"Starting activity for operation: {context.instance_id}", extra=log_extra
     )
     deadline = context.current_utc_datetime + timedelta(
         seconds=_ACTIVITY_TIMEOUT_SECONDS
@@ -240,7 +240,9 @@ def agent_operation_orchestrator(context: DurableOrchestrationContext):
         timeout_task.cancel()
         return activity_task.result
 
-    root_logger.info("Orchestrator activity timed out", extra=log_extra)
+    root_logger.info(
+        f"Orchestrator activity: {context.instance_id} timed out", extra=log_extra
+    )
     return {
         ATTRIBUTE_NAME_ERROR: f"Activity timed out after {_ACTIVITY_TIMEOUT_SECONDS} seconds."
     }

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -235,6 +235,9 @@ def agent_operation_orchestrator(context: DurableOrchestrationContext):
     activity_task = context.call_activity("agent_operation", client_input)
     timeout_task: TimerTask = cast(TimerTask, context.create_timer(deadline))
 
+    # "Abandon" feature, the activity is abandoned after 14:45 minutes so it is not retried
+    # by the Durable Functions framework. Based on Azure docs:
+    # https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-error-handling?tabs=python#function-timeouts
     winner = yield context.task_any([activity_task, timeout_task])
     if winner == activity_task:
         timeout_task.cancel()

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -227,7 +227,7 @@ def agent_operation_orchestrator(context: DurableOrchestrationContext):
     log_extra["timeout"] = _ACTIVITY_TIMEOUT_SECONDS
 
     root_logger.info(
-        f"Starting activity for operation: {context.instance_id}", extra=log_extra
+        f"Running orchestrator for operation: {context.instance_id}", extra=log_extra
     )
     deadline = context.current_utc_datetime + timedelta(
         seconds=_ACTIVITY_TIMEOUT_SECONDS

--- a/apollo/interfaces/azure/log_context.py
+++ b/apollo/interfaces/azure/log_context.py
@@ -1,7 +1,10 @@
 import json
+from threading import local
 from typing import Dict, cast, Any
 
 from apollo.interfaces.generic.log_context import BaseLogContext
+
+_context = local()
 
 
 class AzureLogContext(BaseLogContext):
@@ -15,7 +18,7 @@ class AzureLogContext(BaseLogContext):
     """
 
     def set_agent_context(self, context: Dict):
-        self._context = self.filter_log_context(context)
+        _context.value = self.filter_log_context(context)
 
     @staticmethod
     def filter_log_context(context: Dict) -> Dict:
@@ -40,9 +43,10 @@ class AzureLogContext(BaseLogContext):
         Updates the log record with the agent context, OpenTelemetry doesn't support an "extra" attribute, we
         set the attributes as individual attributes in `record` making sure they are prefixed with "mcd_".
         """
-        if not self._context:
+        context = _context.value
+        if not context:
             return record
 
-        for key, value in cast(Dict[str, Any], self._context).items():
+        for key, value in cast(Dict[str, Any], context).items():
             setattr(record, key if key.startswith("mcd_") else f"mcd_{key}", value)
         return record

--- a/apollo/interfaces/azure/log_context.py
+++ b/apollo/interfaces/azure/log_context.py
@@ -43,7 +43,10 @@ class AzureLogContext(BaseLogContext):
         Updates the log record with the agent context, OpenTelemetry doesn't support an "extra" attribute, we
         set the attributes as individual attributes in `record` making sure they are prefixed with "mcd_".
         """
-        context = _context.value
+        try:
+            context = _context.value
+        except AttributeError:
+            context = None
         if not context:
             return record
 

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -325,16 +325,6 @@ def execute_agent_script(connection_type: str, json_request: Dict) -> AgentRespo
     return agent.execute_script(connection_type, script, credentials)
 
 
-@app.route("/api/v1/test/sleep", methods=["GET"])
-def test_sleep() -> Tuple[Dict, int]:
-    request_dict: Dict = request.args  # type: ignore
-    seconds = int(request_dict.get("seconds", 10))
-    logger.info(f"Waiting for {seconds} seconds")
-    sleep(seconds)
-    logger.info(f"Wait for {seconds} seconds finished")
-    return {"message": f"{seconds} seconds"}, 200
-
-
 @app.route("/api/v1/test/health", methods=["GET"])
 def test_health_get() -> Tuple[Dict, int]:
     """

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 from datetime import datetime, timezone, timedelta
+from time import sleep
 from typing import Dict, Tuple, Callable, Optional, Union, Any, BinaryIO
 
 from flask import Flask, request, Response, send_file, jsonify, render_template
@@ -322,6 +323,16 @@ def execute_agent_script(connection_type: str, json_request: Dict) -> AgentRespo
     credentials = json_request.get("credentials", {})
 
     return agent.execute_script(connection_type, script, credentials)
+
+
+@app.route("/api/v1/test/sleep", methods=["GET"])
+def test_sleep() -> Tuple[Dict, int]:
+    request_dict: Dict = request.args  # type: ignore
+    seconds = int(request_dict.get("seconds", 10))
+    logger.info(f"Waiting for {seconds} seconds")
+    sleep(seconds)
+    logger.info(f"Wait for {seconds} seconds finished")
+    return {"message": f"{seconds} seconds"}, 200
 
 
 @app.route("/api/v1/test/health", methods=["GET"])

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -2,7 +2,6 @@ import io
 import logging
 import os
 from datetime import datetime, timezone, timedelta
-from time import sleep
 from typing import Dict, Tuple, Callable, Optional, Union, Any, BinaryIO
 
 from flask import Flask, request, Response, send_file, jsonify, render_template

--- a/tests/test_azure_platform.py
+++ b/tests/test_azure_platform.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import os
 from datetime import datetime, timezone, timedelta
+from threading import Thread
+from typing import Dict
 from unittest import TestCase
 from unittest.mock import patch, Mock, call, ANY
 
@@ -19,6 +21,7 @@ from apollo.interfaces.azure.durable_functions_utils import (
     AzureDurableFunctionsRequest,
     AzureDurableFunctionsCleanupRequest,
 )
+from apollo.interfaces.azure.log_context import AzureLogContext
 
 
 class TestAzurePlatform(TestCase):
@@ -630,3 +633,28 @@ class TestAzurePlatform(TestCase):
                 OrchestrationRuntimeStatus.Pending,
             ],
         )
+
+    def test_log_context(self):
+        log_context = AzureLogContext()
+
+        def _thread_function(thread_context: Dict):
+            log_context.set_agent_context(thread_context)
+            box = Box()
+            log_context._filter(box)
+            thread_context["result"] = box
+
+        c1 = {
+            "name": "c1",
+        }
+        t1 = Thread(target=_thread_function, args=(c1,))
+        c2 = {
+            "name": "c2",
+        }
+        t2 = Thread(target=_thread_function, args=(c2,))
+
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        self.assertEqual("c1", c1.get("result").mcd_name)
+        self.assertEqual("c2", c2.get("result").mcd_name)

--- a/tests/test_azure_platform.py
+++ b/tests/test_azure_platform.py
@@ -335,7 +335,9 @@ class TestAzurePlatform(TestCase):
             ]
         )
 
-        expected_result = {"message": f"Update in progress, image: {new_image}"}
+        expected_result = {
+            "message": f"Update in progress, image: {new_image}, function_restart"
+        }
         self.assertEqual(
             expected_result, update_result.result.get(ATTRIBUTE_NAME_RESULT)
         )
@@ -372,7 +374,9 @@ class TestAzurePlatform(TestCase):
             parameters,
         )
 
-        expected_result = {"message": f"Update in progress, parameters: {new_env_vars}"}
+        expected_result = {
+            "message": f"Update in progress, parameters: {new_env_vars}, function_restart"
+        }
         self.assertEqual(
             expected_result, update_result.result.get(ATTRIBUTE_NAME_RESULT)
         )
@@ -405,7 +409,8 @@ class TestAzurePlatform(TestCase):
             ]
         )
         expected_result = {
-            "message": f"Update in progress, image: {new_image}, parameters: {new_env_vars}"
+            "message": f"Update in progress, image: {new_image}, parameters: {new_env_vars}, "
+            "function_restart"
         }
         self.assertEqual(
             expected_result, update_result.result.get(ATTRIBUTE_NAME_RESULT)
@@ -447,7 +452,7 @@ class TestAzurePlatform(TestCase):
             parameters=ANY,
         )
         expected_result = {
-            "message": f"Update in progress, parameters: {new_parameters}"
+            "message": f"Update in progress, parameters: {new_parameters}, function_restart"
         }
         self.assertEqual(
             expected_result, update_result.result.get(ATTRIBUTE_NAME_RESULT)
@@ -489,7 +494,7 @@ class TestAzurePlatform(TestCase):
         parameters = json.loads(call_kwargs["parameters"])
         self.assertEqual(update_env_properties, parameters)
         expected_result = {
-            "message": f"Update in progress, parameters: {new_parameters}"
+            "message": f"Update in progress, parameters: {new_parameters}, function_restart"
         }
         self.assertEqual(
             expected_result, update_result.result.get(ATTRIBUTE_NAME_RESULT)


### PR DESCRIPTION
Multiple improvements to Azure Agents:
- Add more logging to link MC trace ids with Azure Durable Functions operations so we can identify queries causing issues in durable functions
- Fix in `AzureLogContext` to use thread locals to store the context, this could be causing the wrong context to be logged when multiple operations were running at the same time.
- Ability to restart an agent: internally it uses the "update" support and sets a new environment var that is used to force the restart and also to track last time the agent was updated or restarted: `MCD_LAST_UPDATE_TS`
- "Abandon": Durable Functions activities are abandoned after `885` seconds by default, this is intentionally before the Azure Function timeout (configured with `900` seconds) to prevent the task to be automatically retried by Azure and after `860` which is the time out used for MC queries. Based on official Azure docs [here](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-error-handling?tabs=python#function-timeouts).
- Added support to set a new env var that configures Durable Functions: `maxConcurrentOrchestratorFunctions`, it's not clear if we're going to change it but we wanted to have a way to do it in case we need it.