### PR TITLE
Add HTTP connection validator

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -253,7 +253,7 @@ class Agent:
         :param trace_id: Optional trace ID received from the client that will be included in
             the response, if present.
         """
-        with self._inject_log_context("perform_dns_lookup", trace_id):
+        with self._inject_log_context("validate_http_connection", trace_id):
             logger.info(
                 "HTTP connection test request received",
                 extra=self._logging_utils.build_extra(

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -237,6 +237,41 @@ class Agent:
             )
             return ValidateNetwork.perform_dns_lookup(host, port_str, trace_id)
 
+    def validate_http_connection(
+        self,
+        url: Optional[str],
+        include_response_str: Optional[Union[bool, str]],
+        timeout_str: Optional[Union[int, str]],
+        trace_id: Optional[str],
+    ) -> AgentResponse:
+        """
+        Performs a GET request to test the provider URL.
+        :param url: The URL to test, will raise `BadRequestError` if None.
+        :param include_response_str: Optional boolean indicating if the response should be sent back.
+        :param timeout_str: Timeout in seconds as a string containing the numeric value,
+            will raise `BadRequestError` if non-numeric. Defaults to 10 seconds.
+        :param trace_id: Optional trace ID received from the client that will be included in
+            the response, if present.
+        """
+        with self._inject_log_context("perform_dns_lookup", trace_id):
+            logger.info(
+                "HTTP connection test request received",
+                extra=self._logging_utils.build_extra(
+                    trace_id=trace_id,
+                    operation_name="validate_http_connection",
+                    extra=dict(
+                        url=url,
+                        include_response=include_response_str,
+                        timeout=timeout_str,
+                    ),
+                ),
+            )
+            return ValidateNetwork.validate_http_connection(
+                url=url,
+                include_response_str=include_response_str,
+                timeout_str=timeout_str,
+            )
+
     def get_outbound_ip_address(
         self,
         trace_id: Optional[str] = None,

--- a/apollo/validators/validate_network.py
+++ b/apollo/validators/validate_network.py
@@ -242,7 +242,7 @@ class ValidateNetwork:
 
         try:
             response = requests.get(url, timeout=timeout_in_seconds)
-            message = f"URL {url} responded with status code: {response.status_code}"
+            message = f"URL {url} responded with status: {response.status_code} ({response.reason})"
             if include_response:
                 content_str = response.content.decode("utf-8")
                 message += f" and content: {content_str}"

--- a/tests/test_health_network.py
+++ b/tests/test_health_network.py
@@ -157,13 +157,14 @@ class HealthNetworkTests(TestCase):
     def test_http_connection(self, get_mock):
         response_mock = Mock()
         response_mock.status_code = 200
+        response_mock.reason = "OK"
         response_mock.content = b"foo"
         get_mock.return_value = response_mock
         response = self._agent.validate_http_connection(
             "https://foo.bar", "true", None, trace_id=None
         )
         self.assertEqual(
-            "URL https://foo.bar responded with status code: 200 and content: foo",
+            "URL https://foo.bar responded with status: 200 (OK) and content: foo",
             response.result.get(ATTRIBUTE_NAME_RESULT).get("message"),
         )
 
@@ -171,6 +172,6 @@ class HealthNetworkTests(TestCase):
             "https://foo.bar", None, None, trace_id=None
         )
         self.assertEqual(
-            "URL https://foo.bar responded with status code: 200",
+            "URL https://foo.bar responded with status: 200 (OK)",
             response.result.get(ATTRIBUTE_NAME_RESULT).get("message"),
         )


### PR DESCRIPTION
- Added a new networking test to validate `HTTP` connections, similar to the `TCP` related operations
- It takes the URL to test, a flag `include_response` indicating if the response should be sent back and the `timeout` in seconds