### PR TITLE
Prevent Salesforce Data Cloud from revoking access tokens

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -286,7 +286,9 @@ def _get_proxy_client_salesforce_data_cloud(
     core_token = connect_args.get("core_token")
     refresh_token = connect_args.get("refresh_token")
 
-    if not all([domain, client_id, client_secret, core_token, refresh_token]):
+    if not all([domain, client_id, client_secret]) or not any(
+        [core_token, refresh_token]
+    ):
         raise ValueError("Missing required connection parameters")
 
     credentials = SalesforceDataCloudCredentials(

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,3 +5,4 @@ pre-commit==3.5.0
 pyright==1.1.337
 pytest==7.4.2
 python-box==7.1.1
+responses==0.23.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,8 +10,16 @@ blinker==1.8.2
     # via
     #   -c requirements.txt
     #   flask
+certifi==2024.8.30
+    # via
+    #   -c requirements.txt
+    #   requests
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.3.2
+    # via
+    #   -c requirements.txt
+    #   requests
 click==8.1.7
     # via
     #   -c requirements.txt
@@ -31,6 +39,10 @@ flask-swagger==0.2.14
     # via -r requirements-dev.in
 identify==2.5.36
     # via pre-commit
+idna==3.7
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 itsdangerous==2.2.0
@@ -80,6 +92,20 @@ pyyaml==6.0.1
     # via
     #   flask-swagger
     #   pre-commit
+    #   responses
+requests==2.32.3
+    # via
+    #   -c requirements.txt
+    #   responses
+responses==0.23.3
+    # via -r requirements-dev.in
+types-pyyaml==6.0.12.20250516
+    # via responses
+urllib3==2.4.0
+    # via
+    #   -c requirements.txt
+    #   requests
+    #   responses
 virtualenv==20.26.3
     # via pre-commit
 werkzeug==3.1.0

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1,5 +1,9 @@
+import json
+import uuid
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
+
+import responses
 
 from apollo.agent.agent import Agent
 from apollo.agent.logging_utils import LoggingUtils
@@ -13,15 +17,143 @@ class SalesforceDataCloudProxyClientTests(TestCase):
                 "domain": "test.salesforce.com",
                 "client_id": "test_client_id",
                 "client_secret": "test_client_secret",
-                "core_token": "test_core_token",
-                "refresh_token": "test_refresh_token",
+                "core_token": "test_core_token",  # Default is client credentials which only has core_token
             }
         }
 
-    @patch(
-        "apollo.integrations.db.salesforce_data_cloud_proxy_client.SalesforceCDPConnection"
-    )
-    def test_init(self, mock_connection):
+        self.mock_responses = responses.RequestsMock()
+        self.mock_responses.start()
+
+        self.addCleanup(self.mock_responses.stop)
+        self.addCleanup(self.mock_responses.reset)
+
+        self.setup_salesforce_data_cloud_api()
+
+    def setup_salesforce_data_cloud_api(self):
+        self.metadata_response = [
+            {
+                "name": "Account",
+                "displayName": "Account",
+                "fields": [
+                    {"name": "Id", "displayName": "Id", "type": "STRING"},
+                    {"name": "Name", "displayName": "Name", "type": "STRING"},
+                    {
+                        "name": "CreatedDate",
+                        "displayName": "Created Date",
+                        "type": "DATE_TIME",
+                    },
+                ],
+            },
+            {
+                "name": "Contact",
+                "displayName": "Contact",
+                "fields": [
+                    {"name": "Id", "displayName": "Id", "type": "STRING"},
+                    {
+                        "name": "FirstName",
+                        "displayName": "First Name",
+                        "type": "STRING",
+                    },
+                    {"name": "LastName", "displayName": "Last Name", "type": "STRING"},
+                    {"name": "Email", "displayName": "Email", "type": "STRING"},
+                ],
+            },
+            {
+                "name": "Opportunity",
+                "displayName": "Opportunity",
+                "fields": [
+                    {"name": "Id", "displayName": "Id", "type": "STRING"},
+                    {"name": "Amount", "displayName": "Amount", "type": "DECIMAL"},
+                    {
+                        "name": "CloseDate",
+                        "displayName": "Close Date",
+                        "type": "DATE_TIME",
+                    },
+                ],
+            },
+        ]
+
+        self.data_response = {
+            "data": [
+                ["Account1", "Active", "2021-09-16T16:26:36+00:00"],
+                ["Account2", "Inactive", "2023-01-02T14:20:00+00:00"],
+            ],
+            "startTime": "2022-03-07T19:57:19.374525Z",
+            "endTime": "2022-03-07T19:57:20.063372Z",
+            "rowCount": 3,
+            "queryId": "20220307_195719_00109_5frjj",
+            "nextBatchId": "fa489494-ff42-45ce-afd6-b838854b5a99",
+            "done": True,
+            "metadata": {
+                "Name": {
+                    "type": "VARCHAR",
+                    "placeInOrder": 0,
+                },
+                "Status": {
+                    "type": "VARCHAR",
+                    "placeInOrder": 1,
+                },
+                "CreatedDate": {
+                    "type": "TIMESTAMP",
+                    "placeInOrder": 2,
+                },
+            },
+        }
+
+        self.client_credentials_token = str(uuid.uuid4())
+        self.api_token = str(uuid.uuid4())
+
+        self.client_credentials_token_endpoint = Mock(
+            return_value=(
+                200,
+                {},
+                json.dumps({"access_token": self.client_credentials_token}),
+            )
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/oauth2/token",
+            callback=self.client_credentials_token_endpoint,
+        )
+
+        self.api_token_endpoint = Mock(
+            return_value=(
+                200,
+                {},
+                json.dumps(
+                    {
+                        "access_token": self.api_token,
+                        "expires_in": 3600,
+                        "instance_url": "test.salesforce.com",
+                    }
+                ),
+            )
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            callback=self.api_token_endpoint,
+        )
+
+        self.metadata_endpoint = Mock(
+            return_value=(200, {}, json.dumps({"metadata": self.metadata_response}))
+        )
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url="https://test.salesforce.com/api/v1/metadata",
+            callback=self.metadata_endpoint,
+        )
+
+        self.query_endpoint = Mock(
+            return_value=(200, {}, json.dumps(self.data_response))
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/api/v2/query",
+            callback=self.query_endpoint,
+        )
+
+    def test_init(self):
         # Test that the agent can create a SalesforceDataCloudProxyClient via execute_operation
         operation = {
             "trace_id": "test-trace-id",
@@ -36,38 +168,35 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             credentials=self.credentials,
         )
 
-        # Verify SalesforceCDPConnection was called with correct arguments
-        connect_args = self.credentials["connect_args"]
-        mock_connection.assert_called_once_with(
-            f"https://{connect_args['domain']}",
-            client_id=connect_args["client_id"],
-            client_secret=connect_args["client_secret"],
-            core_token=connect_args["core_token"],
-            refresh_token=connect_args["refresh_token"],
-        )
         # Verify the operation was successful and returned the connection type
         self.assertFalse(response.is_error)
         self.assertEqual(response.result["__mcd_result__"], "salesforce-data-cloud")
 
-    @patch(
-        "apollo.integrations.db.salesforce_data_cloud_proxy_client.SalesforceCDPConnection"
-    )
-    def test_list_tables(self, mock_connection):
-        salesforce_cdp_mock = mock_connection.return_value
+    def test_init_with_refresh_token(self):
+        # Test that the agent can create a SalesforceDataCloudProxyClient via execute_operation
+        operation = {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,  # Force a new client to be created
+            "commands": [{"method": "_connection_type"}],
+        }
 
-        # Create mock tables
-        mock_field1 = MagicMock(display_name="Field 1", type="string")
-        mock_field1.name = "field1"
+        del self.credentials["connect_args"][
+            "core_token"
+        ]  # Using refresh_token instead of core_token
+        self.credentials["connect_args"]["refresh_token"] = "required_but_not_used"
 
-        mock_field2 = MagicMock(display_name="Field 2", type="number")
-        mock_field2.name = "field2"
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_init",
+            operation_dict=operation,
+            credentials=self.credentials,
+        )
 
-        mock_table1 = MagicMock(display_name="Table 1", category="category1")
-        mock_table1.name = "table1"
-        mock_table1.fields = [mock_field1, mock_field2]
+        # Verify the operation was successful and returned the connection type
+        self.assertFalse(response.is_error)
+        self.assertEqual(response.result["__mcd_result__"], "salesforce-data-cloud")
 
-        salesforce_cdp_mock.list_tables.return_value = [mock_table1]
-
+    def test_list_tables(self):
         operation = {
             "trace_id": "test-trace-id",
             "skip_cache": True,  # Force a new client to be created
@@ -81,22 +210,58 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             credentials=self.credentials,
         )
 
-        # Verify list_tables was called
-        salesforce_cdp_mock.list_tables.assert_called_once()
+        tables = response.result["__mcd_result__"]
+        self.assertEqual(len(tables), len(self.metadata_response))
 
-        # Verify the operation was successful
-        self.assertFalse(response.is_error)
+        for mock_table in self.metadata_response:
+            table = next(t for t in tables if t.get("name") == mock_table["name"])
+            self.assertEqual(len(table["fields"]), len(mock_table["fields"]))
+            for mock_field in mock_table["fields"]:
+                field = next(
+                    f for f in table["fields"] if f.get("name") == mock_field["name"]
+                )
+                self.assertEqual(field.get("type"), mock_field["type"])
 
-        # Verify the result is correctly serialized
-        expected_result = [
+        # Verify that the metadata was cached and not re-fetched for fetch_columns
+        self.metadata_endpoint.assert_called_once()
+
+    def test_sql_query_execution(self):
+        sql_query = "SELECT Name, Status, CreatedDate FROM Account LIMIT 10"
+        commands = [
+            {"method": "cursor", "store": "_cursor"},
+            {"args": [sql_query], "method": "execute", "target": "_cursor"},
+            {"method": "fetchall", "store": "tmp_1", "target": "_cursor"},
+            {"method": "description", "store": "tmp_2", "target": "_cursor"},
+            {"method": "close", "target": "_cursor"},
             {
-                "name": "table1",
-                "display_name": "Table 1",
-                "category": "category1",
-                "fields": [
-                    {"name": "field1", "displayName": "Field 1", "type": "string"},
-                    {"name": "field2", "displayName": "Field 2", "type": "number"},
-                ],
-            }
+                "kwargs": {
+                    "all_results": {"__reference__": "tmp_1"},
+                    "description": {"__reference__": "tmp_2"},
+                },
+                "method": "build_dict",
+                "target": "__utils",
+            },
         ]
-        self.assertEqual(response.result["__mcd_result__"], expected_result)
+        operation = {
+            "commands": commands,
+            "skip_cache": True,
+            "trace_id": "f6e0e3fe-e03c-4f6f-9bfd-55478350ea45",
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_tables",
+            operation_dict=operation,
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error)
+        result = response.result["__mcd_result__"]
+
+        for i, row in enumerate(self.data_response["data"]):
+            self.assertEqual(result["all_results"][i][0], row[0])
+            self.assertEqual(result["all_results"][i][1], row[1])
+
+        for i, (key, value) in enumerate(self.data_response["metadata"].items()):
+            self.assertEqual(result["description"][i][0], key)
+            self.assertEqual(result["description"][i][1], value["type"])


### PR DESCRIPTION
This PR wraps the SalesforceCDPConnection to prevent it from revoking the core token. Details explained [in the comments](https://github.com/monte-carlo-data/apollo-agent/pull/202/files#diff-990f39cb62f6d7533fc25036b135d11eaaeef6d0a05dc7e628e548286e09d1abR20).