### PR TITLE
Azure Agent: don't start tasks after the timeout period

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -259,6 +259,11 @@ def agent_operation(body: Dict):
     """
     # first check how long the activity has been waiting to be executed
     # it doesn't make sense to start running a task when nobody is waiting for its result
+    log_extra = {
+        "mcd_trace_id": body.get("payload", {}).get("operation", {}).get("trace_id"),
+        "operation_name": body.get("operation_name"),
+        "connection_type": body.get("connection_type"),
+    }
     timestamp_str = body.get("timestamp")
     if timestamp_str:
         timestamp = datetime.fromisoformat(timestamp_str)
@@ -266,11 +271,15 @@ def agent_operation(body: Dict):
             datetime.now(timezone.utc) - timestamp
         ).total_seconds()
         if seconds_since_triggered > _ACTIVITY_TIMEOUT_SECONDS:
+            root_logger.warning(
+                f"Activity expired after {seconds_since_triggered} seconds.",
+                extra=log_extra,
+            )
             return {
                 ATTRIBUTE_NAME_ERROR: f"Activity expired after {seconds_since_triggered} seconds."
             }
     else:
-        root_logger.warning("No timestamp in orchestrator request")
+        root_logger.warning("No timestamp in orchestrator request", extra=log_extra)
 
     agent_response = main.execute_agent_operation(
         connection_type=body["connection_type"],

--- a/tests/test_azure_platform.py
+++ b/tests/test_azure_platform.py
@@ -697,3 +697,22 @@ class TestAzurePlatform(TestCase):
         t2.join()
         self.assertEqual("c1", c1.get("result").mcd_name)
         self.assertEqual("c2", c2.get("result").mcd_name)
+
+    def test_task_expiration(self):
+        body = {
+            "timestamp": (
+                datetime.now(timezone.utc) - timedelta(minutes=20)
+            ).isoformat(),
+        }
+        expired, seconds = AzureDurableFunctionsUtils.check_expired_task(body, 15 * 60)
+        self.assertTrue(expired)
+        self.assertTrue(seconds > 15 * 60)
+
+        body = {
+            "timestamp": (
+                datetime.now(timezone.utc) - timedelta(minutes=14)
+            ).isoformat(),
+        }
+        expired, seconds = AzureDurableFunctionsUtils.check_expired_task(body, 15 * 60)
+        self.assertFalse(expired)
+        self.assertTrue(seconds < 15 * 60)


### PR DESCRIPTION
We detected that tasks that failed due to high memory or cpu usage (or crashes with exit codes 137 or 139) are retried multiple times and could be potentially executed forever if they crash (or get killed) again every time they are executed.

This PR adds code to prevent starting a task after the timeout period, this is because the client won't be waiting for the result and it doesn't make sense to keep trying, it also helps preventing to execute the task forever.