### PR TITLE
update Dockerfile dependencies to fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
 RUN . $VENV_DIR/bin/activate && pip install setuptools==75.1.0
 
 # Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
+# ODBC Driver 17's latest release was April, 2024. To patch vulnerabilities raised since then,
+# we have to apt-get those specific versions:
 # [VULN-602] update passwd to 1:4.13+dfsg1-1+deb12u1
 # [VULN-606] update krb5 (kerberos) to 1.20.1-2+deb12u3
 # [VULN-XXX] update libcap2 to 1:2.66-4+deb12u1


### PR DESCRIPTION
- Bumps the version on a few dependencies to resolve these build errors:
```
Version '1.20.1-2+deb12u3' for 'libgssapi-krb5-2' was not found
Version '1.20.1-2+deb12u3' for 'libkrb5-3' was not found
Version '1.20.1-2+deb12u3' for 'libkrb5support0' was not found
```