### PR TITLE
Ssmith/mes 1109 support ssl mysql with the agent

### DIFF
--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -52,6 +52,7 @@ class SslOptions:
     verify_cert: bool = True
     verify_identity: bool = True
     disabled: bool = False
+    mechanism: str | None = None
 
     def __post_init__(self):
         # Validation for conflicting flags

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -106,6 +106,9 @@ class SslOptions:
 
     def _set_cert_and_key_to_context(self, ssl_context: ssl.SSLContext) -> None:
         """Check if temp file exists, if not create it from certificate or key data."""
+        if not self.cert_data:
+            return
+
         with tempfile.NamedTemporaryFile(
             delete=True
         ) as cert_file, tempfile.NamedTemporaryFile(delete=True) as key_file:

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -52,7 +52,6 @@ class SslOptions:
     verify_cert: bool = True
     verify_identity: bool = True
     disabled: bool = False
-    mechanism: str | None = None
 
     def __post_init__(self):
         # Validation for conflicting flags

--- a/apollo/integrations/db/base_db_proxy_client.py
+++ b/apollo/integrations/db/base_db_proxy_client.py
@@ -1,5 +1,8 @@
 import logging
+import ssl
+import tempfile
 from abc import ABC
+from dataclasses import dataclass
 from typing import (
     Any,
     Dict,
@@ -15,6 +18,109 @@ from apollo.integrations.storage.base_storage_client import BaseStorageClient
 from apollo.integrations.storage.storage_proxy_client import StorageProxyClient
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SslOptions:
+    """
+    Represents the SSL options for connecting to a database.
+
+    This class contains various configuration options related to SSL certificates
+    and verification that are used when establishing a secure connection to a database.
+
+    For ca_data, cert_data and key_data the content of the certificate should be base64 encoded.
+    Example of an expected format can be found here: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions
+
+    Attributes:
+        ca (str | None): The path to a CA PEM file that can be downloaded.
+        ca_data (str | None): The certificate authority data for SSL verification.
+        cert_data (str | None): The client certificate data for SSL connection.
+        key_data (str | None): The private key data for SSL connection.
+        key_password (str | None): The password for the private key (if applicable).
+        skip_cert_verification (bool, optional): Whether to skip the validity of the certificate and identity of the server.
+        verify_cert (bool, optional): Whether to verify the validity of the server SSL certificate.
+        verify_identity (bool, optional): Whether to verify the identity of the remote server.
+        disabled (bool, optional): Whether the SSL connection is disabled.
+    """
+
+    ca: str | None = None
+    ca_data: str | None = None
+    cert_data: str | None = None
+    key_data: str | None = None
+    key_password: str | None = None
+    skip_cert_verification: bool = False
+    verify_cert: bool = True
+    verify_identity: bool = True
+    disabled: bool = False
+    mechanism: str | None = None
+
+    def __post_init__(self):
+        # Validation for conflicting flags
+        if self.disabled and (self.cert_data or self.key_data or self.ca_data):
+            raise ValueError("disabled is set, but SSL certificate data is provided.")
+
+        if not self.disabled:
+            if self.key_data and not self.cert_data:
+                raise ValueError("key_data is provided, but ssl_cert_data is missing.")
+
+            # If cert or key is provided, the ca data should also be available
+            if (self.cert_data or self.key_data) and not self.ca_data:
+                raise ValueError(
+                    "cert_data or ssl_key_data is provided, but ca_data is missing"
+                )
+
+            # If the password is provided, at least the cert data must also be provided
+            if self.key_password and (not self.cert_data):
+                raise ValueError("key_password is provided but cert_data is missing.")
+
+            # If a CA file path is provided, there should not also be CA data.
+            if self.ca and self.ca_data:
+                raise ValueError(
+                    "Path to CA authority and CA authority data were provided. Provide one or the other."
+                )
+
+    def get_ssl_context(self) -> ssl.SSLContext | None:
+        if self.disabled or not (self.cert_data or self.key_data or self.ca_data):
+            return None
+
+        ssl_context = ssl.create_default_context()
+        ssl_context.verify_mode = (
+            ssl.CERT_NONE
+            if self.skip_cert_verification
+            else (ssl.CERT_REQUIRED if self.verify_cert else ssl.CERT_NONE)
+        )
+        ssl_context.check_hostname = (
+            not self.skip_cert_verification and self.verify_identity
+        )
+
+        if self.ca_data:
+            ssl_context.load_verify_locations(cadata=self.ca_data)
+
+        if self.cert_data:
+            # We need to create temporary files for the certificate and key data because the function
+            # `load_cert_chain` requires a file path as input and does not accept the data directly.
+            # More info here: https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
+            self._set_cert_and_key_to_context(ssl_context)
+
+        return ssl_context
+
+    def _set_cert_and_key_to_context(self, ssl_context: ssl.SSLContext) -> None:
+        """Check if temp file exists, if not create it from certificate or key data."""
+        with tempfile.NamedTemporaryFile(
+            delete=True
+        ) as cert_file, tempfile.NamedTemporaryFile(delete=True) as key_file:
+            cert_file.write(self.cert_data.encode("ascii"))
+            cert_file.flush()
+
+            if self.key_data:
+                key_file.write(self.key_data.encode("ascii"))
+                key_file.flush()
+
+            ssl_context.load_cert_chain(
+                certfile=cert_file.name,
+                keyfile=key_file.name if self.key_data else None,
+                password=self.key_password,
+            )
 
 
 class BaseDbProxyClient(BaseProxyClient, ABC):

--- a/apollo/integrations/db/mysql_proxy_client.py
+++ b/apollo/integrations/db/mysql_proxy_client.py
@@ -9,7 +9,7 @@ from typing import (
 
 import pymysql
 
-from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient, SslOptions
 
 _ATTR_CONNECT_ARGS = "connect_args"
 _MYSQL_DIRECTORY = "mysql/certs"
@@ -32,15 +32,16 @@ class MysqlProxyClient(BaseDbProxyClient):
             )
 
         connect_args = credentials[_ATTR_CONNECT_ARGS]
-        ssl_options = credentials.get("ssl_options") or {}
-        if ssl_options.get("ca"):
-            cert_path = self.get_cert_path(
+        ssl_options = SslOptions(credentials.get("ssl_options") or {})
+        if ssl_options.ca:
+            if cert_path := self.get_cert_path(
                 platform=platform,
-                remote_location=ssl_options["ca"],
+                remote_location=ssl_options.ca,
                 sub_folder=_MYSQL_DIRECTORY,
-            )
-            if cert_path:
+            ):
                 connect_args["ssl"] = {"ca": cert_path}
+        elif ssl_context := ssl_options.get_ssl_context():
+            connect_args["ssl"] = ssl_context
         self._connection = pymysql.connect(**connect_args)
 
         # we were having tcp keep alive issues in Azure, so we're forcing it to 30 secs

--- a/apollo/integrations/db/mysql_proxy_client.py
+++ b/apollo/integrations/db/mysql_proxy_client.py
@@ -32,7 +32,13 @@ class MysqlProxyClient(BaseDbProxyClient):
             )
 
         connect_args = credentials[_ATTR_CONNECT_ARGS]
-        ssl_options = SslOptions(credentials.get("ssl_options") or {})
+
+        # If there is a CA path (ssl_options.ca), download that cert to the storage bucket
+        # and provide the storage bucket's path as a connection argument.
+        #
+        # If instead there is ssl_options.cert_data, ssl_options.key_data or ssl_options.ca_data,
+        # use the data to create a SSLContext obj and provide that as a connection argument.
+        ssl_options = SslOptions(**(credentials.get("ssl_options") or {}))
         if ssl_options.ca:
             if cert_path := self.get_cert_path(
                 platform=platform,
@@ -42,7 +48,11 @@ class MysqlProxyClient(BaseDbProxyClient):
                 connect_args["ssl"] = {"ca": cert_path}
         elif ssl_context := ssl_options.get_ssl_context():
             connect_args["ssl"] = ssl_context
+
         self._connection = pymysql.connect(**connect_args)
+
+        if self._connection and self._connection.ssl:
+            logger.info("MySQL SSL connection established")
 
         # we were having tcp keep alive issues in Azure, so we're forcing it to 30 secs
         sock: Optional[socket.socket] = (

--- a/apollo/integrations/db/mysql_proxy_client.py
+++ b/apollo/integrations/db/mysql_proxy_client.py
@@ -40,26 +40,19 @@ class MysqlProxyClient(BaseDbProxyClient):
         # use the data to create a SSLContext obj and provide that as a connection argument.
         ssl_options = SslOptions(**(credentials.get("ssl_options") or {}))
         if ssl_options.ca:
-            logger.info("MySQL cert path found.")
             if cert_path := self.get_cert_path(
                 platform=platform,
                 remote_location=ssl_options.ca,
                 sub_folder=_MYSQL_DIRECTORY,
             ):
                 connect_args["ssl"] = {"ca": cert_path}
-        else:
-            logger.info("MySQL checking for ssl context.")
-            ssl_context = ssl_options.get_ssl_context()
-            if ssl_context:
-                logger.info("MySQL ssl context found.")
-                connect_args["ssl"] = ssl_context
+        elif ssl_context := ssl_options.get_ssl_context():
+            connect_args["ssl"] = ssl_context
 
         self._connection = pymysql.connect(**connect_args)
 
         if self._connection and self._connection.ssl:
             logger.info("MySQL SSL connection established")
-        else:
-            logger.info("MySQL connection established")
 
         # we were having tcp keep alive issues in Azure, so we're forcing it to 30 secs
         sock: Optional[socket.socket] = (


### PR DESCRIPTION
Updates MySQL client to support SSL cert data and maintain support for existing SSL cert path param.

Testing:
Running validations on Azure agent and AWS agent for MySQL with SSL and confirmed the connection was established with SSL fro m the logs:

![Screenshot 2025-01-14 at 12 08 09 AM](https://github.com/user-attachments/assets/b9a88f51-4ee6-4d59-a637-27ef28ca5b55)
![Screenshot 2025-01-14 at 12 08 09 AM](https://github.com/user-attachments/assets/3f501597-f140-414e-8d75-194be5b42d42)

