### PR TITLE
fix: Addressing CVE-2025-15467

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get install -y --no-install-recommends git
 RUN apt-get install -y --no-install-recommends libcrypt1
 # openssh-client required by git client
 RUN apt-get install -y openssh-client
+# CVE-2025-15467: OpenSSL stack-based OOB write in CMS AuthEnvelopedData (CRITICAL)
+# Upgrade openssl and libssl3 to patched version >= 3.5.4
+RUN apt-get install -y --no-install-recommends openssl libssl3
 
 RUN python -m venv $VENV_DIR
 RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
@@ -109,7 +112,8 @@ COPY --from=lambda-builder "${LAMBDA_TASK_ROOT}" "${LAMBDA_TASK_ROOT}"
 
 # install unixodbc and 'ODBC Driver 17 for SQL Server', needed for Azure Dedicated SQL Pools
 # install git needed for looker views collection
-RUN dnf -y update
+# CVE-2025-15467: upgrade openssl to patched version
+RUN dnf -y update openssl
 RUN dnf -y install unixODBC git
 RUN curl https://packages.microsoft.com/config/rhel/7/prod.repo \
     | tee /etc/yum.repos.d/mssql-release.repo

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ azure-mgmt-storage==21.2.1
 azure-storage-blob==12.23.0
 brotli==1.2.0  # Upgrade transient dependency of flask-compress to address SEC-1143 (CVE-2025-6176)
 clickhouse-connect==0.8.18
-cryptography>=44.0.1
+cryptography>=46.0.0  # CVE-2025-15467: ensure linkage against patched OpenSSL 3.5.4+
 databricks-sql-connector==4.0.0
 databricks-sdk==0.39.0
 duckdb==1.1.0
@@ -35,7 +35,7 @@ pycryptodome>=3.21.0
 pyjwt>=2.8.0
 PyMySQL>=1.1.1
 pyodbc==5.0.1
-pyOpenSSL>=24.2.1
+pyOpenSSL>=25.3.0  # CVE-2025-15467: supports cryptography 46.x
 RestrictedPython==8.0
 retry2==0.9.5
 salesforce-cdp-connector==1.0.16  # For Salesforce Data Cloud integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ click==8.1.7
     #   presto-python-client
 clickhouse-connect==0.8.18
     # via -r requirements.in
-cryptography==44.0.1
+cryptography==46.0.5
     # via
     #   -r requirements.in
     #   azure-identity
@@ -288,7 +288,7 @@ pymysql==1.1.1
     # via -r requirements.in
 pyodbc==5.0.1
     # via -r requirements.in
-pyopenssl==24.3.0
+pyopenssl==25.3.0
     # via
     #   -r requirements.in
     #   snowflake-connector-python


### PR DESCRIPTION
## Summary

Addresses **CVE-2025-15467** — a CRITICAL severity stack-based out-of-bounds write vulnerability in OpenSSL 3.x affecting CMS AuthEnvelopedData parsing with AEAD ciphers (e.g., AES-GCM).

### Vulnerability Details

| Field | Value |
|-------|-------|
| **CVE ID** | CVE-2025-15467 |
| **Severity** | CRITICAL |
| **Component** | OpenSSL 3.0–3.6 |
| **Attack Vector** | Network (unauthenticated) |
| **Impact** | Denial of Service / potential Remote Code Execution |
| **Fixed In** | OpenSSL 3.0.19, 3.3.6, 3.4.4, 3.5.5, 3.6.1+ |

### Root Cause

When parsing CMS AuthEnvelopedData structures using AEAD ciphers, the IV encoded in ASN.1 parameters is copied into a fixed-size stack buffer **without bounds checking**. An attacker can supply an oversized IV in a crafted CMS/PKCS#7 message to trigger a stack-based overflow **before** any authentication or tag verification occurs — no valid key material required.

### Changes

- **`Dockerfile` (base stage):** Explicitly installs patched `openssl` and `libssl3` via `apt-get` to ensure the Debian base image carries a fixed OpenSSL version.
- **`Dockerfile` (lambda stage):** Scoped `dnf update` to `openssl` only to apply the patch on Amazon Linux.
- **`requirements.in`:** Bumped `cryptography>=46.0.0` and `pyOpenSSL>=25.3.0` to ensure Python SSL bindings link against the patched OpenSSL library.
- **`requirements.txt`:** Updated compiled pins to `cryptography==46.0.5` and `pyopenssl==25.3.0`.

> **Note:** The `azure` stage already runs `apt-get upgrade -y` and is covered by that existing step — no additional change required there.

## Test plan

- [ ] Build `base` stage image and verify `openssl version` reports a patched version (>= 3.5.5 / 3.0.19)
- [ ] Build `lambda` stage image and confirm `openssl version` reflects the update
- [ ] Confirm `cryptography==46.0.5` and `pyopenssl==25.3.0` are installed in the venv
- [ ] Run existing test suite (`pytest tests`) — no regressions expected from the OpenSSL/cryptography bump
- [ ] Re-scan image with Trivy/Docker Scout and confirm CVE-2025-15467 is no longer reported