### PR TITLE
VULN-597: Upgraded libcap2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
-RUN apt-get install -y git
+RUN apt-get install -y git \
+    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Upgrade pip globally to fix the vulnerability - VULN-510
 RUN pip install --no-cache-dir -U pip==25.0.0
@@ -33,6 +34,7 @@ RUN . $VENV_DIR/bin/activate && pip install setuptools==75.1.0
 # Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
 # [VULN-602] update passwd to 1:4.13+dfsg1-1+deb12u1
 # [VULN-606] update krb5 (kerberos) to 1.20.1-2+deb12u3
+# [VULN-607] update libcap2 to 1:2.66-4+deb12u1
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -41,7 +43,8 @@ RUN apt-get update \
     && apt-get update \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc unixodbc-dev \
     && apt-get install -y passwd=1:4.13+dfsg1-1+deb12u1 \
-    && apt-get install -y libgssapi-krb5-2=1.20.1-2+deb12u3 libkrb5-3=1.20.1-2+deb12u3 libkrb5support0=1.20.1-2+deb12u3
+    && apt-get install -y libgssapi-krb5-2=1.20.1-2+deb12u3 libkrb5-3=1.20.1-2+deb12u3 libkrb5support0=1.20.1-2+deb12u3 \
+    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # copy sources in the last step so we don't install python libraries due to a change in source code
 COPY apollo/ ./apollo
@@ -84,6 +87,7 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloud
 
 RUN apt update
 RUN apt install git -y
+RUN apt install libcap2=1:2.66-4+deb12u1 -y  # Fix CVE-2025-1390
 
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
@@ -143,6 +147,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git wget  # VULN-543 upgrade wget
+RUN apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Azure database clients and sql-server uses pyodbc which requires unixODBC and 'ODBC Driver 17
 # for SQL Server' Microsoft's python 3.12 base image comes with msodbcsql18 but we are expecting to


### PR DESCRIPTION
## Summary

This PR addresses a security vulnerability related to the system package **libcap2** by:

- Explicitly installing/upgrading `libcap2` to version `1:2.66-4+deb12u1` in the Dockerfile to resolve CVE-2025-1390.
- Documenting the process for fixing vulnerabilities, rebuilding Docker images, and verifying that the correct library versions are installed, in a new section in `README.md`.

## Details

- Updated the Dockerfile to ensure `libcap2=1:2.66-4+deb12u1` is installed in all relevant build stages.
- Added a new section to `README.md`:
  - How to update system and Python dependencies when a vulnerability is reported.
  - How to rebuild the Docker image locally.
  - How to verify that the correct library versions are installed in the image (for both Python and system packages).
  - How to run tests in Docker to ensure everything works as expected.

## How to Test

1. **Rebuild the Docker image:**  
   ```sh
   docker build -t local_agent --target generic --platform=linux/amd64 .
   ```

2. **Verify libcap2 version:**  
   ```sh
   docker run --rm local_agent dpkg -l | grep libcap2
   ```
   This should show `libcap2` at version `1:2.66-4+deb12u1`.

3. **Run tests in Docker (optional):**  
   ```sh
   docker build -t test_agent --target tests --platform=linux/amd64 --build-arg CACHEBUST="`date`" --progress=plain .
   ```

## Notes

- Please review the new `README.md` section for a step-by-step guide on fixing vulnerabilities and verifying upgrades.
- No changes were made to Python dependencies in this PR.
