### PR TITLE
Update runtime to pick up latest openssl lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN apt install git -y
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
-FROM public.ecr.aws/lambda/python:3.12.2024.11.14.18 AS lambda-builder
+FROM public.ecr.aws/lambda/python:3.12.2025.04.28.11 AS lambda-builder
 
 RUN dnf update -y
 # install git as we need it for the direct oscrypto dependency
@@ -97,7 +97,7 @@ RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" \
     -r requirements.txt \
     -r requirements-lambda.txt
 
-FROM public.ecr.aws/lambda/python:3.12.2024.11.14.18 AS lambda
+FROM public.ecr.aws/lambda/python:3.12.2025.04.28.11 AS lambda
 
 # VULN-423: setuptools 68.0.0 contains (CVE-2024-6345)
 RUN pip install --no-cache-dir setuptools==75.1.0


### PR DESCRIPTION
**How I tested this change:**

From my local machine:
```sh
cd apollo-agent
docker build -t lambda_agent --target lambda --platform=linux/amd64 .
docker run --entrypoint /bin/sh --rm --platform linux/amd64 -it lambda_agent
```
Then from inside the container:
```sh
sh-5.2# ls -R / | grep -Ei "ssl.*so"
libssl.so.3
libssl.so.3.2.2
SSLeay.so
_ssl.cpython-312-x86_64-linux-gnu.so
mybusinesslodging.v1.json
libssl-3e69114b.so.1.1
ssl_wrap_socket.py
ssl_wrap_socket.cpython-312.pyc
TSSLSocket.py
TSSLSocket.cpython-312.opt-1.pyc
TSSLSocket.cpython-312.pyc

sh-5.2# python -c "import ssl; print(ssl.OPENSSL_VERSION)"
OpenSSL 3.2.2 4 Jun 2024
```

So it looks like `public.ecr.aws/lambda/python:3.12.2025.04.28.11` now includes OpenSSL version 3.2.2 🎉 

- [x] deployed to `dev`