### PR TITLE
Support Tableau Data Quality Warnings through Connected Apps

### DIFF
--- a/apollo/integrations/tableau/tableau_proxy_client.py
+++ b/apollo/integrations/tableau/tableau_proxy_client.py
@@ -41,7 +41,13 @@ def generate_jwt(
         "jti": token_id,
         "aud": "tableau",
         "sub": user_name,
-        "scp": ["tableau:content:read", "tableau:users:read", "tableau:labels:*"],
+        "scp": [
+            "tableau:content:read",
+            "tableau:users:read",
+            "tableau:labels:read",
+            "tableau:labels:update",
+            "tableau:labels:create",
+        ],
     }
     return jwt.encode(
         payload=payload, key=secret_value, algorithm="HS256", headers=headers

--- a/apollo/integrations/tableau/tableau_proxy_client.py
+++ b/apollo/integrations/tableau/tableau_proxy_client.py
@@ -41,7 +41,7 @@ def generate_jwt(
         "jti": token_id,
         "aud": "tableau",
         "sub": user_name,
-        "scp": ["tableau:content:read", "tableau:users:read"],
+        "scp": ["tableau:content:read", "tableau:users:read", "tableau:labels:*"],
     }
     return jwt.encode(
         payload=payload, key=secret_value, algorithm="HS256", headers=headers


### PR DESCRIPTION
Add Tableau JWT scopes `tableau:labels:read`, `tableau:labels:update`, `tableau:labels:create` which are used for managing Labels on assets. This will let us read and create Data Quality Warnings on Tableau assets when connected through a connected_app