### PR TITLE
Update openssl from 3.0.8-1.amzn2023.0.14 to 3.0.8-1.amzn2023.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ RUN apt install git -y
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
-FROM public.ecr.aws/lambda/python:3.12.2024.10.16.13 AS lambda-builder
+FROM public.ecr.aws/lambda/python:3.12.2024.11.14.18 AS lambda-builder
 
 RUN dnf update -y
 # install git as we need it for the direct oscrypto dependency
@@ -80,7 +80,7 @@ RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" \
     -r requirements.txt \
     -r requirements-lambda.txt
 
-FROM public.ecr.aws/lambda/python:3.12.2024.10.16.13 AS lambda
+FROM public.ecr.aws/lambda/python:3.12.2024.11.14.18 AS lambda
 
 # VULN-423: setuptools 68.0.0 contains (CVE-2024-6345)
 RUN pip install --no-cache-dir setuptools==75.1.0


### PR DESCRIPTION
### Before

```
➜ docker build --platform=linux/amd64 -t lambda --target lambda .
➜ docker run --rm -it --entrypoint /bin/bash lambda

bash-5.2# openssl version
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)

bash-5.2# dnf -y install binutils
bash-5.2# strings /lib64/libssl.so.3.0.8 | grep version | grep openssl
{"type":"rpm","name":"openssl","version":"3.0.8-1.amzn2023.0.14","architecture":"x86_64","osCpe":"cpe:2.3:o:amazon:amazon_linux:2023"}
```

- **Version:** `3.0.8-1.amzn2023.0.14`

### After

```
➜ docker build --platform=linux/amd64 -t lambda --target lambda .
➜ docker run --rm -it --entrypoint /bin/bash lambda

bash-5.2# openssl version
OpenSSL 3.0.8 7 Feb 2023 (Library: OpenSSL 3.0.8 7 Feb 2023)

bash-5.2# dnf -y install binutils
bash-5.2# strings /lib64/libssl.so.3.0.8 | grep version | grep openssl
{"type":"rpm","name":"openssl","version":"3.0.8-1.amzn2023.0.16","architecture":"x86_64","osCpe":"cpe:2.3:o:amazon:amazon_linux:2023"}
```

- **Version:** `3.0.8-1.amzn2023.0.16`
