### PR TITLE
ilamden/VULN-458 bump werkzeug to 3.1.0 [apollo-agent]

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -82,7 +82,7 @@ pyyaml==6.0.1
     #   pre-commit
 virtualenv==20.26.3
     # via pre-commit
-werkzeug==3.0.3
+werkzeug==3.1.0
     # via
     #   -c requirements.txt
     #   flask

--- a/requirements.in
+++ b/requirements.in
@@ -42,4 +42,4 @@ oscrypto @ git+https://github.com/wbond/oscrypto@master
 # Note this is a beta version of impyla that is needed in order to support HTTPS connections on python 3.12.
 # It should be updated to stable version 0.20.0 once that is released.
 impyla==0.20a1
-werkzeug==3.0.3
+werkzeug==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -310,7 +310,7 @@ urllib3==2.2.2
     #   databricks-sql-connector
     #   requests
     #   tableauserverclient
-werkzeug==3.0.3
+werkzeug==3.1.0
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
Update the werkzeug library to version 3.1.0.

Context:
https://linear.app/montecarlodata/issue/VULN-458/small-upgrade-for-werkzeug
https://app.aikido.dev/issues/3251889/detail

Pushed to dev and updated MC agents:
https://us-east-1.console.aws.amazon.com/ecr/repositories/private/404798114945/mcd-pre-release-agent/_/image/sha256:ec751047d4c60fb61a3b3cde90c28550f0217eb4e3d1578023ef7766253796c1/details?region=us-east-1

Image tags **latest, 1.2.4rc1434**

![image](https://github.com/user-attachments/assets/4bc1c505-53ef-466e-bebe-3f77ea24fbad)
