### PR TITLE
VULN-413 - update databricks sql connector to version 3.5.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ azure-mgmt-storage==21.2.1
 azure-storage-blob==12.23.0
 boto3==1.34.151
 cryptography>=43.0.1
-databricks-sql-connector==2.8.0
+databricks-sql-connector==3.5.0
 dataclasses-json==0.6.0
 duckdb==0.10.3
 flask==2.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile requirements.in
 #
-alembic==1.13.2
-    # via databricks-sql-connector
 asn1crypto==1.5.1
     # via
     #   oscrypto
@@ -69,7 +67,7 @@ cryptography==43.0.1
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
-databricks-sql-connector==2.8.0
+databricks-sql-connector==3.5.0
     # via -r requirements.in
 dataclasses-json==0.6.0
     # via -r requirements.in
@@ -149,12 +147,9 @@ looker-sdk==24.2.0
     # via -r requirements.in
 lz4==4.3.3
     # via databricks-sql-connector
-mako==1.3.5
-    # via alembic
 markupsafe==2.1.5
     # via
     #   jinja2
-    #   mako
     #   werkzeug
 marshmallow==3.21.3
     # via dataclasses-json
@@ -283,10 +278,6 @@ snowflake-connector-python==3.12.2
     # via -r requirements.in
 sortedcontainers==2.4.0
     # via snowflake-connector-python
-sqlalchemy==1.4.52
-    # via
-    #   alembic
-    #   databricks-sql-connector
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
     # via -r requirements.in
 teradatasql==20.0.0.15
@@ -302,7 +293,6 @@ tomlkit==0.12.5
     # via snowflake-connector-python
 typing-extensions==4.12.2
     # via
-    #   alembic
     #   azure-core
     #   azure-identity
     #   azure-storage-blob
@@ -319,6 +309,7 @@ uritemplate==4.1.1
 urllib3==2.2.2
     # via
     #   botocore
+    #   databricks-sql-connector
     #   requests
     #   tableauserverclient
 werkzeug==3.0.3


### PR DESCRIPTION
Updates the databricks-sql-connector library to the most recent version (3.5.0) for the sake of a vulnerability in the logging of potentially sensitive information