### PR TITLE
VULN-415: Upgraded dependencies to upgrade cryptography to v43.0.1

### DIFF
--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -20,7 +20,7 @@ azure-common==1.1.28
     # via
     #   -c requirements.txt
     #   azure-mgmt-resource
-azure-core==1.30.2
+azure-core==1.31.0
     # via
     #   -c requirements.txt
     #   azure-core-tracing-opentelemetry

--- a/requirements-cloudrun.txt
+++ b/requirements-cloudrun.txt
@@ -19,7 +19,6 @@ charset-normalizer==3.3.2
 google-api-core[grpc]==2.19.1
     # via
     #   -c requirements.txt
-    #   google-api-core
     #   google-cloud-appengine-logging
     #   google-cloud-core
     #   google-cloud-logging

--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
-azure-identity==1.17.1
+azure-identity==1.18.0
 azure-mgmt-storage==21.2.1
-azure-storage-blob==12.20.0
+azure-storage-blob==12.23.0
 boto3==1.34.151
-cryptography>=42.0.4
+cryptography>=43.0.1
 databricks-sql-connector==2.8.0
 dataclasses-json==0.6.0
 duckdb==0.9.2
@@ -15,9 +15,9 @@ hdbcli==2.18.27
 jinja2>=3.1.4
 lambda-git==0.1.1
 looker-sdk==24.2.0
-msal==1.24.1
+msal==1.31.0
 numpy<2.0.0  # prevent "numpy.dtype size changed" errors: https://github.com/numpy/numpy/issues/26710
-oracledb>=1.3.1
+oracledb>=2.4.1
 presto-python-client==0.8.3
 protobuf<5.0.0dev  # from google-cloud-logging in requirements-cloudrun
 psycopg2-binary==2.9.7
@@ -26,11 +26,11 @@ pycryptodome>=3.19.1
 pyjwt>=2.8.0
 PyMySQL>=1.1.1
 pyodbc==5.0.1
-pyOpenSSL>=24.0.0
+pyOpenSSL>=24.2.1
 requests>=2.32.0
 RestrictedPython==7.0
 retry2==0.9.5
-snowflake-connector-python>=3.7.1
+snowflake-connector-python>=3.12.2
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python
 tableauserverclient==0.25 ; python_version < "3.10"
 # using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,18 +16,18 @@ attrs==23.2.0
     #   looker-sdk
 azure-common==1.1.28
     # via azure-mgmt-storage
-azure-core==1.30.2
+azure-core==1.31.0
     # via
     #   azure-identity
     #   azure-mgmt-core
     #   azure-storage-blob
-azure-identity==1.17.1
+azure-identity==1.18.0
     # via -r requirements.in
 azure-mgmt-core==1.4.0
     # via azure-mgmt-storage
 azure-mgmt-storage==21.2.1
     # via -r requirements.in
-azure-storage-blob==12.20.0
+azure-storage-blob==12.23.0
     # via -r requirements.in
 blinker==1.8.2
     # via flask
@@ -59,7 +59,7 @@ click==8.1.7
     # via
     #   flask
     #   presto-python-client
-cryptography==42.0.8
+cryptography==43.0.1
     # via
     #   -r requirements.in
     #   azure-identity
@@ -158,12 +158,12 @@ markupsafe==2.1.5
     #   werkzeug
 marshmallow==3.21.3
     # via dataclasses-json
-msal==1.24.1
+msal==1.31.0
     # via
     #   -r requirements.in
     #   azure-identity
     #   msal-extensions
-msal-extensions==1.1.0
+msal-extensions==1.2.0
     # via azure-identity
 mypy-extensions==1.0.0
     # via typing-inspect
@@ -177,7 +177,7 @@ oauthlib==3.2.2
     # via databricks-sql-connector
 openpyxl==3.1.5
     # via databricks-sql-connector
-oracledb==2.2.1
+oracledb==2.4.1
     # via -r requirements.in
 oscrypto @ git+https://github.com/wbond/oscrypto@master
     # via -r requirements.in
@@ -185,7 +185,6 @@ packaging==24.1
     # via
     #   gunicorn
     #   marshmallow
-    #   msal-extensions
     #   snowflake-connector-python
     #   tableauserverclient
 pandas==2.1.1
@@ -226,7 +225,7 @@ pycryptodome==3.20.0
     # via
     #   -r requirements.in
     #   teradatasql
-pyhive[hive-pure-sasl]==0.7.0 ; python_version >= "3.11"
+pyhive[hive_pure_sasl]==0.7.0 ; python_version >= "3.11"
     # via -r requirements.in
 pyjwt[crypto]==2.8.0
     # via
@@ -237,7 +236,7 @@ pymysql==1.1.1
     # via -r requirements.in
 pyodbc==5.0.1
     # via -r requirements.in
-pyopenssl==24.1.0
+pyopenssl==24.2.1
     # via
     #   -r requirements.in
     #   snowflake-connector-python
@@ -280,7 +279,7 @@ six==1.16.0
     #   python-dateutil
     #   thrift
     #   thrift-sasl
-snowflake-connector-python==3.11.0
+snowflake-connector-python==3.12.2
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python


### PR DESCRIPTION
Upgraded cryptography to v43.0.1 and all the necessary dependencies

In `dev.apollo.agent@montecarlodata.com` account I updated all the agents to use the latest version (v1328):

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/1523a384-9ee7-47ea-bd0b-bbb11c5427aa">

Scheduler runs:

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/291fdbe1-3a63-4b5a-bddc-ffcbab60274c">

No errors in the last 4 hours ([link](https://app.datadoghq.com/logs?query=service%3A%28node1403%2A%20OR%20node2421%2A%20OR%20node1561%2A%20OR%20node1562%2A%20OR%20node1754%2A%20OR%20node1189%2A%29%20env%3Adev%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=1668586&storage=hot&stream_sort=desc&viz=stream&from_ts=1727181211680&to_ts=1727195611680&live=true)):

<img width="1565" alt="image" src="https://github.com/user-attachments/assets/56498c39-90c1-477d-be19-47f017732f30">

