### PR TITLE
MES-1053 - update databricks sdk

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ azure-storage-blob==12.23.0
 boto3==1.34.151
 cryptography>=43.0.1
 databricks-sql-connector==3.5.0
+databricks-sdk==0.39.0
 dataclasses-json==0.6.0
 duckdb==0.10.3
 flask==2.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,8 @@ cryptography==43.0.1
     #   pyjwt
     #   pyopenssl
     #   snowflake-connector-python
+databricks-sdk==0.39.0
+    # via -r requirements.in
 databricks-sql-connector==3.5.0
     # via -r requirements.in
 dataclasses-json==0.6.0
@@ -98,6 +100,7 @@ google-api-python-client==2.98.0
     # via -r requirements.in
 google-auth==2.30.0
     # via
+    #   databricks-sdk
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2


### PR DESCRIPTION
The old version of the DBX sdk did not support non-AWS Databricks environments using OAuth. We didn't catch it because we only have AWS Databricks environments for MC to test against (and use in prod).