### PR TITLE
VULN-463: Upgraded teradatasql and pycryptodome dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ PyMySQL>=1.1.1
 pyodbc==5.0.1
 pyOpenSSL>=24.2.1
 requests>=2.32.0
-RestrictedPython==7.4
+RestrictedPython==8.0
 retry2==0.9.5
 snowflake-connector-python>=3.12.3
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python

--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ presto-python-client==0.8.3
 protobuf<5.0.0dev  # from google-cloud-logging in requirements-cloudrun
 psycopg2-binary==2.9.9
 pyarrow==14.0.1  # CVE-2023-47248
-pycryptodome>=3.19.1
+pycryptodome>=3.21.0
 pyjwt>=2.8.0
 PyMySQL>=1.1.1
 pyodbc==5.0.1
@@ -37,7 +37,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 # using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
 
-teradatasql>=20.0.0.15
+teradatasql>=20.0.0.23
 oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 # Note this is a beta version of impyla that is needed in order to support HTTPS connections on python 3.12.

--- a/requirements.txt
+++ b/requirements.txt
@@ -219,7 +219,7 @@ pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.22
     # via cffi
-pycryptodome==3.20.0
+pycryptodome==3.21.0
     # via
     #   -r requirements.in
     #   teradatasql
@@ -282,7 +282,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.15
+teradatasql==20.0.0.23
     # via -r requirements.in
 thrift==0.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -259,7 +259,7 @@ requests==2.32.3
     #   presto-python-client
     #   snowflake-connector-python
     #   tableauserverclient
-restrictedpython==7.4
+restrictedpython==8.0
     # via -r requirements.in
 retry2==0.9.5
     # via -r requirements.in


### PR DESCRIPTION
- Upgraded teradatasql and pycryptodome dependencies
- Upgraded RestrictedPython from v7.4 to 8.0 to fix a high vuln issue

Test:

Upgraded agents in dev:

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/3f046339-94b7-4664-a34f-cced8b31067a" />

Tested Azure Agent:

<img width="605" alt="image" src="https://github.com/user-attachments/assets/5c021259-c99a-416d-b241-296d3fe594e5" />

Tested GCP Agent:

<img width="603" alt="image" src="https://github.com/user-attachments/assets/a4edf4ff-6a3a-494a-a3f4-aa6e97a7cb48" />

Tested AWS Agent:

<img width="601" alt="image" src="https://github.com/user-attachments/assets/59c5de9e-1796-4479-b21e-d6d12b0b99c3" />

Tested Teradata Integration:

<img width="746" alt="image" src="https://github.com/user-attachments/assets/6ed66d33-2570-4143-b8a3-813cdb31d280" />

Triggered Metadata collection for Teradata (no errors):

<img width="1562" alt="image" src="https://github.com/user-attachments/assets/a16a8ab7-56f1-4fd1-961d-6132838caa38" />
