### PR TITLE
Upgrade teradatasql (VULN-555)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 # using master branch to get urllib3 dependency updated to ==2.2.2, switch to v0.32 when released
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
 
-teradatasql>=20.0.0.25
+teradatasql>=20.0.0.26
 oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 # Note this is a beta version of impyla that is needed in order to support HTTPS connections on python 3.12.

--- a/requirements.txt
+++ b/requirements.txt
@@ -280,7 +280,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tableauserverclient @ git+https://github.com/tableau/server-client-python.git@master ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.25
+teradatasql==20.0.0.29
     # via -r requirements.in
 thrift==0.16.0
     # via


### PR DESCRIPTION
Upgrade `teradata` to upgrade golang.org/x/crypto crypto version to 0.36.0

See: https://github.com/Teradata/python-driver?tab=readme-ov-file#change-log