### PR TITLE
vuln updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,12 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -U pip==25.0.0  # VUL
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloudrun.txt
 
 RUN apt update
-RUN apt install git -y
+# [VULN-606] update krb5 (kerberos) to 1.20.1-2+deb12u3
+# [VULN-602] update passwd to 1:4.13+dfsg1-1+deb12u1
+RUN apt install git -y && apt install -y --only-upgrade libgssapi-krb5-2=1.20.1-2+deb12u3 \
+    libkrb5-3=1.20.1-2+deb12u3 \
+    libkrb5support0=1.20.1-2+deb12u3 \
+    passwd=1:4.13+dfsg1-1+deb12u1
 
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
@@ -146,10 +151,11 @@ RUN apt-get install -y git wget  # VULN-543 upgrade wget
 # to downgrade some pre-installed packages.
 # Updating libgnutls30 to resolve CVE-2024-28835 and CVE-2024-28834.
 # Updating libglib to resolve CVE-2024-52533.
+# Updating OpenSSL to resolve CVE-2024-13176
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https libgnutls30 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 odbcinst=2.3.11-2+deb12u1 odbcinst1debian2=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1 \
-    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.15-1~deb12u1 libglib2.0-0
+    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.16-1~deb12u1 libglib2.0-0
 
 # delete this file that includes an old golang version (including vulns) and is not used
 RUN rm -rf /opt/startupcmdgen/


### PR DESCRIPTION
Minor dependency updates to address vulnerabilities.

cloudrun agent:
- update kerberos (CVE-2024-26462) and passwd (CVE-2023-4641 and CVE-2023-29383)

azure agent:
- update openssl (CVE-2024-13176)