### PR TITLE
MES-306 - update boto

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 azure-identity==1.17.1
 azure-mgmt-storage==21.2.1
 azure-storage-blob==12.20.0
-boto3==1.34.135
+boto3==1.34.151
 cryptography>=42.0.4
 databricks-sql-connector==2.8.0
 dataclasses-json==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ azure-storage-blob==12.20.0
     # via -r requirements.in
 blinker==1.8.2
     # via flask
-boto3==1.34.135
+boto3==1.34.151
     # via -r requirements.in
-botocore==1.34.135
+botocore==1.34.152
     # via
     #   boto3
     #   s3transfer
@@ -226,10 +226,8 @@ pycryptodome==3.20.0
     # via
     #   -r requirements.in
     #   teradatasql
-pyhive[hive-pure-sasl]==0.7.0 ; python_version >= "3.11"
-    # via
-    #   -r requirements.in
-    #   pyhive
+pyhive[hive_pure_sasl]==0.7.0 ; python_version >= "3.11"
+    # via -r requirements.in
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
We're seeing some very strange issues with our Glue Integration (https://linear.app/montecarlodata/issue/MES-494/glue-getdatabases-returning-empty-responses-despite-having-access, https://linear.app/montecarlodata/issue/MES-306/investigate-schema-changing-for-old-mutual, https://linear.app/montecarlodata/issue/MES-460/old-mutual-glue-metadata-collection-timing-out) and want to bump the boto version. There is some difference in the Glue client between the version we're on now and the most updated version.