### PR TITLE
feat: merge connect_args from dc and external creds

### DIFF
--- a/apollo/credentials/asm.py
+++ b/apollo/credentials/asm.py
@@ -22,7 +22,11 @@ class AwsSecretsManagerCredentialsService(BaseCredentialsService):
                 raise ValueError(
                     f"Failed to fetch credentials from AWS Secrets Manager: No secret string found for secret name: {secret_name}"
                 )
-            return json.loads(secret_str)
+            external_credentials = json.loads(secret_str)
+            return self._merge_connect_args(
+                incoming_credentials=credentials,
+                external_credentials=external_credentials,
+            )
         except Exception as e:
             raise ValueError(
                 f"Failed to fetch credentials from AWS Secrets Manager: {e}"

--- a/apollo/credentials/asm.py
+++ b/apollo/credentials/asm.py
@@ -11,7 +11,7 @@ class AwsSecretsManagerCredentialsService(BaseCredentialsService):
     Credentials service that fetches credentials from AWS Secrets Manager.
     """
 
-    def get_credentials(self, credentials: dict) -> dict:
+    def _load_external_credentials(self, credentials: dict) -> dict:
         secret_name = credentials.get(SECRET_NAME)
         if not secret_name:
             raise ValueError("Missing expected secret name 'aws_secret' in credentials")
@@ -22,11 +22,7 @@ class AwsSecretsManagerCredentialsService(BaseCredentialsService):
                 raise ValueError(
                     f"Failed to fetch credentials from AWS Secrets Manager: No secret string found for secret name: {secret_name}"
                 )
-            external_credentials = json.loads(secret_str)
-            return self._merge_connect_args(
-                incoming_credentials=credentials,
-                external_credentials=external_credentials,
-            )
+            return json.loads(secret_str)
         except Exception as e:
             raise ValueError(
                 f"Failed to fetch credentials from AWS Secrets Manager: {e}"

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -5,6 +5,13 @@ class BaseCredentialsService:
     """
 
     def get_credentials(self, credentials: dict) -> dict:
+        external_credentials = self._load_external_credentials(credentials)
+        return self._merge_connect_args(
+            incoming_credentials=credentials,
+            external_credentials=external_credentials,
+        )
+
+    def _load_external_credentials(self, credentials: dict) -> dict:
         return credentials
 
     def _merge_connect_args(

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -17,8 +17,10 @@ class BaseCredentialsService:
         """
         incoming_connect_args = incoming_credentials.get("connect_args", {})
         external_connect_args = external_credentials.get("connect_args", {})
-        external_credentials["connect_args"] = {
+        merged_connect_args = {
             **incoming_connect_args,
             **external_connect_args,
         }
+        if merged_connect_args:
+            external_credentials["connect_args"] = merged_connect_args
         return external_credentials

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -6,3 +6,19 @@ class BaseCredentialsService:
 
     def get_credentials(self, credentials: dict) -> dict:
         return credentials
+
+    def _merge_connect_args(
+        self, incoming_credentials: dict, external_credentials: dict
+    ) -> dict:
+        """
+        Merges the 'connect_args' objects from the incoming credentials (from the service node)
+        and the external credentials (provided by the customer).
+        Returns the external credentials containing the merged 'connect_args' object.
+        """
+        incoming_connect_args = incoming_credentials.get("connect_args", {})
+        external_connect_args = external_credentials.get("connect_args", {})
+        external_credentials["connect_args"] = {
+            **incoming_connect_args,
+            **external_connect_args,
+        }
+        return external_credentials

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -15,12 +15,25 @@ class BaseCredentialsService:
         and the external credentials (provided by the customer).
         Returns the external credentials containing the merged 'connect_args' object.
         """
-        incoming_connect_args = incoming_credentials.get("connect_args", {})
-        external_connect_args = external_credentials.get("connect_args", {})
+        incoming_connect_args = incoming_credentials.get("connect_args")
+        external_connect_args = external_credentials.get("connect_args")
+        if not incoming_connect_args:
+            # when incoming credentials don't have connect args, return external credentials as is
+            return external_credentials
+        if not external_connect_args:
+            # when external credentials don't have connect args, return incoming connect args
+            external_credentials["connect_args"] = incoming_connect_args
+            return external_credentials
+        if not isinstance(external_connect_args, dict) or not isinstance(
+            incoming_connect_args, dict
+        ):
+            # when connect args is not a dict (could be a connection string), return
+            # external credentials as is
+            return external_credentials
+        # merge the connect args dicts, external credentials take precedence
         merged_connect_args = {
             **incoming_connect_args,
             **external_connect_args,
         }
-        if merged_connect_args:
-            external_credentials["connect_args"] = merged_connect_args
+        external_credentials["connect_args"] = merged_connect_args
         return external_credentials

--- a/apollo/credentials/env_var.py
+++ b/apollo/credentials/env_var.py
@@ -28,6 +28,10 @@ class EnvVarCredentialsService(BaseCredentialsService):
             env_var_credentials, credentials
         )
         try:
-            return json.loads(env_var_credentials)
+            external_credentials = json.loads(env_var_credentials)
+            return self._merge_connect_args(
+                incoming_credentials=credentials,
+                external_credentials=external_credentials,
+            )
         except Exception:
             raise ValueError(f"Invalid JSON in environment variable: {env_var_name}")

--- a/apollo/credentials/env_var.py
+++ b/apollo/credentials/env_var.py
@@ -12,7 +12,7 @@ class EnvVarCredentialsService(BaseCredentialsService):
     and decrypts them if necessary.
     """
 
-    def get_credentials(self, credentials: dict) -> dict:
+    def _load_external_credentials(self, credentials: dict) -> dict:
         env_var_name = credentials.get(ENV_VAR_NAME)
         if not env_var_name:
             raise ValueError(
@@ -28,10 +28,6 @@ class EnvVarCredentialsService(BaseCredentialsService):
             env_var_credentials, credentials
         )
         try:
-            external_credentials = json.loads(env_var_credentials)
-            return self._merge_connect_args(
-                incoming_credentials=credentials,
-                external_credentials=external_credentials,
-            )
+            return json.loads(env_var_credentials)
         except Exception:
             raise ValueError(f"Invalid JSON in environment variable: {env_var_name}")

--- a/tests/credentials/test_asm.py
+++ b/tests/credentials/test_asm.py
@@ -114,3 +114,19 @@ class TestAwsSecretsManagerCredentialsService(TestCase):
         self.assertTrue(
             "No secret string found for secret name" in str(context.exception)
         )
+
+    @patch("apollo.credentials.asm.SecretsManagerProxyClient")
+    def test_get_credentials_merge_connect_args(self, mock_client_class: Mock):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.get_secret_string.return_value = (
+            '{"connect_args": {"password": "secret"}}'
+        )
+        credentials = {
+            SECRET_NAME: "test-secret",
+            "connect_args": {"username": "test"},
+        }
+        result = self.service.get_credentials(credentials)
+        self.assertEqual(
+            {"connect_args": {"username": "test", "password": "secret"}}, result
+        )

--- a/tests/credentials/test_env_var.py
+++ b/tests/credentials/test_env_var.py
@@ -60,3 +60,15 @@ class TestEnvVarCredentialsService(TestCase):
             )
 
             self.assertEqual({"key": "decrypted_value"}, credentials)
+
+    def test_get_credentials_merge_connect_args(self):
+        with patch.dict(
+            os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'}
+        ):
+            credentials = self.service.get_credentials(
+                {"env_var_name": "TEST_CREDS", "connect_args": {"username": "test"}}
+            )
+            self.assertEqual(
+                {"connect_args": {"username": "test", "password": "secret"}},
+                credentials,
+            )

--- a/tests/credentials/test_env_var.py
+++ b/tests/credentials/test_env_var.py
@@ -72,3 +72,23 @@ class TestEnvVarCredentialsService(TestCase):
                 {"connect_args": {"username": "test", "password": "secret"}},
                 credentials,
             )
+        # test merge credentials when connect_args is a string
+        with patch.dict(
+            os.environ, {"TEST_CREDS": '{"connect_args": "external connect args"}'}
+        ):
+            credentials = self.service.get_credentials(
+                {"env_var_name": "TEST_CREDS", "connect_args": "incoming connect args"}
+            )
+            self.assertEqual(
+                {"connect_args": "external connect args"},
+                credentials,
+            )
+        # test merge credentials when internal connect_args is not provided
+        with patch.dict(
+            os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'}
+        ):
+            credentials = self.service.get_credentials({"env_var_name": "TEST_CREDS"})
+            self.assertEqual(
+                {"connect_args": {"password": "secret"}},
+                credentials,
+            )


### PR DESCRIPTION
in the DC we specify some hard coded values that we want to include in `connect_args`. instead of requiring customers to include these hard coded values in their self-hosted creds, lets merge the `connect_args` objects from the DC and provided by the customer

context: https://montecarlodata.slack.com/archives/C083XJFGN2X/p1744323378271009

- [x] Unit tests
- [x] Deployed to dev