### PR TITLE
Set Image Tag for CircleCI Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,9 @@ jobs:
           command: make VERSION=<< parameters.code_version >> publish-docs
 
   update-and-validate-golden-agent:
-    executor: aws-cli/default
+    executor:
+      name: aws-cli/default
+      tag: current-22.04
     parameters:
       use_aws_cli:
         description: Use the AWS CLI to perform the update
@@ -327,7 +329,6 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: gcp-dev-update-and-validate-golden-agent
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -344,7 +345,6 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: az-dev-update-and-validate-golden-agent
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
@@ -362,7 +362,6 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: gcp-prod-update-and-validate-golden-agent-merge-queue
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -379,7 +378,6 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: az-prod-update-and-validate-golden-agent-merge-queue
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
@@ -416,7 +414,6 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: aws-dev-update-and-validate-golden-agent
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -433,7 +430,6 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: aws-prod-update-and-validate-golden-agent-merge-queue
-          tag: current-22.04
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
@@ -487,7 +483,6 @@ workflows:
               ignore: /.*/
       - update-and-validate-golden-agent:
           name: gcp-prod-update-and-validate-golden-agent
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${VERSION_TAG}
           pre-steps:
@@ -499,7 +494,6 @@ workflows:
             - build-and-push-prod
       - update-and-validate-golden-agent:
           name: az-prod-update-and-validate-golden-agent
-          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${VERSION_TAG}
           sleep_seconds: "120"
@@ -531,7 +525,6 @@ workflows:
               ignore: /.*/
       - update-and-validate-golden-agent:
           name: aws-prod-update-and-validate-golden-agent
-          tag: current-22.04
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${VERSION_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,9 +249,9 @@ jobs:
           name: Install dependencies
           command: |
             curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-            python get-pip.py
-            pip install --no-cache-dir --upgrade pip
-            pip install --no-cache-dir montecarlodata
+            python get-pip.py --break-system-packages
+            pip install --no-cache-dir --upgrade pip --break-system-package
+            pip install --no-cache-dir montecarlodata --break-system-package
       - when:
           condition:
             equal: [ true, << parameters.use_aws_cli >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,9 +249,9 @@ jobs:
           name: Install dependencies
           command: |
             curl https://bootstrap.pypa.io/get-pip.py > get-pip.py
-            python get-pip.py --break-system-packages
-            pip install --no-cache-dir --upgrade pip --break-system-package
-            pip install --no-cache-dir montecarlodata --break-system-package
+            python get-pip.py
+            pip install --no-cache-dir --upgrade pip
+            pip install --no-cache-dir montecarlodata
       - when:
           condition:
             equal: [ true, << parameters.use_aws_cli >> ]
@@ -327,6 +327,7 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: gcp-dev-update-and-validate-golden-agent
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -343,6 +344,7 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: az-dev-update-and-validate-golden-agent
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
@@ -360,6 +362,7 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: gcp-prod-update-and-validate-golden-agent-merge-queue
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -376,6 +379,7 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: az-prod-update-and-validate-golden-agent-merge-queue
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${NEXT_VERSION}
           sleep_seconds: "120"
@@ -412,6 +416,7 @@ workflows:
                 - /.*\/pr-.*/
       - update-and-validate-golden-agent:
           name: aws-dev-update-and-validate-golden-agent
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
           image_repo: pre-release-agent
@@ -428,6 +433,7 @@ workflows:
                 - dev
       - update-and-validate-golden-agent:
           name: aws-prod-update-and-validate-golden-agent-merge-queue
+          tag: current-22.04
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${NEXT_VERSION}
@@ -481,6 +487,7 @@ workflows:
               ignore: /.*/
       - update-and-validate-golden-agent:
           name: gcp-prod-update-and-validate-golden-agent
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_GCP_AGENT}
           agent_version: ${VERSION_TAG}
           pre-steps:
@@ -492,6 +499,7 @@ workflows:
             - build-and-push-prod
       - update-and-validate-golden-agent:
           name: az-prod-update-and-validate-golden-agent
+          tag: current-22.04
           agent_uuid: ${MCD_AGENT_UUID_WITH_AZ_AGENT}
           agent_version: ${VERSION_TAG}
           sleep_seconds: "120"
@@ -523,6 +531,7 @@ workflows:
               ignore: /.*/
       - update-and-validate-golden-agent:
           name: aws-prod-update-and-validate-golden-agent
+          tag: current-22.04
           use_aws_cli: true
           agent_uuid: ${MCD_AGENT_UUID_WITH_AWS_AGENT}
           agent_version: ${VERSION_TAG}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
-RUN apt-get install -y git
+RUN apt-get install -y git \Add commentMore actions
+    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Upgrade pip globally to fix the vulnerability - VULN-510
 RUN pip install --no-cache-dir -U pip==25.0.0
@@ -33,7 +34,7 @@ RUN . $VENV_DIR/bin/activate && pip install setuptools==75.1.0
 # Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
 # [VULN-602] update passwd to 1:4.13+dfsg1-1+deb12u1
 # [VULN-606] update krb5 (kerberos) to 1.20.1-2+deb12u3
-# [VULN-XXX] update libcap2 to 1:2.66-4+deb12u1
+# [VULN-607] update libcap2 to 1:2.66-4+deb12u1
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -43,7 +44,7 @@ RUN apt-get update \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc unixodbc-dev \
     && apt-get install -y passwd=1:4.13+dfsg1-1+deb12u1 \
     && apt-get install -y libgssapi-krb5-2=1.20.1-2+deb12u3 libkrb5-3=1.20.1-2+deb12u3 libkrb5support0=1.20.1-2+deb12u3 \
-    && apt-get install -y libcap2=1:2.66-4+deb12u1
+    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # copy sources in the last step so we don't install python libraries due to a change in source code
 COPY apollo/ ./apollo
@@ -86,6 +87,7 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloud
 
 RUN apt update
 RUN apt install git -y
+RUN apt install libcap2=1:2.66-4+deb12u1 -y  # Fix CVE-2025-1390
 
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
@@ -145,6 +147,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git wget  # VULN-543 upgrade wget
+RUN apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Azure database clients and sql-server uses pyodbc which requires unixODBC and 'ODBC Driver 17
 # for SQL Server' Microsoft's python 3.12 base image comes with msodbcsql18 but we are expecting to
@@ -156,8 +159,7 @@ RUN apt-get install -y git wget  # VULN-543 upgrade wget
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https libgnutls30 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 odbcinst=2.3.11-2+deb12u1 odbcinst1debian2=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1 \
-    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.16-1~deb12u1 libglib2.0-0 \
-    && apt-get install -y libcap2=1:2.66-4+deb12u1
+    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.16-1~deb12u1 libglib2.0-0
 
 # delete this file that includes an old golang version (including vulns) and is not used
 RUN rm -rf /opt/startupcmdgen/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
-RUN apt-get install -y git \Add commentMore actions
+RUN apt-get install -y git \
     && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Upgrade pip globally to fix the vulnerability - VULN-510

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN apt-get update
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
 # see: https://community.snowflake.com/s/article/Python-Connector-fails-to-connect-with-LibraryNotFoundError-Error-detecting-the-version-of-libcrypto
-RUN apt-get install -y git \
-    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
+RUN apt-get install -y git
 
 # Upgrade pip globally to fix the vulnerability - VULN-510
 RUN pip install --no-cache-dir -U pip==25.0.0
@@ -34,7 +33,7 @@ RUN . $VENV_DIR/bin/activate && pip install setuptools==75.1.0
 # Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
 # [VULN-602] update passwd to 1:4.13+dfsg1-1+deb12u1
 # [VULN-606] update krb5 (kerberos) to 1.20.1-2+deb12u3
-# [VULN-607] update libcap2 to 1:2.66-4+deb12u1
+# [VULN-XXX] update libcap2 to 1:2.66-4+deb12u1
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https \
     && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -44,7 +43,7 @@ RUN apt-get update \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc unixodbc-dev \
     && apt-get install -y passwd=1:4.13+dfsg1-1+deb12u1 \
     && apt-get install -y libgssapi-krb5-2=1.20.1-2+deb12u3 libkrb5-3=1.20.1-2+deb12u3 libkrb5support0=1.20.1-2+deb12u3 \
-    && apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
+    && apt-get install -y libcap2=1:2.66-4+deb12u1
 
 # copy sources in the last step so we don't install python libraries due to a change in source code
 COPY apollo/ ./apollo
@@ -87,7 +86,6 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloud
 
 RUN apt update
 RUN apt install git -y
-RUN apt install libcap2=1:2.66-4+deb12u1 -y  # Fix CVE-2025-1390
 
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
@@ -147,7 +145,6 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y git wget  # VULN-543 upgrade wget
-RUN apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 
 # Azure database clients and sql-server uses pyodbc which requires unixODBC and 'ODBC Driver 17
 # for SQL Server' Microsoft's python 3.12 base image comes with msodbcsql18 but we are expecting to
@@ -159,7 +156,8 @@ RUN apt-get install -y libcap2=1:2.66-4+deb12u1  # Fix CVE-2025-1390
 RUN apt-get update \
     && apt-get install -y gnupg gnupg2 gnupg1 curl apt-transport-https libgnutls30 \
     && ACCEPT_EULA=Y apt-get install -y msodbcsql17 odbcinst=2.3.11-2+deb12u1 odbcinst1debian2=2.3.11-2+deb12u1 unixodbc-dev=2.3.11-2+deb12u1 unixodbc=2.3.11-2+deb12u1 \
-    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.16-1~deb12u1 libglib2.0-0
+    && apt-get install -y sqlite3=3.40.1-2+deb12u1 openssl=3.0.16-1~deb12u1 libglib2.0-0 \
+    && apt-get install -y libcap2=1:2.66-4+deb12u1
 
 # delete this file that includes an old golang version (including vulns) and is not used
 RUN rm -rf /opt/startupcmdgen/


### PR DESCRIPTION
- The `aws-cli` orb released a new version, 5.4.0, which uses the CircleCI docker image tag `current`
- CircleCI made an update to the `current` tag to use Ubuntu 24 instead of 22. This broke our CI build when trying to use `pip install`