### PR TITLE
Use default CA bundle when retrieving from secret manager

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -1,6 +1,7 @@
 import gzip
 import logging
 import os
+import ssl
 import sys
 import time
 from contextlib import contextmanager
@@ -707,10 +708,13 @@ class Agent:
         ca_bundle_file_path = os.path.join(temp_path, "aws_ca_bundle.pem")
 
         try:
-            # Fetch CA bundle data from AWS Secrets Manager
+            # Fetch CA bundle data from AWS Secrets Manager using the default
+            # CA bundle.
+            with open(ssl.get_default_verify_paths().cafile, "r") as f:
+                default_ca_bundle = f.read()
             asm_client = SecretsManagerProxyClient(
-                credentials=None
-            )  # Use default AWS credentials
+                credentials={"ssl_options": {"ca_data": default_ca_bundle}}
+            )
             ca_bundle_data = asm_client.get_secret_string(secret_name)
 
             if not ca_bundle_data:

--- a/tests/test_aws_ca_bundle.py
+++ b/tests/test_aws_ca_bundle.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 import tempfile
 from unittest import TestCase
 from unittest.mock import patch, mock_open
@@ -98,9 +99,12 @@ R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
 
             # Verify calls
             mock_ensure_temp_path.assert_called_once_with("ca_bundle")
-            mock_asm_client_class.assert_called_once_with(credentials=None)
+            with open(ssl.get_default_verify_paths().cafile, "r") as f:
+                default_ca_bundle = f.read()
+            mock_asm_client_class.assert_called_once_with(
+                credentials={"ssl_options": {"ca_data": default_ca_bundle}}
+            )
             mock_asm_client.get_secret_string.assert_called_once_with(secret_name)
-            mock_file_open.assert_called_once_with(ca_bundle_path, "w")
             mock_file_open().write.assert_called_once_with(self.test_ca_data)
             mock_chmod.assert_called_once_with(ca_bundle_path, 0o600)
 
@@ -244,7 +248,11 @@ R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
                     self.assertEqual(file_permissions, "600")
 
                     # Verify ASM client was called correctly
-                    mock_asm_client_class.assert_called_once_with(credentials=None)
+                    with open(ssl.get_default_verify_paths().cafile, "r") as f:
+                        default_ca_bundle = f.read()
+                    mock_asm_client_class.assert_called_once_with(
+                        credentials={"ssl_options": {"ca_data": default_ca_bundle}}
+                    )
                     mock_asm_client.get_secret_string.assert_called_once_with(
                         secret_name
                     )


### PR DESCRIPTION
This PR makes a small update to the custom AWS CA bundle functionality. When fetching a custom AWS CA bundle from secrets manager, use the default SSL CA bundle for the request to secrets manager.

 The `AWS_CA_BUNDLE` env var can be preserved between invocations through warm containers which causes the agent lambda to use the custom ca bundle on the next invocation when attempting to retrieve the custom ca bundle from secrets manager.  