### PR TITLE
VULN: Upgrade `urllib3` from `2.0.7` to `2.2.2`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,11 @@ RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" -r requirements.tx
 
 FROM public.ecr.aws/lambda/python:3.11 AS lambda
 
-# VULN-29: Base ECR image has setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
+# VULN-29: Base ECR image includes setuptools-56.0.0 which is vulnerable (CVE-2022-40897)
 RUN pip install --no-cache-dir setuptools==68.0.0
+# VULN-369: Base ECR image includes urllib3-1.26.18 which is vulnerable (CVE-2024-37891)
+RUN pip install --no-cache-dir --upgrade urllib3==1.26.19
+RUN rm -rf /var/lang/lib/python3.11/site-packages/urllib3-1.26.18.dist-info
 
 # VULN-230 CWE-77
 RUN pip install --no-cache-dir --upgrade pip

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -12,7 +12,7 @@ aiosignal==1.3.1
     # via aiohttp
 asgiref==3.8.1
     # via opentelemetry-instrumentation-asgi
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   -c requirements.txt
     #   aiohttp
@@ -20,7 +20,7 @@ azure-common==1.1.28
     # via
     #   -c requirements.txt
     #   azure-mgmt-resource
-azure-core==1.29.5
+azure-core==1.30.2
     # via
     #   -c requirements.txt
     #   azure-core-tracing-opentelemetry
@@ -45,11 +45,11 @@ azure-mgmt-resource==23.0.1
     # via -r requirements-azure.in
 azure-monitor-opentelemetry==1.3.0
     # via -r requirements-azure.in
-azure-monitor-opentelemetry-exporter==1.0.0b23
+azure-monitor-opentelemetry-exporter==1.0.0b27
     # via azure-monitor-opentelemetry
 azure-monitor-query==1.2.1
     # via -r requirements-azure.in
-certifi==2023.11.17
+certifi==2024.6.2
     # via
     #   -c requirements.txt
     #   msrest
@@ -73,8 +73,10 @@ idna==3.7
     #   -c requirements.txt
     #   requests
     #   yarl
-importlib-metadata==6.11.0
-    # via opentelemetry-api
+importlib-metadata==7.1.0
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-instrumentation-flask
 isodate==0.6.1
     # via
     #   -c requirements.txt
@@ -91,7 +93,7 @@ oauthlib==3.2.2
     # via
     #   -c requirements.txt
     #   requests-oauthlib
-opentelemetry-api==1.23.0
+opentelemetry-api==1.25.0
     # via
     #   azure-core-tracing-opentelemetry
     #   azure-monitor-opentelemetry-exporter
@@ -107,7 +109,8 @@ opentelemetry-api==1.23.0
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-instrumentation==0.44b0
+    #   opentelemetry-semantic-conventions
+opentelemetry-instrumentation==0.46b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-dbapi
@@ -119,35 +122,35 @@ opentelemetry-instrumentation==0.44b0
     #   opentelemetry-instrumentation-urllib
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
-opentelemetry-instrumentation-asgi==0.44b0
+opentelemetry-instrumentation-asgi==0.46b0
     # via opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-dbapi==0.44b0
+opentelemetry-instrumentation-dbapi==0.46b0
     # via opentelemetry-instrumentation-psycopg2
-opentelemetry-instrumentation-django==0.44b0
+opentelemetry-instrumentation-django==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-fastapi==0.44b0
+opentelemetry-instrumentation-fastapi==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-flask==0.44b0
+opentelemetry-instrumentation-flask==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-psycopg2==0.44b0
+opentelemetry-instrumentation-psycopg2==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-requests==0.44b0
+opentelemetry-instrumentation-requests==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-urllib==0.44b0
+opentelemetry-instrumentation-urllib==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-urllib3==0.44b0
+opentelemetry-instrumentation-urllib3==0.46b0
     # via azure-monitor-opentelemetry
-opentelemetry-instrumentation-wsgi==0.44b0
+opentelemetry-instrumentation-wsgi==0.46b0
     # via
     #   opentelemetry-instrumentation-django
     #   opentelemetry-instrumentation-flask
-opentelemetry-resource-detector-azure==0.1.3
+opentelemetry-resource-detector-azure==0.1.5
     # via azure-monitor-opentelemetry
-opentelemetry-sdk==1.23.0
+opentelemetry-sdk==1.25.0
     # via
     #   azure-monitor-opentelemetry-exporter
     #   opentelemetry-resource-detector-azure
-opentelemetry-semantic-conventions==0.44b0
+opentelemetry-semantic-conventions==0.46b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-dbapi
@@ -159,7 +162,7 @@ opentelemetry-semantic-conventions==0.44b0
     #   opentelemetry-instrumentation-urllib3
     #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-opentelemetry-util-http==0.44b0
+opentelemetry-util-http==0.46b0
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-django
@@ -171,15 +174,17 @@ opentelemetry-util-http==0.44b0
     #   opentelemetry-instrumentation-wsgi
 orderedmultidict==1.0.1
     # via furl
-packaging==23.2
+packaging==24.1
     # via
     #   -c requirements.txt
     #   opentelemetry-instrumentation-flask
-python-dateutil==2.8.2
+psutil==5.9.8
+    # via azure-monitor-opentelemetry-exporter
+python-dateutil==2.9.0.post0
     # via
     #   -c requirements.txt
     #   azure-functions-durable
-requests==2.32.2
+requests==2.32.3
     # via
     #   -c requirements.txt
     #   azure-core
@@ -196,13 +201,13 @@ six==1.16.0
     #   isodate
     #   orderedmultidict
     #   python-dateutil
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   -c requirements.txt
     #   azure-core
     #   azure-monitor-query
     #   opentelemetry-sdk
-urllib3==2.0.7
+urllib3==2.2.2
     # via
     #   -c requirements.txt
     #   requests
@@ -214,7 +219,7 @@ wrapt==1.16.0
     #   opentelemetry-instrumentation-urllib3
 yarl==1.9.4
     # via aiohttp
-zipp==3.18.1
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-cloudrun.in
+++ b/requirements-cloudrun.in
@@ -1,3 +1,3 @@
 -c requirements.txt
-google-cloud-logging==3.6.0
-google-cloud-run==0.9.1
+google-cloud-logging==3.10.0
+google-cloud-run==0.10.5

--- a/requirements-cloudrun.txt
+++ b/requirements-cloudrun.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile requirements-cloudrun.in
 #
-cachetools==5.3.2
+cachetools==5.3.3
     # via
     #   -c requirements.txt
     #   google-auth
-certifi==2023.11.17
+certifi==2024.6.2
     # via
     #   -c requirements.txt
     #   requests
@@ -16,7 +16,7 @@ charset-normalizer==3.3.2
     # via
     #   -c requirements.txt
     #   requests
-google-api-core[grpc]==2.15.0
+google-api-core[grpc]==2.19.1
     # via
     #   -c requirements.txt
     #   google-api-core
@@ -24,12 +24,15 @@ google-api-core[grpc]==2.15.0
     #   google-cloud-core
     #   google-cloud-logging
     #   google-cloud-run
-google-auth==2.25.2
+google-auth==2.30.0
     # via
     #   -c requirements.txt
     #   google-api-core
+    #   google-cloud-appengine-logging
     #   google-cloud-core
-google-cloud-appengine-logging==1.4.0
+    #   google-cloud-logging
+    #   google-cloud-run
+google-cloud-appengine-logging==1.4.3
     # via google-cloud-logging
 google-cloud-audit-log==0.2.5
     # via google-cloud-logging
@@ -37,39 +40,41 @@ google-cloud-core==2.4.1
     # via
     #   -c requirements.txt
     #   google-cloud-logging
-google-cloud-logging==3.6.0
+google-cloud-logging==3.10.0
     # via -r requirements-cloudrun.in
-google-cloud-run==0.9.1
+google-cloud-run==0.10.5
     # via -r requirements-cloudrun.in
-googleapis-common-protos[grpc]==1.62.0
+googleapis-common-protos[grpc]==1.63.2
     # via
     #   -c requirements.txt
     #   google-api-core
     #   google-cloud-audit-log
     #   grpc-google-iam-v1
     #   grpcio-status
-grpc-google-iam-v1==0.13.0
+grpc-google-iam-v1==0.13.1
     # via
     #   google-cloud-logging
     #   google-cloud-run
-grpcio==1.60.0
+grpcio==1.64.1
     # via
     #   google-api-core
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-status
-grpcio-status==1.60.0
+grpcio-status==1.62.2
     # via google-api-core
 idna==3.7
     # via
     #   -c requirements.txt
     #   requests
-proto-plus==1.23.0
+proto-plus==1.24.0
     # via
+    #   -c requirements.txt
+    #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-logging
     #   google-cloud-run
-protobuf==4.25.1
+protobuf==4.25.3
     # via
     #   -c requirements.txt
     #   google-api-core
@@ -81,16 +86,16 @@ protobuf==4.25.1
     #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   -c requirements.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via
     #   -c requirements.txt
     #   google-auth
-requests==2.32.2
+requests==2.32.3
     # via
     #   -c requirements.txt
     #   google-api-core
@@ -98,7 +103,7 @@ rsa==4.9
     # via
     #   -c requirements.txt
     #   google-auth
-urllib3==2.0.7
+urllib3==2.2.2
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 black==24.3.0
     # via -r requirements-dev.in
-blinker==1.7.0
+blinker==1.8.2
     # via
     #   -c requirements.txt
     #   flask
@@ -19,7 +19,7 @@ click==8.1.7
     #   flask
 distlib==0.3.8
     # via virtualenv
-filelock==3.13.1
+filelock==3.15.4
     # via
     #   -c requirements.txt
     #   virtualenv
@@ -29,11 +29,11 @@ flask==2.3.3
     #   flask-swagger
 flask-swagger==0.2.14
     # via -r requirements-dev.in
-identify==2.5.33
+identify==2.5.36
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via
     #   -c requirements.txt
     #   flask
@@ -41,7 +41,7 @@ jinja2==3.1.4
     # via
     #   -c requirements.txt
     #   flask
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   -c requirements.txt
     #   jinja2
@@ -50,23 +50,23 @@ mypy-extensions==1.0.0
     # via
     #   -c requirements.txt
     #   black
-nodeenv==1.8.0
+nodeenv==1.9.1
     # via
     #   pre-commit
     #   pyright
-packaging==23.2
+packaging==24.1
     # via
     #   -c requirements.txt
     #   black
     #   pytest
 pathspec==0.12.1
     # via black
-platformdirs==3.11.0
+platformdirs==4.2.2
     # via
     #   -c requirements.txt
     #   black
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
 pre-commit==3.5.0
     # via -r requirements-dev.in
@@ -80,12 +80,9 @@ pyyaml==6.0.1
     # via
     #   flask-swagger
     #   pre-commit
-virtualenv==20.25.0
+virtualenv==20.26.3
     # via pre-commit
 werkzeug==3.0.3
     # via
     #   -c requirements.txt
     #   flask
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ retry2==0.9.5
 snowflake-connector-python>=3.7.1
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python
 tableauserverclient==0.25 ; python_version < "3.10"
+# using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master; python_version >= "3.10"
 
 teradatasql>=17.20.0.31

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 azure-identity==1.17.1
 azure-mgmt-storage==21.2.1
 azure-storage-blob==12.20.0
-boto3==1.28.21
+boto3==1.34.135
 cryptography>=42.0.4
 databricks-sql-connector==2.8.0
 dataclasses-json==0.6.0
@@ -18,6 +18,7 @@ looker-sdk==24.2.0
 msal==1.24.1
 oracledb>=1.3.1
 presto-python-client==0.8.3
+protobuf<5.0.0dev  # from google-cloud-logging in requirements-cloudrun
 psycopg2-binary==2.9.7
 pyarrow==14.0.1  # CVE-2023-47248
 pycryptodome>=3.19.1
@@ -31,7 +32,7 @@ retry2==0.9.5
 snowflake-connector-python>=3.7.1
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python
 tableauserverclient==0.25 ; python_version < "3.10"
-tableauserverclient>=0.29 ; python_version >= "3.10"
+tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master; python_version >= "3.10"
 
 teradatasql>=17.20.0.31
 oscrypto @ git+https://github.com/wbond/oscrypto@master
@@ -41,4 +42,5 @@ oscrypto @ git+https://github.com/wbond/oscrypto@master
 # pure-sasl via additional extras 'pyhive[hive_pure_sasl]' which support Python 3.11.
 pyhive[hive_pure_sasl]==0.7.0 ; python_version >= "3.11"
 pyhive[hive]==0.6.5 ; python_version < "3.11"
+#urllib3>=2.2.2
 werkzeug==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.13.0
+alembic==1.13.2
     # via databricks-sql-connector
 asn1crypto==1.5.1
     # via
     #   oscrypto
     #   snowflake-connector-python
-attrs==23.1.0
+attrs==23.2.0
     # via
     #   cattrs
     #   looker-sdk
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.29.5
+azure-core==1.30.2
     # via
     #   azure-identity
     #   azure-mgmt-core
@@ -29,21 +29,21 @@ azure-mgmt-storage==21.2.1
     # via -r requirements.in
 azure-storage-blob==12.20.0
     # via -r requirements.in
-blinker==1.7.0
+blinker==1.8.2
     # via flask
-boto3==1.28.21
+boto3==1.34.135
     # via -r requirements.in
-botocore==1.31.85
+botocore==1.34.135
     # via
     #   boto3
     #   s3transfer
 brotli==1.1.0
     # via flask-compress
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
 cattrs==23.2.3
     # via looker-sdk
-certifi==2023.11.17
+certifi==2024.6.2
     # via
     #   requests
     #   snowflake-connector-python
@@ -59,7 +59,7 @@ click==8.1.7
     # via
     #   flask
     #   presto-python-client
-cryptography==42.0.5
+cryptography==42.0.8
     # via
     #   -r requirements.in
     #   azure-identity
@@ -81,7 +81,7 @@ duckdb==0.9.2
     # via -r requirements.in
 et-xmlfile==1.1.0
     # via openpyxl
-filelock==3.13.1
+filelock==3.15.4
     # via snowflake-connector-python
 flask==2.3.3
     # via
@@ -89,16 +89,16 @@ flask==2.3.3
     #   flask-compress
 flask-compress==1.14
     # via -r requirements.in
-future==0.18.3
+future==1.0.0
     # via pyhive
-google-api-core==2.15.0
+google-api-core==2.19.1
     # via
     #   google-api-python-client
     #   google-cloud-core
     #   google-cloud-storage
 google-api-python-client==2.98.0
     # via -r requirements.in
-google-auth==2.25.2
+google-auth==2.30.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -113,9 +113,9 @@ google-cloud-storage==2.10.0
     # via -r requirements.in
 google-crc32c==1.5.0
     # via google-resumable-media
-google-resumable-media==2.7.0
+google-resumable-media==2.7.1
     # via google-cloud-storage
-googleapis-common-protos==1.62.0
+googleapis-common-protos==1.63.2
     # via google-api-core
 gunicorn==22.0.0
     # via -r requirements.in
@@ -133,7 +133,7 @@ isodate==0.6.1
     # via
     #   azure-mgmt-storage
     #   azure-storage-blob
-itsdangerous==2.1.2
+itsdangerous==2.2.0
     # via flask
 jinja2==3.1.4
     # via
@@ -147,16 +147,16 @@ lambda-git==0.1.1
     # via -r requirements.in
 looker-sdk==24.2.0
     # via -r requirements.in
-lz4==4.3.2
+lz4==4.3.3
     # via databricks-sql-connector
-mako==1.3.0
+mako==1.3.5
     # via alembic
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via
     #   jinja2
     #   mako
     #   werkzeug
-marshmallow==3.20.1
+marshmallow==3.21.3
     # via dataclasses-json
 msal==1.24.1
     # via
@@ -167,38 +167,42 @@ msal-extensions==1.1.0
     # via azure-identity
 mypy-extensions==1.0.0
     # via typing-inspect
-numpy==1.24.4
+numpy==2.0.0
     # via
     #   databricks-sql-connector
     #   pandas
     #   pyarrow
 oauthlib==3.2.2
     # via databricks-sql-connector
-openpyxl==3.1.2
+openpyxl==3.1.5
     # via databricks-sql-connector
-oracledb==1.4.2
+oracledb==2.2.1
     # via -r requirements.in
 oscrypto @ git+https://github.com/wbond/oscrypto@master
     # via -r requirements.in
-packaging==23.2
+packaging==24.1
     # via
     #   gunicorn
     #   marshmallow
     #   msal-extensions
     #   snowflake-connector-python
     #   tableauserverclient
-pandas==2.0.3
+pandas==2.2.2
     # via databricks-sql-connector
-platformdirs==3.11.0
+platformdirs==4.2.2
     # via snowflake-connector-python
-portalocker==2.8.2
+portalocker==2.10.0
     # via msal-extensions
 presto-python-client==0.8.3
     # via -r requirements.in
-protobuf==4.25.1
+proto-plus==1.24.0
+    # via google-api-core
+protobuf==4.25.3
     # via
+    #   -r requirements.in
     #   google-api-core
     #   googleapis-common-protos
+    #   proto-plus
 psycopg2-binary==2.9.7
     # via -r requirements.in
 pure-sasl==0.6.2
@@ -209,15 +213,15 @@ pyarrow==14.0.1
     # via
     #   -r requirements.in
     #   databricks-sql-connector
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pycryptodome==3.19.1
+pycryptodome==3.20.0
     # via
     #   -r requirements.in
     #   teradatasql
@@ -234,22 +238,22 @@ pymysql==1.1.1
     # via -r requirements.in
 pyodbc==5.0.1
     # via -r requirements.in
-pyopenssl==24.0.0
+pyopenssl==24.1.0
     # via
     #   -r requirements.in
     #   snowflake-connector-python
-pyparsing==3.1.1
+pyparsing==3.1.2
     # via httplib2
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   pandas
     #   pyhive
-pytz==2023.3.post1
+pytz==2024.1
     # via
     #   pandas
     #   snowflake-connector-python
-requests==2.32.2
+requests==2.32.3
     # via
     #   -r requirements.in
     #   azure-core
@@ -267,7 +271,7 @@ retry2==0.9.5
     # via -r requirements.in
 rsa==4.9
     # via google-auth
-s3transfer==0.6.2
+s3transfer==0.10.2
     # via boto3
 six==1.16.0
     # via
@@ -277,17 +281,17 @@ six==1.16.0
     #   python-dateutil
     #   thrift
     #   thrift-sasl
-snowflake-connector-python==3.7.1
+snowflake-connector-python==3.11.0
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
-sqlalchemy==1.4.50
+sqlalchemy==1.4.52
     # via
     #   alembic
     #   databricks-sql-connector
-tableauserverclient==0.30 ; python_version >= "3.10"
+tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.2
+teradatasql==20.0.0.13
     # via -r requirements.in
 thrift==0.16.0
     # via
@@ -296,9 +300,9 @@ thrift==0.16.0
     #   thrift-sasl
 thrift-sasl==0.4.3
     # via pyhive
-tomlkit==0.12.3
+tomlkit==0.12.5
     # via snowflake-connector-python
-typing-extensions==4.9.0
+typing-extensions==4.12.2
     # via
     #   alembic
     #   azure-core
@@ -306,14 +310,15 @@ typing-extensions==4.9.0
     #   azure-storage-blob
     #   looker-sdk
     #   snowflake-connector-python
+    #   tableauserverclient
     #   typing-inspect
 typing-inspect==0.9.0
     # via dataclasses-json
-tzdata==2023.3
+tzdata==2024.1
     # via pandas
 uritemplate==4.1.1
     # via google-api-python-client
-urllib3==2.0.7
+urllib3==2.2.2
     # via
     #   botocore
     #   requests


### PR DESCRIPTION
- `urllib3==2.0.7` is vulnerable to `CVE-2024-37891`
- This PR updates it to `2.2.2` and additionally:
  - Updates `tableauserverclient` to `master` branch as `0.31` depends on `urllib3==2.0.7` and `0.32` wasn't released yet
  - Updates `boto3` to `1.34.135` to avoid version conflicts
- The `Dockerfile` for the Lambda agent is updated to upgrade the `urllib3` version included in the base image from `1.26.18` to `1.26.19` to fix the same vulnerability.