### PR TITLE
[VULN-453] upgrade azure extension bundle to 4.x

### DIFF
--- a/apollo/interfaces/azure/host.json
+++ b/apollo/interfaces/azure/host.json
@@ -9,7 +9,7 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.*, 4.0.0)"
+    "version": "[4.0.0, 5.0.0)"
   },
   "extensions": 
   {


### PR DESCRIPTION
Upgrade extension bundle to upgrade vulnerable messagepack dependency.

See: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-register#extension-bundles