### PR TITLE
Azure Agent vulnerabilities: sqlite3, viztracer and openssl updated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,8 @@ RUN apt install git -y
 # Updating libgnutls30 to resolve CVE-2024-28835 and CVE-2024-28834.
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https libgnutls30 \
-    && ACCEPT_EULA=Y apt-get install -y msodbcsql17 odbcinst=2.3.11-2+deb12u1 odbcinst1debian2=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1
+    && ACCEPT_EULA=Y apt-get install -y msodbcsql17 odbcinst=2.3.11-2+deb12u1 odbcinst1debian2=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1 \
+    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.15-1~deb12u1
 
 # delete this file that includes an old golang version (including vulns) and is not used
 RUN rm -rf /opt/startupcmdgen/

--- a/requirements-azure.in
+++ b/requirements-azure.in
@@ -5,3 +5,4 @@ azure-mgmt-resource==23.0.1
 azure-monitor-opentelemetry==1.3.0
 azure-monitor-query==1.2.1
 aiohttp==3.10.2
+viztracer==0.17.1

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -95,6 +95,8 @@ oauthlib==3.2.2
     # via
     #   -c requirements.txt
     #   requests-oauthlib
+objprint==0.3.0
+    # via viztracer
 opentelemetry-api==1.25.0
     # via
     #   azure-core-tracing-opentelemetry
@@ -213,6 +215,8 @@ urllib3==2.2.2
     # via
     #   -c requirements.txt
     #   requests
+viztracer==0.17.1
+    # via -r requirements-azure.in
 wrapt==1.16.0
     # via
     #   deprecated


### PR DESCRIPTION
This PR:
- updates `sqlite3` to `3.40.1-2+deb12u1` to fix a vulnerability (VULN-469)
- updates `viztracer` to `0.17.1` to fix a vulnerability (VULN-471)
- updates `openssl` to `3.0.15-1~deb12u1` to fix a critical vulnerability reported by Docker Scout and detected during the fix for the other two issues 

Tested in dev and confirmed the issues are no longer reported by Aikido