### PR TITLE
Upload the lambda image to the "legacy" ECR Dev repo for merge-queue builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,6 +452,7 @@ workflows:
             branches:
               only:
                 - dev
+                - /.*\/pr-.*/
       - build-and-push:
           name: build-and-push-prod
           docker_hub_repository: agent


### PR DESCRIPTION
Right now as part of the build we run in the merge queue we upload an image to the ECR dev repo in order to update the "golden" AWS agents, but we upload it only to the "new" ECR Repo in the CaaS account.
This causes the latest image to be only in the "new" ECR repo and updating an agent using the "old" ECR repo to fail.

This PR will make the image available also in the old repo.