### PR TITLE
MES-1703: Add clickhouse client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -299,6 +299,16 @@ def _get_proxy_client_salesforce_data_cloud(
     return SalesforceDataCloudProxyClient(credentials=credentials)
 
 
+def _get_proxy_client_clickhouse(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.db.clickhouse_proxy_client import (
+        ClickHouseProxyClient,
+    )
+
+    return ClickHouseProxyClient(credentials=credentials, platform=platform)
+
+
 @dataclass
 class ProxyClientCacheEntry:
     created_time: datetime
@@ -335,6 +345,7 @@ _CLIENT_FACTORY_MAPPING = {
     "dremio": _get_proxy_client_dremio,
     "salesforce-crm": _get_proxy_client_salesforce_crm,
     "salesforce-data-cloud": _get_proxy_client_salesforce_data_cloud,
+    "clickhouse": _get_proxy_client_clickhouse,
 }
 
 

--- a/apollo/integrations/db/clickhouse_proxy_client.py
+++ b/apollo/integrations/db/clickhouse_proxy_client.py
@@ -1,0 +1,27 @@
+from typing import Any, Dict, Optional
+
+import clickhouse_connect.dbapi
+
+from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+class ClickHouseProxyClient(BaseDbProxyClient):
+    """
+    Proxy client for ClickHouse.
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        super().__init__(connection_type="clickhouse")
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Clickhouse agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+
+        connect_args = credentials[_ATTR_CONNECT_ARGS]
+        self._connection = clickhouse_connect.dbapi.connect(**connect_args)
+
+    @property
+    def wrapped_client(self):
+        return self._connection

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ azure-identity==1.18.0
 azure-mgmt-storage==21.2.1
 azure-storage-blob==12.23.0
 boto3==1.34.151
+clickhouse-connect==0.8.18
 cryptography>=44.0.1
 databricks-sql-connector==4.0.0
 databricks-sdk==0.39.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ cattrs==23.2.3
     # via looker-sdk
 certifi==2024.8.30
     # via
+    #   clickhouse-connect
     #   requests
     #   snowflake-connector-python
 cffi==1.16.0
@@ -60,6 +61,8 @@ click==8.1.7
     # via
     #   flask
     #   presto-python-client
+clickhouse-connect==0.8.18
+    # via -r requirements.in
 cryptography==44.0.1
     # via
     #   -r requirements.in
@@ -155,7 +158,9 @@ looker-sdk==24.2.0
 lxml==5.4.0
     # via zeep
 lz4==4.3.3
-    # via databricks-sql-connector
+    # via
+    #   clickhouse-connect
+    #   databricks-sql-connector
 markupsafe==2.1.5
     # via
     #   jinja2
@@ -257,6 +262,7 @@ python-dateutil==2.9.0.post0
     #   salesforce-cdp-connector
 pytz==2024.1
     # via
+    #   clickhouse-connect
     #   pandas
     #   snowflake-connector-python
     #   zeep
@@ -339,6 +345,7 @@ uritemplate==4.1.1
 urllib3==2.4.0
     # via
     #   botocore
+    #   clickhouse-connect
     #   databricks-sql-connector
     #   requests
     #   salesforce-cdp-connector
@@ -349,3 +356,5 @@ werkzeug==3.1.0
     #   flask
 zeep==4.3.1
     # via simple-salesforce
+zstandard==0.23.0
+    # via clickhouse-connect

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -1,0 +1,189 @@
+import datetime
+import decimal
+from typing import List, Any, Optional
+from unittest import TestCase
+from unittest.mock import Mock, call, patch
+
+from apollo.agent.agent import Agent
+from apollo.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.agent.logging_utils import LoggingUtils
+
+_CLICKHOUSE_CREDENTIALS = {
+    "host": "localhost",
+    "port": "8123",
+    "username": "u",
+    "password": "p",
+    "database": "db1",
+}
+
+
+class ClickHouseClientTests(TestCase):
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+        self._mock_connection = Mock()
+        self._mock_cursor = Mock()
+        self._mock_connection.cursor.return_value = self._mock_cursor
+
+    @patch("clickhouse_connect.dbapi.connect")
+    def test_query(self, mock_connect: Mock):
+        query = "SELECT id, name, price, xpos FROM table"  # noqa
+        expected_data = [
+            [
+                111,
+                "name_1",
+                decimal.Decimal("11.400"),
+                0.111429,
+            ],
+            [
+                222,
+                "name_2",
+                decimal.Decimal("22.210"),
+                0.254735,
+            ],
+        ]
+        expected_description = [
+            ["id", "UInt32", None, None, None, None, None],
+            ["name", "String", None, None, None, None, None],
+            ["price", "Decimal(18, 3)", None, None, None, None, None],
+            ["xpos", "Float64", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, expected_data, expected_description)
+
+    @patch("clickhouse_connect.dbapi.connect")
+    def test_datetime_query(self, mock_connect: Mock):
+        query = "SELECT name, created_date, updated_datetime FROM table"  # noqa
+        data = [
+            [
+                "name_1",
+                datetime.date.fromisoformat("2023-11-01"),
+                datetime.datetime.fromisoformat("2023-11-01T10:59:00"),
+            ],
+        ]
+        description = [
+            ["name", "String", None, None, None, None, None],
+            ["created_date", "Date", None, None, None, None, None],
+            ["updated_datetime", "DateTime", None, None, None, None, None],
+        ]
+        self._test_run_query(mock_connect, query, data, description)
+
+    def _test_run_query(
+        self,
+        mock_connect: Mock,
+        query: str,
+        data: List,
+        description: List,
+        raise_exception: Optional[Exception] = None,
+        expected_error_type: Optional[str] = None,
+    ):
+        operation_dict = {
+            "trace_id": "1234",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "target": "_cursor",
+                    "method": "execute",
+                    "args": [
+                        query,
+                        None,
+                    ],
+                },
+                {"target": "_cursor", "method": "fetchall", "store": "tmp_1"},
+                {"target": "_cursor", "method": "description", "store": "tmp_2"},
+                {"target": "_cursor", "method": "rowcount", "store": "tmp_3"},
+                {
+                    "target": "__utils",
+                    "method": "build_dict",
+                    "kwargs": {
+                        "all_results": {"__reference__": "tmp_1"},
+                        "description": {"__reference__": "tmp_2"},
+                        "rowcount": {"__reference__": "tmp_3"},
+                    },
+                },
+            ],
+        }
+        mock_connect.return_value = self._mock_connection
+
+        expected_rows = len(data)
+
+        if raise_exception:
+            self._mock_cursor.execute.side_effect = raise_exception
+        self._mock_cursor.fetchall.return_value = data
+        self._mock_cursor.description.return_value = description
+        self._mock_cursor.rowcount.return_value = expected_rows
+
+        response = self._agent.execute_operation(
+            "clickhouse",
+            "run_query",
+            operation_dict,
+            {
+                "connect_args": _CLICKHOUSE_CREDENTIALS,
+            },
+        )
+
+        if raise_exception:
+            self.assertEqual(
+                str(raise_exception), response.result.get(ATTRIBUTE_NAME_ERROR)
+            )
+            self.assertEqual(
+                expected_error_type, response.result.get(ATTRIBUTE_NAME_ERROR_TYPE)
+            )
+            return
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
+        result = response.result.get(ATTRIBUTE_NAME_RESULT)
+        print(result)
+
+        mock_connect.assert_called_with(
+            **_CLICKHOUSE_CREDENTIALS,
+        )
+        self._mock_cursor.execute.assert_has_calls(
+            [
+                call(query, None),
+            ]
+        )
+        self._mock_cursor.description.assert_called()
+        self._mock_cursor.rowcount.assert_called()
+
+        expected_data = self._serialized_data(data)
+        self.assertTrue("all_results" in result)
+        self.assertEqual(expected_data, result["all_results"])
+
+        self.assertTrue("description" in result)
+        self.assertEqual(description, result["description"])
+
+        self.assertTrue("rowcount" in result)
+        self.assertEqual(expected_rows, result["rowcount"])
+
+    @classmethod
+    def _serialized_data(cls, data: List) -> List:
+        return [cls._serialized_row(v) for v in data]
+
+    @classmethod
+    def _serialized_row(cls, row: List) -> List:
+        return [cls._serialized_value(v) for v in row]
+
+    @classmethod
+    def _serialized_value(cls, value: Any) -> Any:
+        if isinstance(value, datetime.datetime):
+            return {
+                "__type__": "datetime",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, datetime.date):
+            return {
+                "__type__": "date",
+                "__data__": value.isoformat(),
+            }
+        elif isinstance(value, decimal.Decimal):
+            return {
+                "__type__": "decimal",
+                "__data__": str(value),
+            }
+        else:
+            return value


### PR DESCRIPTION
The `clickhouse-connect` package ([official python client library from Clickhouse](https://clickhouse.com/docs/integrations/python)) provides an implementation of the DB-API. Plus, gathering metadata in Clickhouse is done by running SQL queries against system tables.

Both of those things mean that our clickhouse agent can be a standard plugin/transactional-db proxy client. Other than creating the connection, `ClickhouseProxyClient` should be able to use the `BaseDbProxyClient` entirely as-is.