### PR TITLE
add support for an s3 proxy client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
     - id: black
       name: black
-      entry: ./.venv/bin/black
+      entry: black
       language: python
       types_or: [python, pyi]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
     - id: black
       name: black
-      entry: black
+      entry: ./.venv/bin/black
       language: python
       types_or: [python, pyi]
 

--- a/apollo/agent/constants.py
+++ b/apollo/agent/constants.py
@@ -43,6 +43,10 @@ ATTRIBUTE_VALUE_TYPE_CALL = "call"
 # Value for the attribute __type__ to indicate this is a bytes array, data is encoded in base64
 ATTRIBUTE_VALUE_TYPE_BYTES = "bytes"
 
+# Value for the attribute __type__ to indicate this is a boto3 StreamingBody object, data is
+# gzip compressed and encoded in base64
+ATTRIBUTE_VALUE_TYPE_STREAMING_BODY = "StreamingBody;gzip/base64"
+
 # Value for the attribute __type__ to indicate this is a datetime
 ATTRIBUTE_VALUE_TYPE_DATETIME = "datetime"
 

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -47,6 +47,16 @@ def _get_proxy_client_http(credentials: Optional[Dict], **kwargs) -> BaseProxyCl
     return HttpProxyClient(credentials=credentials)
 
 
+def _get_proxy_client_s3(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.aws.s3_proxy_client import (
+        S3ProxyClient,
+    )
+
+    return S3ProxyClient(credentials=credentials, platform=platform)
+
+
 def _get_proxy_client_storage(
     credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
@@ -255,6 +265,7 @@ _CLIENT_FACTORY_MAPPING = {
     "bigquery": _get_proxy_client_bigquery,
     "databricks": _get_proxy_client_databricks,
     "http": _get_proxy_client_http,
+    "s3": _get_proxy_client_s3,
     "storage": _get_proxy_client_storage,
     "looker": _get_proxy_client_looker,
     "git": _get_proxy_client_git,

--- a/apollo/integrations/aws/s3_proxy_client.py
+++ b/apollo/integrations/aws/s3_proxy_client.py
@@ -12,6 +12,6 @@ class S3ProxyClient(BaseAwsProxyClient):
     def process_result(self, value: Any) -> Any:
         """
         Process the result of the methods on this client before being serialized to JSON.
-        Serializes the value to JSON using the AgentSerializer and parses it back from JSON.
+        Ensures all values can be JSON serializable.
         """
         return encode_dictionary(value)

--- a/apollo/integrations/aws/s3_proxy_client.py
+++ b/apollo/integrations/aws/s3_proxy_client.py
@@ -1,0 +1,17 @@
+import json
+from typing import Any, Dict, Optional
+
+from apollo.agent.serde import AgentSerializer, encode_dictionary
+from apollo.integrations.aws.base_aws_proxy_client import BaseAwsProxyClient
+
+
+class S3ProxyClient(BaseAwsProxyClient):
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        BaseAwsProxyClient.__init__(self, service_type="s3", credentials=credentials)
+
+    def process_result(self, value: Any) -> Any:
+        """
+        Process the result of the methods on this client before being serialized to JSON.
+        Serializes the value to JSON using the AgentSerializer and parses it back from JSON.
+        """
+        return encode_dictionary(value)

--- a/tests/test_s3_client.py
+++ b/tests/test_s3_client.py
@@ -1,0 +1,89 @@
+import base64
+import gzip
+from io import BytesIO
+from unittest import TestCase
+from unittest.mock import patch, Mock
+
+from botocore.response import StreamingBody
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_VALUE_TYPE_STREAMING_BODY,
+)
+from apollo.agent.logging_utils import LoggingUtils
+from apollo.integrations.aws.base_aws_proxy_client import BaseAwsProxyClient
+
+_S3_OPERATION = {
+    "trace_id": "1234",
+    "commands": [
+        {
+            "method": "get_object",
+            "kwargs": {
+                "path": "s3://bucket/path",
+                "encoding": "utf-8",
+            },
+        }
+    ],
+}
+
+_S3_CREDENTIALS = {
+    "assumable_role": "arn:aws:iam::foo:role/bar",
+    "aws_region": "us-east-1",
+    "external_id": "fizzbuzz",
+}
+
+
+class TestS3Client(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_client = Mock()
+
+    @patch.object(BaseAwsProxyClient, "create_boto_client")
+    def test_get_object(self, mock_boto_client):
+        mock_boto_client.return_value = self._mock_client
+
+        # Create a real BytesIO object to wrap
+        bytes_io_data = BytesIO("body".encode("utf8"))
+
+        body = Mock(
+            spec=StreamingBody, wraps=StreamingBody(bytes_io_data, len(b"body"))
+        )
+        body.read.side_effect = [b"bo", b"dy", None]
+
+        object_result = {"Body": body}
+        self._mock_client.get_object.return_value = object_result
+        result = self._agent.execute_operation(
+            "s3",
+            "get_object",
+            {
+                "trace_id": "1234",
+                "skip_cache": True,
+                "commands": [
+                    {
+                        "method": "get_object",
+                        "kwargs": {
+                            "Bucket": "s3://bucket/path",
+                            "encoding": "utf-8",
+                        },
+                    }
+                ],
+            },
+            credentials=_S3_CREDENTIALS,
+        )
+        self.assertIsNone(result.result.get(ATTRIBUTE_NAME_ERROR))
+
+        response = result.result[ATTRIBUTE_NAME_RESULT]
+        self.assertEqual(
+            {
+                "Body": {
+                    "__data__": base64.b64encode(gzip.compress(b"body")).decode(
+                        "ascii"
+                    ),
+                    # Expected base64 encoded gzip string
+                    "__type__": ATTRIBUTE_VALUE_TYPE_STREAMING_BODY,
+                }
+            },
+            response,
+        )


### PR DESCRIPTION
At the moment we need to download `athena` results by making calls to get_query_results. The maximum page size to return is 1000, which is too low when fetching million of results (eg. for metric monitors with very high segment count), requiring too many roundtrips and long execution times to execute a monitor run or backfill job.

Add an S3 proxy client to support downloading athena result files from S3 and reduce the number of roundtrips. 

I'm adding a separate proxy client instead of using the `StorageClient`, as storage client API is geared to represent the MC storage agent specifically.