### PR TITLE
MES-1507: Add salesforce-crm client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,6 @@ cython_debug/
 
 # direnv
 /.envrc
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -7,11 +7,13 @@ deployment options.
 ## Local development environment
 ### Pre-requisites
 - Python 3.12 or later
+- If you are on a Mac, you'll need to [install a driver manager for ODBC](https://github.com/mkleehammer/pyodbc/wiki/Install#installing-on-macosx): `brew install unixodbc`.
 
 ### Prepare your local environment
 - Create a virtual env, for example: `python -m venv .venv` and activate it: `. .venv/bin/activate`
   - If you don't use the virtual env in `.venv` you must create a symbolic link: `ln -s VENV_DIR .venv` because pyright requires the virtual env to be in `.venv` directory.
-- Install the required libraries: `pip install -r requirements.txt -r requirements-dev.txt -r requirements-cloudrun.txt`
+- Install the required libraries: `pip install -r requirements.txt -r requirements-dev.txt -r requirements-cloudrun.txt -r requirements-azure.txt -r requirements-lambda.txt`
+- If you're on a Mac and the `pyodbc` version is < 5.1.0, [try installing by compiling from source](https://github.com/mkleehammer/pyodbc/wiki/Install#installing-on-macosx): `pip install --no-binary=pyodbc pyodbc`.
 - Install the pre-commit hooks: `pre-commit install`
 
 ### Tests execution

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -299,7 +299,7 @@ _CLIENT_FACTORY_MAPPING = {
     "msk-connect": _get_proxy_client_msk_connect,
     "msk-kafka": _get_proxy_client_msk_kafka,
     "dremio": _get_proxy_client_dremio,
-    "salesforce_crm": _get_proxy_client_salesforce_crm,
+    "salesforce-crm": _get_proxy_client_salesforce_crm,
 }
 
 

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -255,6 +255,16 @@ def _get_proxy_client_dremio(
     return DremioProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_salesforce_crm(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.salesforce_crm_proxy_client import (
+        SalesforceCRMProxyClient,
+    )
+
+    return SalesforceCRMProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -289,6 +299,7 @@ _CLIENT_FACTORY_MAPPING = {
     "msk-connect": _get_proxy_client_msk_connect,
     "msk-kafka": _get_proxy_client_msk_kafka,
     "dremio": _get_proxy_client_dremio,
+    "salesforce_crm": _get_proxy_client_salesforce_crm,
 }
 
 

--- a/apollo/integrations/db/salesforce_crm_proxy_client.py
+++ b/apollo/integrations/db/salesforce_crm_proxy_client.py
@@ -38,21 +38,25 @@ class SalesforceCRMProxyClient(BaseDbProxyClient):
             records = [[row.get(field) for field in field_names] for row in records_raw]
         description = self._infer_cursor_description(records_raw[0])
 
+        for record in records:
+            for i in range(len(record)):
+                print(description[i][0:2], record[i])
+
         return {"records": records, "rowcount": rowcount, "description": description}
 
-    def describe_global(self):
+    def describe_global(self) -> Dict:
         results = self._connection.describe()
         if results:
             return {"objects": results["sobjects"]}
         else:
             return {"objects": []}
 
-    def describe_object(self, object_name: str):
+    def describe_object(self, object_name: str) -> Dict:
         salesforce_object = getattr(self._connection, object_name)
         results = salesforce_object.describe()
         return {"object_description": results}
 
-    def _infer_cursor_description(self, row: dict):
+    def _infer_cursor_description(self, row: dict) -> List[Tuple]:
         def infer_type(value: Any) -> str:
             if value is None:
                 return "str"

--- a/apollo/integrations/db/salesforce_crm_proxy_client.py
+++ b/apollo/integrations/db/salesforce_crm_proxy_client.py
@@ -9,7 +9,7 @@ _ATTR_CONNECT_ARGS = "connect_args"
 
 class SalesforceCRMProxyClient(BaseDbProxyClient):
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
-        super().__init__(connection_type="salesforce_crm")
+        super().__init__(connection_type="salesforce-crm")
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Salesforce CRM agent client requires {_ATTR_CONNECT_ARGS} in credentials"

--- a/apollo/integrations/db/salesforce_crm_proxy_client.py
+++ b/apollo/integrations/db/salesforce_crm_proxy_client.py
@@ -55,10 +55,10 @@ class SalesforceCRMProxyClient(BaseDbProxyClient):
         return {"object_description": results}
 
     def _infer_cursor_description(self, row: dict):
-        def infer_type(value: Any) -> Any:
+        def infer_type(value: Any) -> str:
             if value is None:
-                return str
-            return type(value)
+                return "str"
+            return type(value).__name__
 
         return [
             (

--- a/apollo/integrations/db/salesforce_crm_proxy_client.py
+++ b/apollo/integrations/db/salesforce_crm_proxy_client.py
@@ -15,7 +15,6 @@ class SalesforceCRMProxyClient(BaseDbProxyClient):
                 f"Salesforce CRM agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
         self._connection = Salesforce(**credentials[_ATTR_CONNECT_ARGS])  # type: ignore
-        print("Salesforce CRM connection established")
 
     @property
     def wrapped_client(self):
@@ -39,7 +38,6 @@ class SalesforceCRMProxyClient(BaseDbProxyClient):
             records = [[row.get(field) for field in field_names] for row in records_raw]
         description = self._infer_cursor_description(records_raw[0])
 
-        print(f"Query results: {records}")
         return {"records": records, "rowcount": rowcount, "description": description}
 
     def describe_global(self):

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -794,7 +794,7 @@ def test_network_http_connection_get() -> Tuple[Dict, int]:
                     description: The trace_id passed as an input parameter.
             example:
                 __mcd_result__:
-                    message: URL https://getmontecarlo.com responded with status code: 200.
+                    message: "URL https://getmontecarlo.com responded with status code: 200."
                 __mcd_trace_id__: 324986b4-b185-4187-b4af-b0c2cd60f7a0
     responses:
         200:

--- a/requirements.in
+++ b/requirements.in
@@ -31,6 +31,7 @@ pyOpenSSL>=24.2.1
 requests>=2.32.0
 RestrictedPython==8.0
 retry2==0.9.5
+simple-salesforce==1.12.6
 snowflake-connector-python>=3.13.1
 # python_version conditions below to resolve urllib3 compatibility issues with snowflake-connector-python
 tableauserverclient==0.25 ; python_version < "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ attrs==23.2.0
     # via
     #   cattrs
     #   looker-sdk
+    #   zeep
 azure-common==1.1.28
     # via azure-mgmt-storage
 azure-core==1.31.0
@@ -136,6 +137,7 @@ isodate==0.6.1
     # via
     #   azure-mgmt-storage
     #   azure-storage-blob
+    #   zeep
 itsdangerous==2.2.0
     # via flask
 jinja2==3.1.6
@@ -150,6 +152,8 @@ lambda-git==0.1.1
     # via -r requirements.in
 looker-sdk==24.2.0
     # via -r requirements.in
+lxml==5.4.0
+    # via zeep
 lz4==4.3.3
     # via databricks-sql-connector
 markupsafe==2.1.5
@@ -158,6 +162,8 @@ markupsafe==2.1.5
     #   werkzeug
 marshmallow==3.21.3
     # via dataclasses-json
+more-itertools==10.7.0
+    # via simple-salesforce
 msal==1.31.0
     # via
     #   -r requirements.in
@@ -190,7 +196,9 @@ packaging==24.1
 pandas==2.1.1
     # via databricks-sql-connector
 platformdirs==4.3.6
-    # via snowflake-connector-python
+    # via
+    #   snowflake-connector-python
+    #   zeep
 portalocker==2.10.1
     # via msal-extensions
 presto-python-client==0.8.3
@@ -225,6 +233,7 @@ pyjwt[crypto]==2.8.0
     # via
     #   -r requirements.in
     #   msal
+    #   simple-salesforce
     #   snowflake-connector-python
 pymysql==1.1.1
     # via -r requirements.in
@@ -244,6 +253,7 @@ pytz==2024.1
     # via
     #   pandas
     #   snowflake-connector-python
+    #   zeep
 requests==2.32.3
     # via
     #   -r requirements.in
@@ -255,8 +265,16 @@ requests==2.32.3
     #   looker-sdk
     #   msal
     #   presto-python-client
+    #   requests-file
+    #   requests-toolbelt
+    #   simple-salesforce
     #   snowflake-connector-python
     #   tableauserverclient
+    #   zeep
+requests-file==2.1.0
+    # via zeep
+requests-toolbelt==1.0.0
+    # via zeep
 restrictedpython==8.0
     # via -r requirements.in
 retry2==0.9.5
@@ -265,6 +283,8 @@ rsa==4.9
     # via google-auth
 s3transfer==0.10.2
     # via boto3
+simple-salesforce==1.12.6
+    # via -r requirements.in
 six==1.16.0
     # via
     #   azure-core
@@ -297,6 +317,7 @@ typing-extensions==4.12.2
     #   azure-identity
     #   azure-storage-blob
     #   looker-sdk
+    #   simple-salesforce
     #   snowflake-connector-python
     #   tableauserverclient
     #   typing-inspect
@@ -316,3 +337,5 @@ werkzeug==3.1.0
     # via
     #   -r requirements.in
     #   flask
+zeep==4.3.1
+    # via simple-salesforce

--- a/tests/test_salesforce_crm_client.py
+++ b/tests/test_salesforce_crm_client.py
@@ -42,7 +42,7 @@ class SalesforceCRMProxyClientTests(TestCase):
         # Verify connection is set
         self.assertEqual(client._connection, mock_sf_instance)
         # Verify connection type
-        self.assertEqual(client._connection_type, "salesforce_crm")
+        self.assertEqual(client._connection_type, "salesforce-crm")
 
     @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
     def test_wrapped_client_property(self, mock_salesforce: MagicMock):

--- a/tests/test_salesforce_crm_client.py
+++ b/tests/test_salesforce_crm_client.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from apollo.integrations.db.salesforce_crm_proxy_client import SalesforceCRMProxyClient
+
+
+class SalesforceCRMProxyClientTests(TestCase):
+    def setUp(self):
+        self.credentials = {
+            "connect_args": {
+                "username": "test@example.com",
+                "password": "password123",
+                "security_token": "token123",
+            },
+        }
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute(self, mock_salesforce):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+        client._connection.query = MagicMock()
+        client._connection.query.return_value = {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Account",
+                        "url": "/services/data/v59.0/sobjects/Account/001gL0000071FgvQAE",
+                    },
+                    "Id": "001gL0000071FgvQAE",
+                    "IsDeleted": False,
+                    "ParentId": None,
+                    "AccountNumber": "CD451796",
+                    "Name": "Edge Communications",
+                    "Phone": "(512) 757-6000",
+                    "Website": "http://edgecomm.com",
+                    "CreatedDate": "2025-05-22T14:46:46.000+0000",
+                    "AnnualRevenue": 139000000.0,
+                },
+            ],
+        }
+        query = (
+            "SELECT Id, IsDeleted, ParentId, AccountNumber, Name, Phone, Website, CreatedDate, AnnualRevenue "
+            "FROM Account "
+            "LIMIT 1"
+        )
+        result = client.execute(query)
+
+        # Check records
+        expected_records = [
+            [
+                "001gL0000071FgvQAE",
+                False,
+                None,
+                "CD451796",
+                "Edge Communications",
+                "(512) 757-6000",
+                "http://edgecomm.com",
+                "2025-05-22T14:46:46.000+0000",
+                139000000.0,
+            ]
+        ]
+        self.assertEqual(result["records"], expected_records)
+
+        # Check rowcount
+        self.assertEqual(result["rowcount"], 1)
+
+        # Check description
+        expected_description = [
+            ("Id", "str", None, None, None, None, None),
+            ("IsDeleted", "bool", None, None, None, None, None),
+            ("ParentId", "str", None, None, None, None, None),
+            ("AccountNumber", "str", None, None, None, None, None),
+            ("Name", "str", None, None, None, None, None),
+            ("Phone", "str", None, None, None, None, None),
+            ("Website", "str", None, None, None, None, None),
+            ("CreatedDate", "str", None, None, None, None, None),
+            ("AnnualRevenue", "float", None, None, None, None, None),
+        ]
+        self.assertEqual(result["description"], expected_description)

--- a/tests/test_salesforce_crm_client.py
+++ b/tests/test_salesforce_crm_client.py
@@ -14,11 +14,159 @@ class SalesforceCRMProxyClientTests(TestCase):
             },
         }
 
+    # Constructor/Initialization Tests
+    def test_init_missing_credentials(self):
+        with self.assertRaises(ValueError) as context:
+            SalesforceCRMProxyClient(credentials=None)
+        self.assertIn("connect_args", str(context.exception))
+
+    def test_init_empty_credentials(self):
+        with self.assertRaises(ValueError) as context:
+            SalesforceCRMProxyClient(credentials={})
+        self.assertIn("connect_args", str(context.exception))
+
+    def test_init_missing_connect_args(self):
+        with self.assertRaises(ValueError) as context:
+            SalesforceCRMProxyClient(credentials={"other_key": "value"})
+        self.assertIn("connect_args", str(context.exception))
+
     @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
-    def test_execute(self, mock_salesforce):
+    def test_init_successful(self, mock_salesforce: MagicMock):
+        mock_sf_instance = MagicMock()
+        mock_salesforce.return_value = mock_sf_instance
+
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        # Verify Salesforce was called with correct arguments
+        mock_salesforce.assert_called_once_with(**self.credentials["connect_args"])
+        # Verify connection is set
+        self.assertEqual(client._connection, mock_sf_instance)
+        # Verify connection type
+        self.assertEqual(client._connection_type, "salesforce_crm")
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_wrapped_client_property(self, mock_salesforce: MagicMock):
+        mock_sf_instance = MagicMock()
+        mock_salesforce.return_value = mock_sf_instance
+
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        self.assertEqual(client.wrapped_client, mock_sf_instance)
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_close_method(self, mock_salesforce: MagicMock):
         mock_salesforce.return_value = MagicMock()
         client = SalesforceCRMProxyClient(credentials=self.credentials)
-        client._connection.query = MagicMock()
+
+        # Should not raise any exception
+        client.close()
+
+    # Filter attributes tests
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_infer_cursor_description_filters_attributes(
+        self, mock_salesforce: MagicMock
+    ):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        test_row = {
+            "attributes": {"type": "Account", "url": "/test"},
+            "Id": "001ABC123",
+            "Name": "Test Account",
+        }
+
+        description = client._infer_cursor_description(test_row)
+
+        # Should not include attributes field
+        field_names = [desc[0] for desc in description]
+        self.assertNotIn("attributes", field_names)
+        self.assertIn("Id", field_names)
+        self.assertIn("Name", field_names)
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_filters_attributes_from_records(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        client._connection.query.return_value = {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {"type": "Account", "url": "/test"},
+                    "Id": "001ABC123",
+                    "Name": "Test Account",
+                }
+            ],
+        }
+
+        result = client.execute("SELECT Id, Name FROM Account")
+
+        # Should only have Id and Name values, not attributes
+        expected_records = [["001ABC123", "Test Account"]]
+        self.assertEqual(result["records"], expected_records)
+
+    # Describe Methods Tests
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_describe_global(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        mock_sobjects = [
+            {"name": "Account", "label": "Account", "custom": False},
+            {"name": "Contact", "label": "Contact", "custom": False},
+            {"name": "CustomObject__c", "label": "Custom Object", "custom": True},
+        ]
+        client._connection.describe.return_value = {"sobjects": mock_sobjects}
+
+        result = client.describe_global()
+
+        self.assertEqual(result["objects"], mock_sobjects)
+        client._connection.describe.assert_called_once()
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_describe_global_empty_results(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        client._connection.describe.return_value = None
+
+        result = client.describe_global()
+
+        self.assertEqual(result["objects"], [])
+        client._connection.describe.assert_called_once()
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_describe_object(self, mock_salesforce: MagicMock):
+        mock_connection = MagicMock()
+        mock_salesforce.return_value = mock_connection
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        mock_object_description = {
+            "name": "Account",
+            "label": "Account",
+            "fields": [
+                {"name": "Id", "type": "id", "label": "Account ID"},
+                {"name": "Name", "type": "string", "label": "Account Name"},
+            ],
+        }
+
+        # Mock the salesforce object by setting it as an attribute on the connection
+        mock_sf_object = MagicMock()
+        mock_sf_object.describe.return_value = mock_object_description
+
+        # Set the Account attribute directly on the mock connection
+        setattr(mock_connection, "Account", mock_sf_object)
+
+        result = client.describe_object("Account")
+
+        self.assertEqual(result["object_description"], mock_object_description)
+        mock_sf_object.describe.assert_called_once()
+
+    # Execute Method Tests
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
         client._connection.query.return_value = {
             "totalSize": 1,
             "records": [
@@ -78,3 +226,321 @@ class SalesforceCRMProxyClientTests(TestCase):
             ("AnnualRevenue", "float", None, None, None, None, None),
         ]
         self.assertEqual(result["description"], expected_description)
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_empty_results(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+        client._connection.query.return_value = {"totalSize": 0, "records": []}
+
+        result = client.execute("SELECT Id FROM Account WHERE 1=0")
+
+        self.assertEqual(result["rowcount"], 0)
+        self.assertEqual(result["records"], [])
+        self.assertEqual(result["description"], [])
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_with_null_values(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+        client._connection.query.return_value = {
+            "totalSize": 2,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Account",
+                        "url": "/services/data/v59.0/sobjects/Account/001",
+                    },
+                    "Id": "001ABC123",
+                    "Name": "Test Account",
+                    "Phone": None,
+                    "Website": None,
+                    "AnnualRevenue": None,
+                },
+                {
+                    "attributes": {
+                        "type": "Account",
+                        "url": "/services/data/v59.0/sobjects/Account/002",
+                    },
+                    "Id": "002DEF456",
+                    "Name": None,
+                    "Phone": "(555) 123-4567",
+                    "Website": "https://example.com",
+                    "AnnualRevenue": 1000000.0,
+                },
+            ],
+        }
+
+        result = client.execute(
+            "SELECT Id, Name, Phone, Website, AnnualRevenue FROM Account"
+        )
+
+        expected_records = [
+            ["001ABC123", "Test Account", None, None, None],
+            ["002DEF456", None, "(555) 123-4567", "https://example.com", 1000000.0],
+        ]
+        self.assertEqual(result["records"], expected_records)
+        self.assertEqual(result["rowcount"], 2)
+
+        # Check that description handles null values correctly
+        expected_description = [
+            ("Id", "str", None, None, None, None, None),
+            ("Name", "str", None, None, None, None, None),
+            ("Phone", "str", None, None, None, None, None),
+            ("Website", "str", None, None, None, None, None),
+            (
+                "AnnualRevenue",
+                "str",
+                None,
+                None,
+                None,
+                None,
+                None,
+            ),  # TODO: None in first row infers to str
+        ]
+        self.assertEqual(result["description"], expected_description)
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_different_data_types(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        # Test with different data types
+        test_datetime = "2025-01-15T10:30:45.000+0000"
+        test_decimal = 12345.67
+        test_boolean = True
+        test_integer = 42
+
+        client._connection.query.return_value = {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Opportunity",
+                        "url": "/services/data/v59.0/sobjects/Opportunity/006",
+                    },
+                    "Id": "006XYZ789",
+                    "Name": "Big Deal",
+                    "Amount": test_decimal,
+                    "IsClosed": test_boolean,
+                    "CreatedDate": test_datetime,
+                    "NumberOfEmployees": test_integer,
+                }
+            ],
+        }
+
+        result = client.execute(
+            "SELECT Id, Name, Amount, IsClosed, CreatedDate, NumberOfEmployees FROM Opportunity"
+        )
+
+        expected_records = [
+            [
+                "006XYZ789",
+                "Big Deal",
+                test_decimal,
+                test_boolean,
+                test_datetime,
+                test_integer,
+            ]
+        ]
+        self.assertEqual(result["records"], expected_records)
+        self.assertEqual(result["rowcount"], 1)
+
+        # Check type inference for different data types
+        expected_description = [
+            ("Id", "str", None, None, None, None, None),
+            ("Name", "str", None, None, None, None, None),
+            ("Amount", "float", None, None, None, None, None),
+            ("IsClosed", "bool", None, None, None, None, None),
+            ("CreatedDate", "str", None, None, None, None, None),
+            ("NumberOfEmployees", "int", None, None, None, None, None),
+        ]
+        self.assertEqual(result["description"], expected_description)
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_large_result_set(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        # Create multiple records
+        records = []
+        for i in range(5000):
+            records.append(
+                {
+                    "attributes": {
+                        "type": "Contact",
+                        "url": f"/services/data/v59.0/sobjects/Contact/00{i}",
+                    },
+                    "Id": f"00{i}ABC{i}{i}{i}",
+                    "FirstName": f"First{i}",
+                    "LastName": f"Last{i}",
+                    "Email": f"test{i}@example.com",
+                }
+            )
+
+        client._connection.query.return_value = {"totalSize": 5000, "records": records}
+
+        result = client.execute(
+            "SELECT Id, FirstName, LastName, Email FROM Contact LIMIT 5"
+        )
+
+        expected_records = [
+            [f"00{i}ABC{i}{i}{i}", f"First{i}", f"Last{i}", f"test{i}@example.com"]
+            for i in range(5000)
+        ]
+        self.assertEqual(result["records"], expected_records)
+        self.assertEqual(result["rowcount"], 5000)
+        self.assertEqual(len(result["description"]), 4)  # 4 fields
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_realistic_account_query(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        client._connection.query.return_value = {
+            "totalSize": 2,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Account",
+                        "url": "/services/data/v59.0/sobjects/Account/001",
+                    },
+                    "Id": "001ABC123DEF456",
+                    "Name": "Acme Corporation",
+                    "Type": "Customer - Direct",
+                    "Industry": "Technology",
+                    "AnnualRevenue": 5000000.00,
+                    "NumberOfEmployees": 250,
+                    "BillingCity": "San Francisco",
+                    "BillingState": "CA",
+                    "CreatedDate": "2024-01-15T08:30:00.000+0000",
+                },
+                {
+                    "attributes": {
+                        "type": "Account",
+                        "url": "/services/data/v59.0/sobjects/Account/002",
+                    },
+                    "Id": "002GHI789JKL012",
+                    "Name": "Global Industries Inc",
+                    "Type": "Prospect",
+                    "Industry": "Manufacturing",
+                    "AnnualRevenue": 12000000.00,
+                    "NumberOfEmployees": 500,
+                    "BillingCity": "New York",
+                    "BillingState": "NY",
+                    "CreatedDate": "2024-02-20T14:45:30.000+0000",
+                },
+            ],
+        }
+
+        query = """
+        SELECT Id, Name, Type, Industry, AnnualRevenue, NumberOfEmployees,
+               BillingCity, BillingState, CreatedDate
+        FROM Account
+        WHERE Industry IN ('Technology', 'Manufacturing')
+        ORDER BY CreatedDate DESC
+        LIMIT 10
+        """
+
+        result = client.execute(query)
+
+        self.assertEqual(result["rowcount"], 2)
+        self.assertEqual(len(result["records"]), 2)
+        self.assertEqual(len(result["description"]), 9)  # 9 fields selected
+
+        # Verify first record
+        first_record = result["records"][0]
+        self.assertEqual(first_record[0], "001ABC123DEF456")  # Id
+        self.assertEqual(first_record[1], "Acme Corporation")  # Name
+        self.assertEqual(first_record[2], "Customer - Direct")  # Type
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_contact_with_relationships(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        client._connection.query.return_value = {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {
+                        "type": "Contact",
+                        "url": "/services/data/v59.0/sobjects/Contact/003",
+                    },
+                    "Id": "003MNO345PQR678",
+                    "FirstName": "John",
+                    "LastName": "Doe",
+                    "Email": "john.doe@example.com",
+                    "AccountId": "001ABC123DEF456",
+                    "Account": {
+                        "attributes": {
+                            "type": "Account",
+                            "url": "/services/data/v59.0/sobjects/Account/001",
+                        },
+                        "Name": "Acme Corporation",
+                    },
+                }
+            ],
+        }
+
+        result = client.execute(
+            "SELECT Id, FirstName, LastName, Email, AccountId, Account.Name FROM Contact"
+        )
+        account_name_dict = {
+            "attributes": {
+                "type": "Account",
+                "url": "/services/data/v59.0/sobjects/Account/001",
+            },
+            "Name": "Acme Corporation",
+        }
+
+        self.assertEqual(result["rowcount"], 1)
+        record = result["records"][0]
+
+        self.assertEqual(record[0], "003MNO345PQR678")  # Id
+        self.assertEqual(record[1], "John")  # FirstName
+        self.assertEqual(record[2], "Doe")  # LastName
+        self.assertEqual(record[3], "john.doe@example.com")  # Email
+        self.assertEqual(record[4], "001ABC123DEF456")  # AccountId
+        self.assertEqual(record[5], account_name_dict)  # TODO: Handle nested dict
+
+    @patch("apollo.integrations.db.salesforce_crm_proxy_client.Salesforce")
+    def test_execute_with_complex_nested_data(self, mock_salesforce: MagicMock):
+        mock_salesforce.return_value = MagicMock()
+        client = SalesforceCRMProxyClient(credentials=self.credentials)
+
+        client._connection.query.return_value = {
+            "totalSize": 1,
+            "records": [
+                {
+                    "attributes": {"type": "Opportunity", "url": "/test"},
+                    "Id": "006ABC123",
+                    "Name": "Big Deal",
+                    "Account": {
+                        "attributes": {"type": "Account", "url": "/test"},
+                        "Id": "001DEF456",
+                        "Name": "Customer Corp",
+                    },
+                    "OpportunityLineItems": {
+                        "totalSize": 2,
+                        "records": [
+                            {"Id": "00k111", "Quantity": 10},
+                            {"Id": "00k222", "Quantity": 5},
+                        ],
+                    },
+                }
+            ],
+        }
+
+        result = client.execute(
+            "SELECT Id, Name, Account.Name, (SELECT Id, Quantity FROM OpportunityLineItems) FROM Opportunity"
+        )
+
+        self.assertEqual(result["rowcount"], 1)
+        record = result["records"][0]
+        self.assertEqual(record[0], "006ABC123")  # Id
+        self.assertEqual(record[1], "Big Deal")  # Name
+        # Complex nested objects should be preserved as-is
+        # TODO: Handle nested dicts
+        self.assertIsInstance(record[2], dict)  # Account relationship
+        self.assertIsInstance(record[3], dict)  # OpportunityLineItems subquery


### PR DESCRIPTION
This PR is part of the initial support for the Salesforce CRM client implementation. It adds the agent client that will be called by the SalesforceProxyClient from the data-collector.

## Background

To begin implementing the Salesforce CRM integration, I'd like to merge and deploy the following 5 branches to production, in this order:

1. [toffermann/mes-1510-data-pipeline-support-salesforce-crm-connection-type](https://github.com/monte-carlo-data/saas-serverless/tree/toffermann/mes-1510-data-pipeline-support-salesforce-crm-connection-type)

1. [toffermann/mes-1507-agent-add-salesforce-crm-client](https://github.com/monte-carlo-data/apollo-agent/tree/toffermann/mes-1507-agent-add-salesforce-crm-client)

1. [toffermann/mes-1506-collector-salesforce-crm-client-using-plugin-framework](https://github.com/monte-carlo-data/data-collector/tree/toffermann/mes-1506-collector-salesforce-crm-client-using-plugin-framework)

1. [toffermann/mes-1503-monolith-add-salesforce-crm-connection-and-warehouse-type](https://github.com/monte-carlo-data/monolith-django/tree/toffermann/mes-1503-monolith-add-salesforce-crm-connection-and-warehouse-type)

1. [toffermann/mes-1504-monolith-salesforce-crm-onboarding-mutations](https://github.com/monte-carlo-data/monolith-django/tree/toffermann/mes-1504-monolith-salesforce-crm-onboarding-mutations)

Even after all 5 PRs are merged, this integration will not be available for customers yet. However, it will have the ability to perform the metadata job. Support for custom sql monitoring will come in future PRs.

See the SDD for background: https://www.notion.so/montecarlodata/SDD-Salesforce-CRM-Integration-1f8334399e65809e989dead441e5ab55?source=copy_link
