### PR TITLE
Add new endpoint to test DNS lookups

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -209,6 +209,34 @@ class Agent:
                 host, port_str, timeout_str, trace_id
             )
 
+    def perform_dns_lookup(
+        self,
+        host: Optional[str],
+        port_str: Optional[str],
+        trace_id: Optional[str] = None,
+    ) -> AgentResponse:
+        """
+        Performs a DNS lookup for the given host name.
+        :param host: Host to check, will raise `BadRequestError` if None.
+        :param port_str: Optional port to pass to `getaddrinfo` API, both int and
+            string are supported.
+        :param trace_id: Optional trace ID received from the client that will be included in
+            the response, if present.
+        """
+        with self._inject_log_context("perform_dns_lookup", trace_id):
+            logger.info(
+                "DNS lookup request received",
+                extra=self._logging_utils.build_extra(
+                    trace_id=trace_id,
+                    operation_name="perform_dns_lookup",
+                    extra=dict(
+                        host=host,
+                        port=port_str,
+                    ),
+                ),
+            )
+            return ValidateNetwork.perform_dns_lookup(host, port_str, trace_id)
+
     def get_outbound_ip_address(
         self,
         trace_id: Optional[str] = None,

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -5,7 +5,7 @@ import sys
 import time
 from contextlib import contextmanager
 from datetime import datetime
-from typing import Any, Callable, Dict, Optional, List
+from typing import Any, Callable, Dict, Optional, List, Union
 
 from apollo.agent.env_vars import (
     HEALTH_ENV_VARS,
@@ -212,14 +212,14 @@ class Agent:
     def perform_dns_lookup(
         self,
         host: Optional[str],
-        port_str: Optional[str],
+        port_str: Optional[Union[int, str]],
         trace_id: Optional[str] = None,
     ) -> AgentResponse:
         """
         Performs a DNS lookup for the given host name.
         :param host: Host to check, will raise `BadRequestError` if None.
         :param port_str: Optional port to pass to `getaddrinfo` API, both int and
-            string are supported.
+            string are supported. Using `port_str` to be consistent with the other methods.
         :param trace_id: Optional trace ID received from the client that will be included in
             the response, if present.
         """

--- a/apollo/validators/validate_network.py
+++ b/apollo/validators/validate_network.py
@@ -1,6 +1,6 @@
 import socket
 from telnetlib import Telnet
-from typing import Optional, Callable, Dict, Tuple
+from typing import Optional, Callable, Dict, Tuple, Union
 
 from apollo.agent.utils import AgentUtils
 from apollo.interfaces.agent_response import AgentResponse
@@ -75,13 +75,13 @@ class ValidateNetwork:
     def perform_dns_lookup(
         cls,
         host: Optional[str],
-        port_str: Optional[str],
+        port: Optional[Union[int, str]],
         trace_id: Optional[str] = None,
     ):
         """
         Performs a DNS lookup for the specified host name.
         :param host: Host to check, will raise `BadRequestError` if None.
-        :param port_str: Optional port to pass to `getaddrinfo` API, both int and
+        :param port: Optional port to pass to `getaddrinfo` API, both int and
         string are supported.
         :param trace_id: Optional trace ID received from the client that will be included in
         the response, if present.
@@ -89,7 +89,7 @@ class ValidateNetwork:
         return cls._call_validation_method(
             cls._internal_perform_dns_lookup,
             host=host,
-            port_str=port_str,
+            port=port,
             trace_id=trace_id,
         )
 
@@ -174,7 +174,7 @@ class ValidateNetwork:
 
     @classmethod
     def _internal_perform_dns_lookup(
-        cls, host: Optional[str], port_str: Optional[str]
+        cls, host: Optional[str], port: Optional[Union[int, str]]
     ) -> Dict:
         """
         Implementation for the DNS lookup operation, first validates the parameters and then
@@ -184,7 +184,7 @@ class ValidateNetwork:
             raise BadRequestError("host is a required parameter")
 
         try:
-            lookup_result = socket.getaddrinfo(host, port_str)
+            lookup_result = socket.getaddrinfo(host, port)
             addresses = sorted(set([addr[4][0] for addr in lookup_result]))
             return {"message": f"Host {host} resolves to: {', '.join(addresses)}"}
         except Exception as err:

--- a/apollo/validators/validate_network.py
+++ b/apollo/validators/validate_network.py
@@ -185,7 +185,7 @@ class ValidateNetwork:
 
         try:
             lookup_result = socket.getaddrinfo(host, port_str)
-            addresses = set([addr[4][0] for addr in lookup_result])
+            addresses = sorted(set([addr[4][0] for addr in lookup_result]))
             return {"message": f"Host {host} resolves to: {', '.join(addresses)}"}
         except Exception as err:
             raise ConnectionFailedError(


### PR DESCRIPTION
- `/api/v1/test/network/dns?host=HOSTNAME` can now be used to perform a DNS lookup operation and get the IP addresses mapped to the specified hostname