### PR TITLE
Fix JSON serialization error returning `time` fields

### DIFF
--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -56,7 +56,7 @@ ATTRIBUTE_VALUE_TYPE_DECIMAL = "decimal"
 # the right type
 ATTRIBUTE_VALUE_TYPE_LOOKER_CATEGORY = "looker.category"
 
-# Value for the attribute __type__ to indicate this is a date
+# Value for the attribute __type__ to indicate this is a time
 ATTRIBUTE_VALUE_TYPE_TIME = "time"
 
 # Value to use when redacting sensitive data in log messages

--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -56,6 +56,9 @@ ATTRIBUTE_VALUE_TYPE_DECIMAL = "decimal"
 # the right type
 ATTRIBUTE_VALUE_TYPE_LOOKER_CATEGORY = "looker.category"
 
+# Value for the attribute __type__ to indicate this is a date
+ATTRIBUTE_VALUE_TYPE_TIME = "time"
+
 # Value to use when redacting sensitive data in log messages
 ATTRIBUTE_VALUE_REDACTED = "__redacted__"
 

--- a/apollo/agent/serde.py
+++ b/apollo/agent/serde.py
@@ -19,6 +19,7 @@ from apollo.agent.constants import (
     ATTRIBUTE_VALUE_TYPE_DATETIME,
     ATTRIBUTE_VALUE_TYPE_DECIMAL,
     ATTRIBUTE_VALUE_TYPE_BYTES,
+    ATTRIBUTE_VALUE_TYPE_TIME,
 )
 
 
@@ -33,6 +34,11 @@ class AgentSerializer(json.JSONEncoder):
         elif isinstance(value, date):
             return {
                 ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_DATE,
+                ATTRIBUTE_NAME_DATA: value.isoformat(),
+            }
+        elif isinstance(value, time):
+            return {
+                ATTRIBUTE_NAME_TYPE: ATTRIBUTE_VALUE_TYPE_TIME,
                 ATTRIBUTE_NAME_DATA: value.isoformat(),
             }
         elif isinstance(value, Decimal):

--- a/tests/test_snowflake_client.py
+++ b/tests/test_snowflake_client.py
@@ -91,6 +91,25 @@ class SnowflakeClientTests(TestCase):
         self._test_run_query(mock_connect, query, expected_data, expected_description)
 
     @patch("snowflake.connector.connect")
+    def test_query_time(self, mock_connect):
+        query = "SELECT name, value FROM table"  # noqa
+        expected_data = [
+            [
+                "name_1",
+                datetime.time.fromisoformat("14:23:10"),
+            ],
+            [
+                "name_2",
+                datetime.time.fromisoformat("14:23:12"),
+            ],
+        ]
+        expected_description = [
+            ["name", "string", None, None, None, None, None],
+            ["value", "time", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, expected_data, expected_description)
+
+    @patch("snowflake.connector.connect")
     def test_programming_error(self, mock_connect):
         query = ""
         data = []
@@ -217,6 +236,11 @@ class SnowflakeClientTests(TestCase):
         elif isinstance(value, datetime.date):
             return {
                 "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.time):
+            return {
+                "__type__": "time",
                 "__data__": value.isoformat(),
             }
         elif isinstance(value, bytes) or isinstance(value, bytearray):


### PR DESCRIPTION
Time fields were not supported and returning them was actually causing this error:
```
Object of type time is not JSON serializable
```