### PR TITLE
Fix dependency syntax in requirements.in 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,7 @@ snowflake-connector-python>=3.7.1
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python
 tableauserverclient==0.25 ; python_version < "3.10"
 # using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released
-tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master; python_version >= "3.10"
+tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
 
 teradatasql>=17.20.0.31
 oscrypto @ git+https://github.com/wbond/oscrypto@master


### PR DESCRIPTION
There was a missing whitespace after the Tableau repo URL that causes an error when the agent is imported from dc