### PR TITLE
Support for multiple Teradata SSL connections

### DIFF
--- a/apollo/integrations/db/teradata_proxy_client.py
+++ b/apollo/integrations/db/teradata_proxy_client.py
@@ -1,3 +1,4 @@
+import hashlib
 from typing import (
     Any,
     Dict,
@@ -33,9 +34,15 @@ class TeradataProxyClient(BaseDbProxyClient):
             # Purposely a quoted boolean per teradatasql documentation
             connect_args["encryptdata"] = "true"
 
-            # Path to PEM file that contains Certificate Authority (CA) certificates
+            # Path to PEM file that contains Certificate Authority (CA) certificates.
+            # Use the hashed host name in the temp file name to distinguish between
+            # connections if there are multiple teradata connections using SSL through
+            # this agent.
+            hashed_host = hashlib.sha256(
+                connect_args.get("host", "").encode()
+            ).hexdigest()[:12]
             connect_args["sslca"] = ssl_options.write_ca_data_to_temp_file(
-                "/tmp/teradata_ca.pem", upsert=True
+                f"/tmp/{hashed_host}_teradata_ca.pem", upsert=True
             )
 
             # Teradatasql has 2 port connection parameters depending on

--- a/apollo/integrations/db/teradata_proxy_client.py
+++ b/apollo/integrations/db/teradata_proxy_client.py
@@ -38,9 +38,9 @@ class TeradataProxyClient(BaseDbProxyClient):
             # Use the hashed host name in the temp file name to distinguish between
             # connections if there are multiple teradata connections using SSL through
             # this agent.
-            hashed_host = hashlib.sha256(
-                connect_args.get("host", "").encode()
-            ).hexdigest()[:12]
+            hashed_host = hashlib.sha256(connect_args.get("host").encode()).hexdigest()[
+                :12
+            ]
             connect_args["sslca"] = ssl_options.write_ca_data_to_temp_file(
                 f"/tmp/{hashed_host}_teradata_ca.pem", upsert=True
             )

--- a/tests/test_teradata_client.py
+++ b/tests/test_teradata_client.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 from copy import copy
 from typing import (
     Iterable,
@@ -57,7 +58,7 @@ class TeradataClientTests(TestCase):
             "https_port": _TERADATA_CREDENTIALS.get("dbs_port"),
             "sslmode": "VERIFY-FULL",
             "encryptdata": "true",
-            "sslca": "/tmp/teradata_ca.pem",
+            "sslca": f"/tmp/{hashlib.sha256(_TERADATA_CREDENTIALS.get('host').encode()).hexdigest()[:12]}_teradata_ca.pem",
         }
         mock_connect.assert_called_with(**expected_connection_parameters)
 


### PR DESCRIPTION
If Teradata SSL connection is used, CA data is written to a temp file to be provided to the Teradata client. Add a unique identifier to the temp file name in case there are multiple Teradata requests from different connections going through the agent. 