### PR TITLE
ggrushka/DAR-385/tableau url limitation

### DIFF
--- a/apollo/integrations/tableau/tableau_proxy_client.py
+++ b/apollo/integrations/tableau/tableau_proxy_client.py
@@ -138,7 +138,10 @@ class TableauProxyClient(BaseProxyClient):
             "X-Tableau-Auth": self._server.auth_token,
             "Content-Type": content_type,
         }
-        url = f"{self._server.baseurl}/sites/{self._server.site_id}/{path}"
+        if path.startswith("http"):
+            url = path
+        else:
+            url = f"{self._server.baseurl}/sites/{self._server.site_id}/{path}"
         response = requests.request(
             method=request_method, url=url, data=data, headers=headers, params=params
         )

--- a/apollo/integrations/tableau/tableau_proxy_client.py
+++ b/apollo/integrations/tableau/tableau_proxy_client.py
@@ -138,8 +138,8 @@ class TableauProxyClient(BaseProxyClient):
             "X-Tableau-Auth": self._server.auth_token,
             "Content-Type": content_type,
         }
-        if path.startswith("http"):
-            url = path
+        if path.startswith("/"):
+            url = f"{self._server.baseurl}{path}"
         else:
             url = f"{self._server.baseurl}/sites/{self._server.site_id}/{path}"
         response = requests.request(

--- a/tests/test_tableau_client.py
+++ b/tests/test_tableau_client.py
@@ -140,3 +140,64 @@ class TableauTests(TestCase):
             },
             params={"pageNumber": 1, "pageSize": 10},
         )
+
+    @patch("apollo.integrations.tableau.tableau_proxy_client.JwtAuth")
+    @patch("apollo.integrations.tableau.tableau_proxy_client.Server")
+    @patch("apollo.integrations.tableau.tableau_proxy_client.generate_jwt")
+    @patch("requests.request")
+    def test_api_request_with_url(
+            self, mock_request, mock_jwt_gen, mock_server_init, mock_creds_init
+    ):
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        expected_result = (
+            "<tsResponse>\n\t<views>\n"
+            '\t\t<view id="view-id" name="view-name" contentUrl="content-url">\n'
+            '\t\t\t<workbook id="workbook-id" />\n\t\t\t<owner id="owner-id" />\n'
+            '\t\t\t<usage totalViewCount="total-count" />\n\t\t</view>\n\t</views>\n</tsResponse>'
+        )
+        mock_response.status_code = 200
+        mock_response.text = expected_result
+
+        mock_jwt_gen.return_value = "fake_jwt"
+        mock_server_init.return_value = self._mock_client
+        mock_creds_init.return_value = self._mock_creds
+        self._mock_client.baseurl = "https://example.com"
+        self._mock_client.site_id = "sample_site_id"
+        self._mock_client.auth_token = "fizz|buzz|sample_site_id"
+
+        result = self._agent.execute_operation(
+            "tableau",
+            "_query",
+            {
+                "trace_id": "1234",
+                "skip_cache": True,
+                "commands": [
+                    {
+                        "method": "api_request",
+                        "kwargs": {
+                            "path": "https://example.comsites/sample_site_id/views?includeUsageStatistics=true",
+                            "request_method": "GET",
+                            "content_type": "application/xml",
+                            "params": {"pageNumber": 1, "pageSize": 10},
+                        },
+                    }
+                ],
+            },
+            credentials=_TABLEAU_CREDENTIALS,
+        )
+        self.assertIsNone(result.result.get(ATTRIBUTE_NAME_ERROR))
+
+        response = result.result[ATTRIBUTE_NAME_RESULT]
+        self.assertEqual((expected_result, 200), response)
+        self._mock_client.auth.sign_in.assert_called_once_with(self._mock_creds)
+        mock_request.assert_called_once_with(
+            method="GET",
+            url="https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
+            data=None,
+            headers={
+                "X-Tableau-Auth": "fizz|buzz|sample_site_id",
+                "Content-Type": "application/xml",
+            },
+            params={"pageNumber": 1, "pageSize": 10},
+        )

--- a/tests/test_tableau_client.py
+++ b/tests/test_tableau_client.py
@@ -176,7 +176,7 @@ class TableauTests(TestCase):
                     {
                         "method": "api_request",
                         "kwargs": {
-                            "path": "https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
+                            "path": "/sites/sample_site_id/views?includeUsageStatistics=true",
                             "request_method": "GET",
                             "content_type": "application/xml",
                             "params": {"pageNumber": 1, "pageSize": 10},

--- a/tests/test_tableau_client.py
+++ b/tests/test_tableau_client.py
@@ -146,7 +146,7 @@ class TableauTests(TestCase):
     @patch("apollo.integrations.tableau.tableau_proxy_client.generate_jwt")
     @patch("requests.request")
     def test_api_request_with_url(
-            self, mock_request, mock_jwt_gen, mock_server_init, mock_creds_init
+        self, mock_request, mock_jwt_gen, mock_server_init, mock_creds_init
     ):
         mock_response = create_autospec(Response)
         mock_request.return_value = mock_response
@@ -176,7 +176,7 @@ class TableauTests(TestCase):
                     {
                         "method": "api_request",
                         "kwargs": {
-                            "path": "https://example.comsites/sample_site_id/views?includeUsageStatistics=true",
+                            "path": "https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
                             "request_method": "GET",
                             "content_type": "application/xml",
                             "params": {"pageNumber": 1, "pageSize": 10},


### PR DESCRIPTION
Tableau API requests are limited to the following format -
 ` url = f"{self._server.baseurl}/sites/{self._server.site_id}/{path}"`

I'm introducing a new URL call which does not have _sites_ in it's path. Since changing the code in it's entirety is a no go (both data-collector and apollo-agent), this allows to send the full path from the dc code.