### PR TITLE
Change setup.cfg to adhere to new setuptools format

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
`setuptools` most recent versions deprecated the `-` and only accept `_` in key names.