### PR TITLE
Test integrations as part of the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,24 +369,6 @@ workflows:
             branches:
               only:
                 - /.*\/pr-.*/
-      - update-and-validate-golden-agent:
-          name: aws-prod-update-and-validate-golden-agent
-          use_aws_cli: true
-          agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
-          agent_version: ${NEXT_VERSION}
-          ecr_repo_name: "mcd-pre-release-agent"
-          ecr_repo_account: "637423407294"
-          pre-steps:
-            - checkout
-            - generate-version-number-dev
-          context:
-            - mc-prod
-          requires:
-            - build-and-push-dev
-          filters:
-            branches:
-              only:
-                - /.*\/pr-.*/
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
           docker_hub_repository: pre-release-agent
@@ -405,6 +387,7 @@ workflows:
             branches:
               only:
                 - dev
+                - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: aws-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
@@ -417,6 +400,28 @@ workflows:
             - mc-dev
           requires:
             - build-and-push-lambda-dev
+          filters:
+            branches:
+              only:
+                - dev
+      - update-and-validate-golden-agent:
+          name: aws-prod-update-and-validate-golden-agent
+          use_aws_cli: true
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
+          agent_version: ${NEXT_VERSION}
+          ecr_repo_name: "mcd-pre-release-agent"
+          ecr_repo_account: "637423407294"
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-lambda-dev
+          filters:
+            branches:
+              only:
+                - /.*\/pr-.*/
       - push-lambda-legacy-repo:
           name: push-lambda-aws-dev
           docker_hub_repository: pre-release-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
           name: az-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
-          sleep_seconds: 120
+          sleep_seconds: "120"
           image_repo: pre-release-agent
           pre-steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,11 +220,11 @@ jobs:
       ecr_repo_name:
         description: The ECR repository to use for the AWS CLI update
         type: string
-        default: "mcd-agent"
+        default: "${AWS_AGENT_ECR_REPO_PROD}"
       ecr_repo_account:
         description: The AWS account to use for the ECR repo update
         type: string
-        default: "590183797493"
+        default: "${AWS_AGENT_ECR_ACCOUNT_PROD}"
     steps:
       - jq/install
       - run:
@@ -413,8 +413,8 @@ workflows:
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
-          ecr_repo_name: "mcd-pre-release-agent"
-          ecr_repo_account: "637423407294"
+          ecr_repo_name: "${AWS_AGENT_ECR_REPO_DEV}"
+          ecr_repo_account: "${AWS_AGENT_ECR_ACCOUNT_DEV}"
           pre-steps:
             - checkout
             - generate-version-number-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,22 @@ workflows:
             branches:
               only:
                 - /.*\/pr-.*/
+      - update-and-validate-golden-agent:
+          name: az-prod-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
+          agent_version: ${NEXT_VERSION}
+          image_repo: pre-release-agent
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-dev
+          filters:
+            branches:
+              only:
+                - /.*\/pr-.*/
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
           docker_hub_repository: pre-release-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,6 +227,7 @@ jobs:
           command: |
             export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
             export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+            export MCD_AGENT_IMAGE_REPO=<< parameters.image_repo >>
             montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
       - run:
           name: Run Agent Health
@@ -234,7 +235,6 @@ jobs:
             sleep << parameters.sleep_seconds >>
             export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
             export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-            export MCD_AGENT_IMAGE_REPO=<< parameters.image_repo >>
             AGENT_VERSION=`montecarlo agents health --agent-id << parameters.agent_uuid >> | grep -v "Agent health check" | jq -r '.version'`
             echo "Agent Version: $AGENT_VERSION"
             if [ $AGENT_VERSION = "<< parameters.agent_version >>" ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
               only:
                 - dev
       - update-and-validate-golden-agent:
-          name: gcp-prod-update-and-validate-golden-agent
+          name: gcp-prod-update-and-validate-golden-agent-merge-queue
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -357,7 +357,7 @@ workflows:
               only:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
-          name: az-prod-update-and-validate-golden-agent
+          name: az-prod-update-and-validate-golden-agent-merge-queue
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
@@ -409,7 +409,7 @@ workflows:
               only:
                 - dev
       - update-and-validate-golden-agent:
-          name: aws-prod-update-and-validate-golden-agent
+          name: aws-prod-update-and-validate-golden-agent-merge-queue
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
@@ -460,6 +460,29 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - update-and-validate-golden-agent:
+          name: gcp-prod-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
+          agent_version: ${VERSION_TAG}
+          pre-steps:
+            - checkout
+            - generate-version-number-prod
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-prod
+      - update-and-validate-golden-agent:
+          name: az-prod-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
+          agent_version: ${VERSION_TAG}
+          sleep_seconds: "120"
+          pre-steps:
+            - checkout
+            - generate-version-number-prod
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-prod
       - build-and-push-lambda:
           name: build-and-push-lambda-prod
           docker_hub_repository: agent
@@ -479,6 +502,18 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+      - update-and-validate-golden-agent:
+          name: aws-prod-update-and-validate-golden-agent
+          use_aws_cli: true
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
+          agent_version: ${VERSION_TAG}
+          pre-steps:
+            - checkout
+            - generate-version-number-prod
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-lambda-prod
       - push-lambda-legacy-repo:
           name: push-lambda-aws-prod
           docker_hub_repository: agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,6 +291,7 @@ workflows:
           name: az-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
+          sleep_seconds: 120
           image_repo: pre-release-agent
           pre-steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,6 +287,18 @@ workflows:
             - mc-dev
           requires:
             - build-and-push-dev
+      - update-and-validate-golden-agent:
+          name: az-dev-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
+          agent_version: ${NEXT_VERSION}
+          image_repo: pre-release-agent
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-dev
+          requires:
+            - build-and-push-dev
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
           docker_hub_repository: pre-release-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,10 @@ workflows:
             - mc-dev
           requires:
             - build-and-push-dev
+          filters:
+            branches:
+              only:
+                - dev
       - update-and-validate-golden-agent:
           name: az-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
@@ -301,6 +305,26 @@ workflows:
             - mc-dev
           requires:
             - build-and-push-dev
+          filters:
+            branches:
+              only:
+                - dev
+      - update-and-validate-golden-agent:
+          name: gcp-prod-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
+          agent_version: ${NEXT_VERSION}
+          image_repo: pre-release-agent
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-dev
+          filters:
+            branches:
+              only:
+                - /.*\/pr-.*/
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
           docker_hub_repository: pre-release-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,7 @@ workflows:
           name: az-prod-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
+          sleep_seconds: "120"
           image_repo: pre-release-agent
           pre-steps:
             - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,10 @@ jobs:
         description: Seconds to wait after triggering the agent update and before checking for the new version
         type: string
         default: "0"
+      image_repo:
+        description: The image repository to use for the agent, pre-release-agent or agent
+        type: string
+        default: "agent"
     steps:
       - jq/install
       - run:
@@ -230,11 +234,12 @@ jobs:
             sleep << parameters.sleep_seconds >>
             export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
             export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+            export MCD_AGENT_IMAGE_REPO=<< parameters.image_repo >>
             AGENT_VERSION=`montecarlo agents health --agent-id << parameters.agent_uuid >> | grep -v "Agent health check" | jq -r '.version'`
             echo "Agent Version: $AGENT_VERSION"
             if [ $AGENT_VERSION = "<< parameters.agent_version >>" ]
                 then exit 0
-                else echo "Failed to find expected version, found: $AGENT_VERSION"; exit 1
+                else echo "Failed to find expected version (<< parameters.agent_version >>), found: $AGENT_VERSION"; exit 1
             fi
       - run:
           name: Run validations
@@ -274,6 +279,7 @@ workflows:
           name: update-and-validate-golden-agent-gcp-dev
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
+          image_repo: pre-release-agent
           pre-steps:
             - checkout
             - generate-version-number-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ workflows:
               only:
                 - dev
       - update-and-validate-golden-agent:
-          name: update-and-validate-golden-agent-gcp-dev
+          name: gcp-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -284,7 +284,6 @@ workflows:
             - checkout
             - generate-version-number-dev
           context:
-            - docker
             - mc-dev
           requires:
             - build-and-push-dev
@@ -306,6 +305,18 @@ workflows:
             branches:
               only:
                 - dev
+      - update-and-validate-golden-agent:
+          name: aws-dev-update-and-validate-golden-agent
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
+          agent_version: ${NEXT_VERSION}
+          image_repo: pre-release-agent
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-dev
+          requires:
+            - build-and-push-lambda-dev
       - push-lambda-legacy-repo:
           name: push-lambda-aws-dev
           docker_hub_repository: pre-release-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,6 @@ jobs:
   run-linter:
     docker:
       - image: cimg/python:3.11-node
-
     steps:
       - checkout
       - run:
@@ -198,6 +197,7 @@ jobs:
           command: make VERSION=<< parameters.code_version >> publish-docs
 
   update-and-validate-golden-agent:
+    executor: aws-cli/default
     parameters:
       agent_uuid:
         description: UUID of the Agent
@@ -210,38 +210,38 @@ jobs:
         type: string
         default: "0"
     steps:
-    - jq/install
-    - run:
-        name: Install dependencies
-        command: |
-          curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-          python get-pip.py
-          pip install --no-cache-dir --upgrade pip
-          pip install --no-cache-dir montecarlodata
-    - run:
-        name: Update agent
-        command: |
-          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
-          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-          montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
-    - run:
-        name: Run Agent Health
-        command: |
-          sleep << parameters.sleep_seconds >>
-          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
-          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-          AGENT_VERSION=`montecarlo agents health --agent-id << parameters.agent_uuid >> | grep -v "Agent health check" | jq -r '.version'`
-          echo "Agent Version: $AGENT_VERSION"
-          if [ $AGENT_VERSION = "<< parameters.agent_version >>" ]
-              then exit 0
-              else echo "Failed to find expected version, found: $AGENT_VERSION"; exit 1
-          fi
-    - run:
-        name: Run validations
-        command: |
-          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
-          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-          montecarlo collectors run-validations --all-validations --agent-id << parameters.agent_uuid >>
+      - jq/install
+      - run:
+          name: Install dependencies
+          command: |
+            curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+            python get-pip.py
+            pip install --no-cache-dir --upgrade pip
+            pip install --no-cache-dir montecarlodata
+      - run:
+          name: Update agent
+          command: |
+            export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+            export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+            montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
+      - run:
+          name: Run Agent Health
+          command: |
+            sleep << parameters.sleep_seconds >>
+            export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+            export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+            AGENT_VERSION=`montecarlo agents health --agent-id << parameters.agent_uuid >> | grep -v "Agent health check" | jq -r '.version'`
+            echo "Agent Version: $AGENT_VERSION"
+            if [ $AGENT_VERSION = "<< parameters.agent_version >>" ]
+                then exit 0
+                else echo "Failed to find expected version, found: $AGENT_VERSION"; exit 1
+            fi
+      - run:
+          name: Run validations
+          command: |
+            export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+            export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+            montecarlo collectors run-validations --all-validations --agent-id << parameters.agent_uuid >>
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,15 +242,19 @@ jobs:
                 role_arn: "${AWS_AGENT_ACCOUNT_ROLE_ARN}"
                 profile_name: mcd
             - run:
-                name: Update agent
+                name: Trigger AWS agent stack update
                 command: |
                   aws cloudformation update-stack --profile mcd --stack-name "${AWS_AGENT_STACK_NAME}" --use-previous-template --parameters "ParameterKey=ImageUri,ParameterValue=<< parameters.ecr_repo_account >>.dkr.ecr.*.amazonaws.com/<< parameters.ecr_repo_name >>:<< parameters.agent_version >>" --region ${AWS_AGENT_REGION} --capabilities CAPABILITY_IAM
+            - run:
+                name: Wait for update to complete
+                command: |
+                  aws cloudformation wait stack-update-complete --profile mcd --stack-name "${AWS_AGENT_STACK_NAME}" --region ${AWS_AGENT_REGION}
       - when:
           condition:
             not: << parameters.use_aws_cli >>
           steps:
             - run:
-                name: Update AWS agent
+                name: Update agent
                 command: |
                   export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
                   export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,7 @@ workflows:
             branches:
               only:
                 - dev
+                - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: gcp-dev-update-and-validate-golden-agent
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   aws-cli: circleci/aws-cli@4.1.3
   aws-ecr: circleci/aws-ecr@9.0.4
   docker: circleci/docker@2.2.0
+  jq: circleci/jq@3.0.0
 
 commands:
   verify-version-in-docker-image:
@@ -23,6 +24,24 @@ commands:
             then exit 0
             else echo "Failed to find expected version, found: $image_version"; exit 1
           fi
+  generate-version-number-dev:
+    steps:
+    - run:
+        command: |
+          PIPELINE_NUMBER=<< pipeline.number >>
+          if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+          VERSION=${TAG#v}
+          echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
+          source $BASH_ENV
+        name: Generate dev version number
+  generate-version-number-prod:
+    steps:
+    - run:
+        command: |
+          if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
+          echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
+          source $BASH_ENV
+        name: Generate prod version number
 
 jobs:
   run-linter:
@@ -178,6 +197,52 @@ jobs:
           name: Publish docs and invalidate the cloudfront cache
           command: make VERSION=<< parameters.code_version >> publish-docs
 
+  update-and-validate-golden-agent:
+    parameters:
+      agent_uuid:
+        description: UUID of the Agent
+        type: string
+      agent_version:
+        description: The agent version installed, to check after the upgrade is complete
+        type: string
+      sleep_seconds:
+        description: Seconds to wait after triggering the agent update and before checking for the new version
+        type: string
+        default: "0"
+    steps:
+    - jq/install
+    - run:
+        name: Install dependencies
+        command: |
+          curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
+          python get-pip.py
+          pip install --no-cache-dir --upgrade pip
+          pip install --no-cache-dir montecarlodata
+    - run:
+        name: Update agent
+        command: |
+          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+          montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
+    - run:
+        name: Run Agent Health
+        command: |
+          sleep << parameters.sleep_seconds >>
+          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+          AGENT_VERSION=`montecarlo agents health --agent-id << parameters.agent_uuid >> | grep -v "Agent health check" | jq -r '.version'`
+          echo "Agent Version: $AGENT_VERSION"
+          if [ $AGENT_VERSION = "<< parameters.agent_version >>" ]
+              then exit 0
+              else echo "Failed to find expected version, found: $AGENT_VERSION"; exit 1
+          fi
+    - run:
+        name: Run validations
+        command: |
+          export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+          export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+          montecarlo collectors run-validations --all-validations --agent-id << parameters.agent_uuid >>
+
 workflows:
   version: 2
 
@@ -195,13 +260,7 @@ workflows:
           code_version: ${NEXT_VERSION}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  PIPELINE_NUMBER=<< pipeline.number >>
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  VERSION=${TAG#v}
-                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-dev
           context:
             - docker
           requires:
@@ -211,6 +270,18 @@ workflows:
             branches:
               only:
                 - dev
+      - update-and-validate-golden-agent:
+          name: update-and-validate-golden-agent-gcp-dev
+          agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
+          agent_version: ${NEXT_VERSION}
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - docker
+            - mc-dev
+          requires:
+            - build-and-push-dev
       - build-and-push-lambda:
           name: build-and-push-lambda-dev
           docker_hub_repository: pre-release-agent
@@ -218,13 +289,7 @@ workflows:
           code_version: ${NEXT_VERSION}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  PIPELINE_NUMBER=<< pipeline.number >>
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  VERSION=${TAG#v}
-                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-dev
           context:
             - aether-dev
             - docker
@@ -242,13 +307,7 @@ workflows:
           code_version: ${NEXT_VERSION}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  PIPELINE_NUMBER=<< pipeline.number >>
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  VERSION=${TAG#v}
-                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-dev
           context:
             - aws-dev
             - docker
@@ -264,11 +323,7 @@ workflows:
           code_version: ${VERSION_TAG}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-prod
           context:
             - docker
           requires:
@@ -286,11 +341,7 @@ workflows:
           code_version: ${VERSION_TAG}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-prod
           context:
             - aether-prod
             - docker
@@ -309,11 +360,7 @@ workflows:
           code_version: ${VERSION_TAG}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-prod
           context:
             - aws-prod
             - docker
@@ -329,13 +376,7 @@ workflows:
           code_version: ${NEXT_VERSION}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  PIPELINE_NUMBER=<< pipeline.number >>
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  VERSION=${TAG#v}
-                  echo "NEXT_VERSION=$(echo "$VERSION" | awk 'BEGIN{FS=OFS="."} {$3+=1} 1')rc${PIPELINE_NUMBER}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-dev
           context:
             - aws-dev
           requires:
@@ -350,11 +391,7 @@ workflows:
           code_version: ${VERSION_TAG}
           pre-steps:
             - checkout
-            - run:
-                command: |
-                  if git describe --tags --abbrev=0; then TAG=$(git describe --tags --abbrev=0); else exit 1; fi
-                  echo "VERSION_TAG=${TAG#v}" >> $BASH_ENV
-                  source $BASH_ENV
+            - generate-version-number-prod
           context:
             - aws-prod
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,10 @@ jobs:
   update-and-validate-golden-agent:
     executor: aws-cli/default
     parameters:
+      use_aws_cli:
+        description: Use the AWS CLI to perform the update
+        type: boolean
+        default: false
       agent_uuid:
         description: UUID of the Agent
         type: string
@@ -213,6 +217,14 @@ jobs:
         description: The image repository to use for the agent, pre-release-agent or agent
         type: string
         default: "agent"
+      ecr_repo_name:
+        description: The ECR repository to use for the AWS CLI update
+        type: string
+        default: "mcd-agent"
+      ecr_repo_account:
+        description: The AWS account to use for the ECR repo update
+        type: string
+        default: "590183797493"
     steps:
       - jq/install
       - run:
@@ -222,13 +234,28 @@ jobs:
             python get-pip.py
             pip install --no-cache-dir --upgrade pip
             pip install --no-cache-dir montecarlodata
-      - run:
-          name: Update agent
-          command: |
-            export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
-            export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-            export MCD_AGENT_IMAGE_REPO=<< parameters.image_repo >>
-            montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
+      - when:
+          condition:
+            equal: [ true, << parameters.use_aws_cli >> ]
+          steps:
+            - aws-cli/setup:
+                role_arn: "${AWS_AGENT_ACCOUNT_ROLE_ARN}"
+                profile_name: mcd
+            - run:
+                name: Update agent
+                command: |
+                  aws cloudformation update-stack --profile mcd --stack-name "${AWS_AGENT_STACK_NAME}" --use-previous-template --parameters "ParameterKey=ImageUri,ParameterValue=<< parameters.ecr_repo_account >>.dkr.ecr.*.amazonaws.com/<< parameters.ecr_repo_name >>:<< parameters.agent_version >>" --region ${AWS_AGENT_REGION} --capabilities CAPABILITY_IAM
+      - when:
+          condition:
+            not: << parameters.use_aws_cli >>
+          steps:
+            - run:
+                name: Update AWS agent
+                command: |
+                  export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
+                  export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
+                  export MCD_AGENT_IMAGE_REPO=<< parameters.image_repo >>
+                  montecarlo agents upgrade --agent-id << parameters.agent_uuid >>
       - run:
           name: Run Agent Health
           command: |
@@ -331,6 +358,24 @@ workflows:
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
           image_repo: pre-release-agent
+          pre-steps:
+            - checkout
+            - generate-version-number-dev
+          context:
+            - mc-prod
+          requires:
+            - build-and-push-dev
+          filters:
+            branches:
+              only:
+                - /.*\/pr-.*/
+      - update-and-validate-golden-agent:
+          name: aws-prod-update-and-validate-golden-agent
+          use_aws_cli: true
+          agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
+          agent_version: ${NEXT_VERSION}
+          ecr_repo_name: "mcd-pre-release-agent"
+          ecr_repo_account: "637423407294"
           pre-steps:
             - checkout
             - generate-version-number-dev


### PR DESCRIPTION
- Added steps to update and validate test agents as part of the build. Golden accounts in dev and prod are used.
- The build for the merge queue updates the production agents with the pre-release code and runs the validations before merging to `main`.
- Build improved to define `generate-version-number-prod`/`generate-version-number-dev` commands and remove some duplicated lines