### PR TITLE
Ncastagnet/vuln 414 upgrade package go critical

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 # using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
 
-teradatasql>=17.20.0.31
+teradatasql>=20.0.0.15
 oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 # Note: 'pyhive[hive]' extras uses sasl that does not support Python 3.11,

--- a/requirements.txt
+++ b/requirements.txt
@@ -226,7 +226,7 @@ pycryptodome==3.20.0
     # via
     #   -r requirements.in
     #   teradatasql
-pyhive[hive_pure_sasl]==0.7.0 ; python_version >= "3.11"
+pyhive[hive-pure-sasl]==0.7.0 ; python_version >= "3.11"
     # via -r requirements.in
 pyjwt[crypto]==2.8.0
     # via
@@ -290,7 +290,7 @@ sqlalchemy==1.4.52
     #   databricks-sql-connector
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.13
+teradatasql==20.0.0.15
     # via -r requirements.in
 thrift==0.16.0
     # via


### PR DESCRIPTION
- Update the `teradatasql` package to upgrade the included Go version to 1.22.5.