### PR TITLE
Add endpoint to discover custom integration manifests

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -387,6 +387,25 @@ class Agent:
                     "get_infra_details failed:"
                 )
 
+    def get_connection_manifests(self, trace_id: Optional[str]) -> AgentResponse:
+        """
+        Returns manifests, capabilities, and templates for all custom
+        integrations installed on this agent.
+        """
+        with self._inject_log_context("get_connection_manifests", trace_id):
+            try:
+                logger.info("get_connection_manifests requested")
+                from apollo.integrations.custom.custom_proxy_client import (
+                    CustomProxyClient,
+                )
+
+                manifests = CustomProxyClient.get_connection_manifests()
+                return AgentUtils.agent_ok_response(manifests, trace_id)
+            except Exception:  # noqa
+                return AgentUtils.agent_response_for_last_exception(
+                    "get_connection_manifests failed:"
+                )
+
     def _check_updater(self) -> AgentUpdater:
         if not self.updater:
             raise AgentConfigurationError("No updater configured")

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -390,7 +390,7 @@ class Agent:
     def get_connection_manifests(self, trace_id: Optional[str]) -> AgentResponse:
         """
         Returns manifests, capabilities, and templates for all custom
-        integrations installed on this agent.
+        connectors installed on this agent.
         """
         with self._inject_log_context("get_connection_manifests", trace_id):
             try:

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -460,13 +460,13 @@ class ProxyClientFactory:
                 credentials = decode_dictionary(credentials)
             return factory_method(credentials, platform=platform)
 
-        # Check custom integrations before raising an error (opt-in via env var)
-        if os.getenv("MCD_CUSTOM_INTEGRATIONS_ENABLED", "false").lower() == "true":
-            from apollo.integrations.custom.custom_integration_loader import (
-                get_custom_integration_registry,
+        # Check custom connectors before raising an error (opt-in via env var)
+        if os.getenv("MCD_CUSTOM_CONNECTORS_ENABLED", "false").lower() == "true":
+            from apollo.integrations.custom.custom_connector_loader import (
+                get_custom_connector_registry,
             )
 
-            custom_registry = get_custom_integration_registry()
+            custom_registry = get_custom_connector_registry()
             integration_dir = custom_registry.get(connection_type)
             if integration_dir:
                 if credentials:

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -340,11 +340,11 @@ def _get_proxy_client_db2(
 
 
 def _get_proxy_client_custom(
-    credentials: Optional[Dict], integration_dir: str, **kwargs  # type: ignore
+    credentials: Optional[Dict], connector_dir: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
     from apollo.integrations.custom.custom_proxy_client import CustomProxyClient
 
-    return CustomProxyClient(credentials=credentials, integration_dir=integration_dir)
+    return CustomProxyClient(credentials=credentials, connector_dir=connector_dir)
 
 
 @dataclass
@@ -467,12 +467,12 @@ class ProxyClientFactory:
             )
 
             custom_registry = get_custom_connector_registry()
-            integration_dir = custom_registry.get(connection_type)
-            if integration_dir:
+            connector_dir = custom_registry.get(connection_type)
+            if connector_dir:
                 if credentials:
                     credentials = decode_dictionary(credentials)
                 return _get_proxy_client_custom(
-                    credentials, integration_dir=integration_dir
+                    credentials, connector_dir=connector_dir
                 )
 
         raise AgentError(

--- a/apollo/integrations/custom/custom_connector_loader.py
+++ b/apollo/integrations/custom/custom_connector_loader.py
@@ -121,16 +121,3 @@ def load_manifest(connector_dir: str) -> Dict:
 
     with open(manifest_path) as f:
         return json.load(f)
-
-
-def load_capabilities(connector_dir: str) -> Dict:
-    """
-    Read capabilities.json from the connector directory.
-    Returns the parsed dict, or empty dict if not found.
-    """
-    capabilities_path = os.path.join(connector_dir, "capabilities.json")
-    if not os.path.isfile(capabilities_path):
-        return {}
-
-    with open(capabilities_path) as f:
-        return json.load(f)

--- a/apollo/integrations/custom/custom_connector_loader.py
+++ b/apollo/integrations/custom/custom_connector_loader.py
@@ -70,13 +70,13 @@ def get_custom_connector_registry() -> Dict[str, str]:
 
 def load_connector_module(connector_dir: str) -> types.ModuleType:
     """
-    Dynamically load integration.py from the given directory.
+    Dynamically load connector.py from the given directory.
     Uses a unique module name per connector to avoid namespace collisions.
     Returns the loaded module.
     """
-    module_path = os.path.join(connector_dir, "integration.py")
+    module_path = os.path.join(connector_dir, "connector.py")
     if not os.path.isfile(module_path):
-        raise FileNotFoundError(f"integration.py not found in {connector_dir}")
+        raise FileNotFoundError(f"connector.py not found in {connector_dir}")
 
     # Use directory name as part of module name for uniqueness
     dir_name = os.path.basename(connector_dir)

--- a/apollo/integrations/custom/custom_connector_loader.py
+++ b/apollo/integrations/custom/custom_connector_loader.py
@@ -26,11 +26,11 @@ def _discover_custom_connectors() -> Dict[str, str]:
         return registry
 
     for name in sorted(os.listdir(base_path)):
-        integration_dir = os.path.join(base_path, name)
-        if not os.path.isdir(integration_dir):
+        connector_dir = os.path.join(base_path, name)
+        if not os.path.isdir(connector_dir):
             continue
 
-        manifest_path = os.path.join(integration_dir, "manifest.json")
+        manifest_path = os.path.join(connector_dir, "manifest.json")
         if not os.path.isfile(manifest_path):
             logger.warning("Skipping custom connector %s: no manifest.json", name)
             continue
@@ -45,11 +45,11 @@ def _discover_custom_connectors() -> Dict[str, str]:
                     name,
                 )
                 continue
-            registry[connection_type] = integration_dir
+            registry[connection_type] = connector_dir
             logger.info(
                 "Discovered custom connector: %s -> %s",
                 connection_type,
-                integration_dir,
+                connector_dir,
             )
         except Exception:
             logger.exception("Failed to read manifest for custom connector %s", name)
@@ -68,18 +68,18 @@ def get_custom_connector_registry() -> Dict[str, str]:
     return _custom_connector_registry
 
 
-def load_integration_module(integration_dir: str) -> types.ModuleType:
+def load_connector_module(connector_dir: str) -> types.ModuleType:
     """
     Dynamically load integration.py from the given directory.
-    Uses a unique module name per integration to avoid namespace collisions.
+    Uses a unique module name per connector to avoid namespace collisions.
     Returns the loaded module.
     """
-    module_path = os.path.join(integration_dir, "integration.py")
+    module_path = os.path.join(connector_dir, "integration.py")
     if not os.path.isfile(module_path):
-        raise FileNotFoundError(f"integration.py not found in {integration_dir}")
+        raise FileNotFoundError(f"integration.py not found in {connector_dir}")
 
     # Use directory name as part of module name for uniqueness
-    dir_name = os.path.basename(integration_dir)
+    dir_name = os.path.basename(connector_dir)
     module_name = f"custom_connector_{dir_name}"
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
@@ -90,13 +90,13 @@ def load_integration_module(integration_dir: str) -> types.ModuleType:
     return module
 
 
-def load_templates(integration_dir: str) -> Dict[str, str]:
+def load_templates(connector_dir: str) -> Dict[str, str]:
     """
     Read all .j2 template files from the templates/ subdirectory.
     Returns {filename: content} mapping.
     """
     templates: Dict[str, str] = {}
-    templates_dir = os.path.join(integration_dir, "templates")
+    templates_dir = os.path.join(connector_dir, "templates")
 
     if not os.path.isdir(templates_dir):
         return templates
@@ -110,12 +110,12 @@ def load_templates(integration_dir: str) -> Dict[str, str]:
     return templates
 
 
-def load_manifest(integration_dir: str) -> Dict:
+def load_manifest(connector_dir: str) -> Dict:
     """
-    Read manifest.json from the integration directory.
+    Read manifest.json from the connector directory.
     Returns the parsed dict, or empty dict if not found.
     """
-    manifest_path = os.path.join(integration_dir, "manifest.json")
+    manifest_path = os.path.join(connector_dir, "manifest.json")
     if not os.path.isfile(manifest_path):
         return {}
 
@@ -123,12 +123,12 @@ def load_manifest(integration_dir: str) -> Dict:
         return json.load(f)
 
 
-def load_capabilities(integration_dir: str) -> Dict:
+def load_capabilities(connector_dir: str) -> Dict:
     """
-    Read capabilities.json from the integration directory.
+    Read capabilities.json from the connector directory.
     Returns the parsed dict, or empty dict if not found.
     """
-    capabilities_path = os.path.join(integration_dir, "capabilities.json")
+    capabilities_path = os.path.join(connector_dir, "capabilities.json")
     if not os.path.isfile(capabilities_path):
         return {}
 

--- a/apollo/integrations/custom/custom_connector_loader.py
+++ b/apollo/integrations/custom/custom_connector_loader.py
@@ -7,22 +7,22 @@ from typing import Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-_CUSTOM_INTEGRATIONS_BASE_PATH = "/opt/custom-integrations"
+_CUSTOM_CONNECTORS_BASE_PATH = "/opt/custom-connectors"
 
-# Module-level cache: {connection_type: integration_dir_path}
-_custom_integration_registry: Optional[Dict[str, str]] = None
+# Module-level cache: {connection_type: connector_dir_path}
+_custom_connector_registry: Optional[Dict[str, str]] = None
 
 
-def _discover_custom_integrations() -> Dict[str, str]:
+def _discover_custom_connectors() -> Dict[str, str]:
     """
-    Scan the custom integrations directory and build a mapping of
+    Scan the custom connectors directory and build a mapping of
     connection_type -> directory path by reading each manifest.json.
     """
     registry: Dict[str, str] = {}
-    base_path = _CUSTOM_INTEGRATIONS_BASE_PATH
+    base_path = _CUSTOM_CONNECTORS_BASE_PATH
 
     if not os.path.isdir(base_path):
-        logger.info("Custom integrations directory not found: %s", base_path)
+        logger.info("Custom connectors directory not found: %s", base_path)
         return registry
 
     for name in sorted(os.listdir(base_path)):
@@ -32,7 +32,7 @@ def _discover_custom_integrations() -> Dict[str, str]:
 
         manifest_path = os.path.join(integration_dir, "manifest.json")
         if not os.path.isfile(manifest_path):
-            logger.warning("Skipping custom integration %s: no manifest.json", name)
+            logger.warning("Skipping custom connector %s: no manifest.json", name)
             continue
 
         try:
@@ -41,31 +41,31 @@ def _discover_custom_integrations() -> Dict[str, str]:
             connection_type = manifest.get("connection_type")
             if not connection_type:
                 logger.warning(
-                    "Skipping custom integration %s: no connection_type in manifest",
+                    "Skipping custom connector %s: no connection_type in manifest",
                     name,
                 )
                 continue
             registry[connection_type] = integration_dir
             logger.info(
-                "Discovered custom integration: %s -> %s",
+                "Discovered custom connector: %s -> %s",
                 connection_type,
                 integration_dir,
             )
         except Exception:
-            logger.exception("Failed to read manifest for custom integration %s", name)
+            logger.exception("Failed to read manifest for custom connector %s", name)
 
     return registry
 
 
-def get_custom_integration_registry() -> Dict[str, str]:
+def get_custom_connector_registry() -> Dict[str, str]:
     """
-    Return the cached custom integration registry, discovering on first access.
+    Return the cached custom connector registry, discovering on first access.
     Contents are baked into the Docker image so they never change at runtime.
     """
-    global _custom_integration_registry
-    if _custom_integration_registry is None:
-        _custom_integration_registry = _discover_custom_integrations()
-    return _custom_integration_registry
+    global _custom_connector_registry
+    if _custom_connector_registry is None:
+        _custom_connector_registry = _discover_custom_connectors()
+    return _custom_connector_registry
 
 
 def load_integration_module(integration_dir: str) -> types.ModuleType:
@@ -80,7 +80,7 @@ def load_integration_module(integration_dir: str) -> types.ModuleType:
 
     # Use directory name as part of module name for uniqueness
     dir_name = os.path.basename(integration_dir)
-    module_name = f"custom_integration_{dir_name}"
+    module_name = f"custom_connector_{dir_name}"
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:

--- a/apollo/integrations/custom/custom_integration_loader.py
+++ b/apollo/integrations/custom/custom_integration_loader.py
@@ -110,6 +110,19 @@ def load_templates(integration_dir: str) -> Dict[str, str]:
     return templates
 
 
+def load_manifest(integration_dir: str) -> Dict:
+    """
+    Read manifest.json from the integration directory.
+    Returns the parsed dict, or empty dict if not found.
+    """
+    manifest_path = os.path.join(integration_dir, "manifest.json")
+    if not os.path.isfile(manifest_path):
+        return {}
+
+    with open(manifest_path) as f:
+        return json.load(f)
+
+
 def load_capabilities(integration_dir: str) -> Dict:
     """
     Read capabilities.json from the integration directory.

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -6,8 +6,10 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.custom.custom_integration_loader import (
+    get_custom_integration_registry,
     load_capabilities,
     load_integration_module,
+    load_manifest,
     load_templates,
 )
 
@@ -142,6 +144,31 @@ class CustomProxyClient(BaseProxyClient):
     def get_capabilities(self) -> Dict:
         """Return the capabilities.json contents."""
         return self._capabilities
+
+    @staticmethod
+    def get_connection_manifests() -> Dict[str, Dict[str, Any]]:
+        """
+        Discover all custom integrations and return their manifests,
+        capabilities, and templates.
+
+        Returns a dict keyed by connection_type, e.g.:
+            {
+                "custom-integration-abc1234": {
+                    "manifest": {...},
+                    "capabilities": {...},
+                    "templates": {"get_tables.j2": "...", ...}
+                }
+            }
+        """
+        registry = get_custom_integration_registry()
+        result: Dict[str, Dict[str, Any]] = {}
+        for connection_type, integration_dir in registry.items():
+            result[connection_type] = {
+                "manifest": load_manifest(integration_dir),
+                "capabilities": load_capabilities(integration_dir),
+                "templates": load_templates(integration_dir),
+            }
+        return result
 
     def _render_and_execute(
         self, template_name: str, **template_vars: Any

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -8,7 +8,7 @@ from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.custom.custom_connector_loader import (
     get_custom_connector_registry,
     load_capabilities,
-    load_integration_module,
+    load_connector_module,
     load_manifest,
     load_templates,
 )
@@ -36,7 +36,7 @@ class CustomProxyClient(BaseProxyClient):
     Proxy client for custom database connectors loaded from
     /opt/custom-connectors/{name}/.
 
-    The integration module is expected to define a BaseIntegration class
+    The connector module is expected to define a BaseConnector class
     with methods: create_connection, create_cursor, execute_query,
     fetch_all_results, close_connection.
     """
@@ -44,39 +44,39 @@ class CustomProxyClient(BaseProxyClient):
     def __init__(
         self,
         credentials: Optional[Dict],
-        integration_dir: str,
+        connector_dir: str,
         **kwargs: Any,
     ):
-        module = load_integration_module(integration_dir)
-        self._integration = module.BaseIntegration()
+        module = load_connector_module(connector_dir)
+        self._connector = module.BaseConnector()
 
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Custom-connector agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
 
-        self._integration.credentials = credentials[_ATTR_CONNECT_ARGS]
-        self._integration.connection = self._integration.create_connection()
-        self._integration.cursor = self._integration.create_cursor()
+        self._connector.credentials = credentials[_ATTR_CONNECT_ARGS]
+        self._connector.connection = self._connector.create_connection()
+        self._connector.cursor = self._connector.create_cursor()
 
         jinja_env = ImmutableSandboxedEnvironment(
             trim_blocks=True,
             lstrip_blocks=True,
         )
-        raw_templates = load_templates(integration_dir)
+        raw_templates = load_templates(connector_dir)
         self._templates = raw_templates
         self._compiled_templates: Dict[str, Template] = {
             name: jinja_env.from_string(content)
             for name, content in raw_templates.items()
             if name in _COMPILED_TEMPLATE_NAMES
         }
-        self._capabilities = load_capabilities(integration_dir)
+        self._capabilities = load_capabilities(connector_dir)
 
-        logger.info("Opened custom connector connection from %s", integration_dir)
+        logger.info("Opened custom connector connection from %s", connector_dir)
 
     @property
     def wrapped_client(self):
-        return self._integration.connection
+        return self._connector.connection
 
     def test_connection(self) -> Dict[str, bool]:
         """Connection is established in __init__; if we got here it succeeded."""
@@ -162,11 +162,11 @@ class CustomProxyClient(BaseProxyClient):
         """
         registry = get_custom_connector_registry()
         result: Dict[str, Dict[str, Any]] = {}
-        for connection_type, integration_dir in registry.items():
+        for connection_type, connector_dir in registry.items():
             result[connection_type] = {
-                "manifest": load_manifest(integration_dir),
-                "capabilities": load_capabilities(integration_dir),
-                "templates": load_templates(integration_dir),
+                "manifest": load_manifest(connector_dir),
+                "capabilities": load_capabilities(connector_dir),
+                "templates": load_templates(connector_dir),
             }
         return result
 
@@ -185,10 +185,10 @@ class CustomProxyClient(BaseProxyClient):
 
     def _execute_and_collect(self, query: str) -> Dict[str, Any]:
         """Execute a query and collect results with metadata."""
-        self._integration.execute_query(query)
-        all_results = self._integration.fetch_all_results()
+        self._connector.execute_query(query)
+        all_results = self._connector.fetch_all_results()
 
-        cursor = self._integration.cursor
+        cursor = self._connector.cursor
         description = None
         if hasattr(cursor, "description") and cursor.description:
             description = [
@@ -208,7 +208,7 @@ class CustomProxyClient(BaseProxyClient):
 
     def close(self):
         try:
-            self._integration.close_connection()
+            self._connector.close_connection()
             logger.info("Closed custom connector connection")
         except Exception:
             logger.exception("Error closing custom connector connection")

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -5,8 +5,8 @@ from jinja2 import Template
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
-from apollo.integrations.custom.custom_integration_loader import (
-    get_custom_integration_registry,
+from apollo.integrations.custom.custom_connector_loader import (
+    get_custom_connector_registry,
     load_capabilities,
     load_integration_module,
     load_manifest,
@@ -33,8 +33,8 @@ _COMPILED_TEMPLATE_NAMES = frozenset(
 
 class CustomProxyClient(BaseProxyClient):
     """
-    Proxy client for custom database integrations loaded from
-    /opt/custom-integrations/{name}/.
+    Proxy client for custom database connectors loaded from
+    /opt/custom-connectors/{name}/.
 
     The integration module is expected to define a BaseIntegration class
     with methods: create_connection, create_cursor, execute_query,
@@ -52,7 +52,7 @@ class CustomProxyClient(BaseProxyClient):
 
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
-                f"Custom-integration agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+                f"Custom-connector agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
 
         self._integration.credentials = credentials[_ATTR_CONNECT_ARGS]
@@ -72,7 +72,7 @@ class CustomProxyClient(BaseProxyClient):
         }
         self._capabilities = load_capabilities(integration_dir)
 
-        logger.info("Opened custom integration connection from %s", integration_dir)
+        logger.info("Opened custom connector connection from %s", integration_dir)
 
     @property
     def wrapped_client(self):
@@ -148,19 +148,19 @@ class CustomProxyClient(BaseProxyClient):
     @staticmethod
     def get_connection_manifests() -> Dict[str, Dict[str, Any]]:
         """
-        Discover all custom integrations and return their manifests,
+        Discover all custom connectors and return their manifests,
         capabilities, and templates.
 
         Returns a dict keyed by connection_type, e.g.:
             {
-                "custom-integration-abc1234": {
+                "custom-connector-abc1234": {
                     "manifest": {...},
                     "capabilities": {...},
                     "templates": {"get_tables.j2": "...", ...}
                 }
             }
         """
-        registry = get_custom_integration_registry()
+        registry = get_custom_connector_registry()
         result: Dict[str, Dict[str, Any]] = {}
         for connection_type, integration_dir in registry.items():
             result[connection_type] = {
@@ -209,6 +209,6 @@ class CustomProxyClient(BaseProxyClient):
     def close(self):
         try:
             self._integration.close_connection()
-            logger.info("Closed custom integration connection")
+            logger.info("Closed custom connector connection")
         except Exception:
-            logger.exception("Error closing custom integration connection")
+            logger.exception("Error closing custom connector connection")

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -7,7 +7,6 @@ from jinja2.sandbox import ImmutableSandboxedEnvironment
 from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.custom.custom_connector_loader import (
     get_custom_connector_registry,
-    load_capabilities,
     load_connector_module,
     load_manifest,
     load_templates,
@@ -70,7 +69,8 @@ class CustomProxyClient(BaseProxyClient):
             for name, content in raw_templates.items()
             if name in _COMPILED_TEMPLATE_NAMES
         }
-        self._capabilities = load_capabilities(connector_dir)
+        manifest = load_manifest(connector_dir)
+        self._capabilities = manifest.get("capabilities", {})
 
         logger.info("Opened custom connector connection from %s", connector_dir)
 
@@ -142,20 +142,19 @@ class CustomProxyClient(BaseProxyClient):
         return self._templates
 
     def get_capabilities(self) -> Dict:
-        """Return the capabilities.json contents."""
+        """Return the capabilities from the manifest."""
         return self._capabilities
 
     @staticmethod
     def get_connection_manifests() -> Dict[str, Dict[str, Any]]:
         """
-        Discover all custom connectors and return their manifests,
-        capabilities, and templates.
+        Discover all custom connectors and return their manifests and
+        templates.
 
         Returns a dict keyed by connection_type, e.g.:
             {
                 "custom-connector-abc1234": {
                     "manifest": {...},
-                    "capabilities": {...},
                     "templates": {"get_tables.j2": "...", ...}
                 }
             }
@@ -165,7 +164,6 @@ class CustomProxyClient(BaseProxyClient):
         for connection_type, connector_dir in registry.items():
             result[connection_type] = {
                 "manifest": load_manifest(connector_dir),
-                "capabilities": load_capabilities(connector_dir),
                 "templates": load_templates(connector_dir),
             }
         return result

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -105,7 +105,7 @@ class CustomProxyClient(BaseProxyClient):
             "get_tables_query_template.j2",
             database_name=database_name,
             schemas=schemas,
-            tables=tables,
+            table_names=tables,
             offset=offset,
             limit=limit,
         )

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -1150,13 +1150,13 @@ def _get_infra_details() -> Tuple[Dict, int]:
     return response.result, response.status_code
 
 
-@app.route("/api/v1/agent/custom-integrations/manifests", methods=["POST"])
+@app.route("/api/v1/agent/custom-connectors/manifests", methods=["POST"])
 def get_connection_manifests() -> Tuple[Dict, int]:
     """
     Get Connection Manifests
-    Returns manifests, capabilities, and templates for all custom integrations
+    Returns manifests, capabilities, and templates for all custom connectors
     installed on this agent. Used for discovery when the caller does not yet
-    know which custom integrations are available.
+    know which custom connectors are available.
     ---
     tags:
         - Agent Operations
@@ -1174,7 +1174,7 @@ def get_connection_manifests() -> Tuple[Dict, int]:
                   example: 324986b4-b185-4187-b4af-b0c2cd60f7a0
     responses:
         200:
-            description: Returns connection manifests for all custom integrations on this agent.
+            description: Returns connection manifests for all custom connectors on this agent.
     """
     request_dict: Dict = request.json or {}
     trace_id: Optional[str] = request_dict.get("trace_id")

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -1150,6 +1150,38 @@ def _get_infra_details() -> Tuple[Dict, int]:
     return response.result, response.status_code
 
 
+@app.route("/api/v1/agent/custom-integrations/manifests", methods=["POST"])
+def get_connection_manifests() -> Tuple[Dict, int]:
+    """
+    Get Connection Manifests
+    Returns manifests, capabilities, and templates for all custom integrations
+    installed on this agent. Used for discovery when the caller does not yet
+    know which custom integrations are available.
+    ---
+    tags:
+        - Agent Operations
+    produces:
+        - application/json
+    parameters:
+        - in: body
+          name: body
+          schema:
+            id: ConnectionManifestsRequest
+            properties:
+                trace_id:
+                  type: string
+                  description: An optional trace_id
+                  example: 324986b4-b185-4187-b4af-b0c2cd60f7a0
+    responses:
+        200:
+            description: Returns connection manifests for all custom integrations on this agent.
+    """
+    request_dict: Dict = request.json or {}
+    trace_id: Optional[str] = request_dict.get("trace_id")
+    response = agent.get_connection_manifests(trace_id=trace_id)
+    return response.result, response.status_code
+
+
 @app.route("/api/v1/test/network/outbound_ip_address", methods=["GET"])
 def get_outbound_ip_address() -> Tuple[Dict, int]:
     """

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -9,7 +9,6 @@ from apollo.integrations.custom.custom_connector_loader import (
     load_connector_module,
     load_manifest,
     load_templates,
-    load_capabilities,
 )
 from apollo.agent.agent import Agent
 from apollo.integrations.custom.custom_proxy_client import CustomProxyClient
@@ -21,13 +20,21 @@ def _create_mock_connector_dir(
     connection_type,
     templates=None,
     capabilities=None,
+    metrics=None,
 ):
     """Helper to create a mock connector directory structure."""
     connector_dir = os.path.join(tmp_dir, name)
     os.makedirs(connector_dir, exist_ok=True)
 
-    # manifest.json
-    manifest = {"connection_type": connection_type, "name": name}
+    # manifest.json — capabilities and metrics live inside the manifest
+    manifest = {
+        "connection_type": connection_type,
+        "connection_name": name,
+    }
+    if capabilities is not None:
+        manifest["capabilities"] = capabilities
+    if metrics is not None:
+        manifest["metrics"] = metrics
     with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
         json.dump(manifest, f)
 
@@ -63,11 +70,6 @@ class BaseConnector:
         for filename, content in templates.items():
             with open(os.path.join(templates_dir, filename), "w") as f:
                 f.write(content)
-
-    # capabilities.json
-    if capabilities:
-        with open(os.path.join(connector_dir, "capabilities.json"), "w") as f:
-            json.dump(capabilities, f)
 
     return connector_dir
 
@@ -176,23 +178,6 @@ class TestLoadManifest(TestCase):
             self.assertEqual(result, {})
 
 
-class TestLoadCapabilities(TestCase):
-    def test_load_capabilities(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            caps = {"capabilities": {"supports_metadata": True}}
-            with open(os.path.join(tmp_dir, "capabilities.json"), "w") as f:
-                json.dump(caps, f)
-
-            result = load_capabilities(tmp_dir)
-
-            self.assertEqual(result, caps)
-
-    def test_load_capabilities_no_file(self):
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            result = load_capabilities(tmp_dir)
-            self.assertEqual(result, {})
-
-
 class TestCustomProxyClient(TestCase):
     def setUp(self):
         self._mock_module = MagicMock()
@@ -202,7 +187,7 @@ class TestCustomProxyClient(TestCase):
         self._mock_connector.create_cursor.return_value = Mock()
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={"capabilities": {"supports_metadata": True}},
     )
     @patch(
@@ -211,7 +196,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_test_connection(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
 
@@ -226,7 +211,7 @@ class TestCustomProxyClient(TestCase):
         self._mock_connector.create_cursor.assert_called_once()
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -235,7 +220,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_execute_sql_query(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
         self._mock_connector.fetch_all_results.return_value = [
@@ -262,7 +247,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result["rowcount"], 2)
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -273,7 +258,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_databases(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
         self._mock_connector.fetch_all_results.return_value = [["db1"], ["db2"]]
@@ -294,7 +279,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result["all_results"], [["db1"], ["db2"]])
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -304,7 +289,9 @@ class TestCustomProxyClient(TestCase):
         },
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
-    def test_fetch_schemas(self, mock_load_module, mock_load_templates, mock_load_caps):
+    def test_fetch_schemas(
+        self, mock_load_module, mock_load_templates, mock_load_manifest
+    ):
         mock_load_module.return_value = self._mock_module
         self._mock_connector.fetch_all_results.return_value = [
             ["public"],
@@ -329,7 +316,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result["all_results"], [["public"], ["information_schema"]])
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -339,7 +326,9 @@ class TestCustomProxyClient(TestCase):
         },
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
-    def test_fetch_tables(self, mock_load_module, mock_load_templates, mock_load_caps):
+    def test_fetch_tables(
+        self, mock_load_module, mock_load_templates, mock_load_manifest
+    ):
         mock_load_module.return_value = self._mock_module
         self._mock_connector.fetch_all_results.return_value = [["t1"], ["t2"]]
         cursor = self._mock_connector.create_cursor.return_value
@@ -361,7 +350,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result["all_results"], [["t1"], ["t2"]])
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -372,7 +361,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_query_logs(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
         self._mock_connector.fetch_all_results.return_value = [["q1"], ["q2"]]
@@ -395,7 +384,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result["all_results"], [["q1"], ["q2"]])
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -403,7 +392,9 @@ class TestCustomProxyClient(TestCase):
         return_value={"get_tables.j2": "SELECT * FROM tables"},
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
-    def test_get_templates(self, mock_load_module, mock_load_templates, mock_load_caps):
+    def test_get_templates(
+        self, mock_load_module, mock_load_templates, mock_load_manifest
+    ):
         mock_load_module.return_value = self._mock_module
 
         client = CustomProxyClient(
@@ -415,7 +406,7 @@ class TestCustomProxyClient(TestCase):
         self.assertEqual(result, {"get_tables.j2": "SELECT * FROM tables"})
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={"capabilities": {"supports_metadata": True}},
     )
     @patch(
@@ -424,7 +415,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_get_capabilities(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
 
@@ -434,10 +425,10 @@ class TestCustomProxyClient(TestCase):
         )
         result = client.get_capabilities()
 
-        self.assertEqual(result, {"capabilities": {"supports_metadata": True}})
+        self.assertEqual(result, {"supports_metadata": True})
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -446,7 +437,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_missing_template_raises(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
 
@@ -460,7 +451,7 @@ class TestCustomProxyClient(TestCase):
         self.assertIn("Unknown template", str(ctx.exception))
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -468,7 +459,7 @@ class TestCustomProxyClient(TestCase):
         return_value={},
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
-    def test_close(self, mock_load_module, mock_load_templates, mock_load_caps):
+    def test_close(self, mock_load_module, mock_load_templates, mock_load_manifest):
         mock_load_module.return_value = self._mock_module
 
         client = CustomProxyClient(
@@ -480,7 +471,7 @@ class TestCustomProxyClient(TestCase):
         self._mock_connector.close_connection.assert_called_once()
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.load_capabilities",
+        "apollo.integrations.custom.custom_proxy_client.load_manifest",
         return_value={},
     )
     @patch(
@@ -489,7 +480,7 @@ class TestCustomProxyClient(TestCase):
     )
     @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_wrapped_client_returns_connection(
-        self, mock_load_module, mock_load_templates, mock_load_caps
+        self, mock_load_module, mock_load_templates, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
         mock_conn = Mock()
@@ -511,14 +502,14 @@ class TestGetConnectionManifests(TestCase):
                 "db1",
                 "custom-connector-aaa",
                 templates={"get_tables.j2": "SELECT * FROM tables"},
-                capabilities={"capabilities": {"supports_metadata": True}},
+                capabilities={"supports_metadata": True},
             )
             _create_mock_connector_dir(
                 tmp_dir,
                 "db2",
                 "custom-connector-bbb",
                 templates={"get_schemas.j2": "SELECT * FROM schemas"},
-                capabilities={"capabilities": {"supports_query_logs": False}},
+                capabilities={"supports_query_logs": False},
             )
 
             with patch(
@@ -535,10 +526,11 @@ class TestGetConnectionManifests(TestCase):
             self.assertIn("custom-connector-aaa", result)
             aaa = result["custom-connector-aaa"]
             self.assertEqual(aaa["manifest"]["connection_type"], "custom-connector-aaa")
-            self.assertEqual(aaa["manifest"]["name"], "db1")
+            self.assertEqual(aaa["manifest"]["connection_name"], "db1")
             self.assertEqual(
-                aaa["capabilities"], {"capabilities": {"supports_metadata": True}}
+                aaa["manifest"]["capabilities"], {"supports_metadata": True}
             )
+            self.assertNotIn("capabilities", aaa)
             self.assertEqual(
                 aaa["templates"], {"get_tables.j2": "SELECT * FROM tables"}
             )
@@ -563,7 +555,7 @@ class TestGetConnectionManifests(TestCase):
 
             self.assertEqual(result, {})
 
-    def test_handles_missing_capabilities_and_templates(self):
+    def test_handles_missing_templates(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_connector_dir(
                 tmp_dir,
@@ -582,7 +574,7 @@ class TestGetConnectionManifests(TestCase):
 
             aaa = result["custom-connector-aaa"]
             self.assertEqual(aaa["manifest"]["connection_type"], "custom-connector-aaa")
-            self.assertEqual(aaa["capabilities"], {})
+            self.assertNotIn("capabilities", aaa)
             self.assertEqual(aaa["templates"], {})
 
 

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -31,8 +31,8 @@ def _create_mock_connector_dir(
     with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
         json.dump(manifest, f)
 
-    # integration.py
-    integration_code = """
+    # connector.py
+    connector_code = """
 class BaseConnector:
     credentials = {}
     connection = None
@@ -53,8 +53,8 @@ class BaseConnector:
     def close_connection(self):
         pass
 """
-    with open(os.path.join(connector_dir, "integration.py"), "w") as f:
-        f.write(integration_code)
+    with open(os.path.join(connector_dir, "connector.py"), "w") as f:
+        f.write(connector_code)
 
     # templates/
     if templates:

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -4,8 +4,8 @@ import tempfile
 from unittest import TestCase
 from unittest.mock import Mock, patch, MagicMock
 
-from apollo.integrations.custom.custom_integration_loader import (
-    _discover_custom_integrations,
+from apollo.integrations.custom.custom_connector_loader import (
+    _discover_custom_connectors,
     load_integration_module,
     load_manifest,
     load_templates,
@@ -72,54 +72,54 @@ class BaseIntegration:
     return integration_dir
 
 
-class TestCustomIntegrationDiscovery(TestCase):
+class TestCustomConnectorDiscovery(TestCase):
     def test_discovery_reads_manifests(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(tmp_dir, "mydb", "custom-integration-abc1234")
+            _create_mock_integration_dir(tmp_dir, "mydb", "custom-connector-abc1234")
 
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ):
-                registry = _discover_custom_integrations()
+                registry = _discover_custom_connectors()
 
-            self.assertIn("custom-integration-abc1234", registry)
+            self.assertIn("custom-connector-abc1234", registry)
             self.assertEqual(
-                registry["custom-integration-abc1234"],
+                registry["custom-connector-abc1234"],
                 os.path.join(tmp_dir, "mydb"),
             )
 
-    def test_multiple_integrations(self):
+    def test_multiple_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(tmp_dir, "db1", "custom-integration-aaa")
-            _create_mock_integration_dir(tmp_dir, "db2", "custom-integration-bbb")
+            _create_mock_integration_dir(tmp_dir, "db1", "custom-connector-aaa")
+            _create_mock_integration_dir(tmp_dir, "db2", "custom-connector-bbb")
 
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ):
-                registry = _discover_custom_integrations()
+                registry = _discover_custom_connectors()
 
             self.assertEqual(len(registry), 2)
-            self.assertIn("custom-integration-aaa", registry)
-            self.assertIn("custom-integration-bbb", registry)
+            self.assertIn("custom-connector-aaa", registry)
+            self.assertIn("custom-connector-bbb", registry)
 
     def test_discovery_empty_directory(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ):
-                registry = _discover_custom_integrations()
+                registry = _discover_custom_connectors()
 
             self.assertEqual(registry, {})
 
     def test_discovery_missing_directory(self):
         with patch(
-            "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+            "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
             "/nonexistent/path",
         ):
-            registry = _discover_custom_integrations()
+            registry = _discover_custom_connectors()
 
         self.assertEqual(registry, {})
 
@@ -129,10 +129,10 @@ class TestCustomIntegrationDiscovery(TestCase):
             os.makedirs(os.path.join(tmp_dir, "bad_integration"))
 
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ):
-                registry = _discover_custom_integrations()
+                registry = _discover_custom_connectors()
 
             self.assertEqual(registry, {})
 
@@ -162,7 +162,7 @@ class TestLoadTemplates(TestCase):
 class TestLoadManifest(TestCase):
     def test_load_manifest(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            manifest = {"connection_type": "custom-integration-abc", "name": "mydb"}
+            manifest = {"connection_type": "custom-connector-abc", "name": "mydb"}
             with open(os.path.join(tmp_dir, "manifest.json"), "w") as f:
                 json.dump(manifest, f)
 
@@ -217,7 +217,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.test_connection()
 
@@ -251,7 +251,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.execute_sql_query("SELECT name FROM databases")
 
@@ -284,7 +284,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_databases()
 
@@ -319,7 +319,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_schemas(database_name="mydb")
 
@@ -349,7 +349,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_tables(
             database_name="mydb", schemas="public", offset=0, limit=100
@@ -383,7 +383,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_query_logs(
             start_time="2024-01-01", end_time="2024-01-02", limit=1000, offset=0
@@ -408,7 +408,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.get_templates()
 
@@ -430,7 +430,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         result = client.get_capabilities()
 
@@ -452,7 +452,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
 
         with self.assertRaises(ValueError) as ctx:
@@ -473,7 +473,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
         client.close()
 
@@ -497,46 +497,44 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-integrations/mydb",
+            integration_dir="/opt/custom-connectors/mydb",
         )
 
         self.assertEqual(client.wrapped_client, mock_conn)
 
 
 class TestGetConnectionManifests(TestCase):
-    def test_returns_all_integrations(self):
+    def test_returns_all_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_integration_dir(
                 tmp_dir,
                 "db1",
-                "custom-integration-aaa",
+                "custom-connector-aaa",
                 templates={"get_tables.j2": "SELECT * FROM tables"},
                 capabilities={"capabilities": {"supports_metadata": True}},
             )
             _create_mock_integration_dir(
                 tmp_dir,
                 "db2",
-                "custom-integration-bbb",
+                "custom-connector-bbb",
                 templates={"get_schemas.j2": "SELECT * FROM schemas"},
                 capabilities={"capabilities": {"supports_query_logs": False}},
             )
 
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ), patch(
-                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
                 None,
             ):
                 result = CustomProxyClient.get_connection_manifests()
 
             self.assertEqual(len(result), 2)
 
-            self.assertIn("custom-integration-aaa", result)
-            aaa = result["custom-integration-aaa"]
-            self.assertEqual(
-                aaa["manifest"]["connection_type"], "custom-integration-aaa"
-            )
+            self.assertIn("custom-connector-aaa", result)
+            aaa = result["custom-connector-aaa"]
+            self.assertEqual(aaa["manifest"]["connection_type"], "custom-connector-aaa")
             self.assertEqual(aaa["manifest"]["name"], "db1")
             self.assertEqual(
                 aaa["capabilities"], {"capabilities": {"supports_metadata": True}}
@@ -545,22 +543,20 @@ class TestGetConnectionManifests(TestCase):
                 aaa["templates"], {"get_tables.j2": "SELECT * FROM tables"}
             )
 
-            self.assertIn("custom-integration-bbb", result)
-            bbb = result["custom-integration-bbb"]
-            self.assertEqual(
-                bbb["manifest"]["connection_type"], "custom-integration-bbb"
-            )
+            self.assertIn("custom-connector-bbb", result)
+            bbb = result["custom-connector-bbb"]
+            self.assertEqual(bbb["manifest"]["connection_type"], "custom-connector-bbb")
             self.assertEqual(
                 bbb["templates"], {"get_schemas.j2": "SELECT * FROM schemas"}
             )
 
-    def test_returns_empty_when_no_integrations(self):
+    def test_returns_empty_when_no_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ), patch(
-                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
                 None,
             ):
                 result = CustomProxyClient.get_connection_manifests()
@@ -572,29 +568,27 @@ class TestGetConnectionManifests(TestCase):
             _create_mock_integration_dir(
                 tmp_dir,
                 "db1",
-                "custom-integration-aaa",
+                "custom-connector-aaa",
             )
 
             with patch(
-                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
                 tmp_dir,
             ), patch(
-                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
                 None,
             ):
                 result = CustomProxyClient.get_connection_manifests()
 
-            aaa = result["custom-integration-aaa"]
-            self.assertEqual(
-                aaa["manifest"]["connection_type"], "custom-integration-aaa"
-            )
+            aaa = result["custom-connector-aaa"]
+            self.assertEqual(aaa["manifest"]["connection_type"], "custom-connector-aaa")
             self.assertEqual(aaa["capabilities"], {})
             self.assertEqual(aaa["templates"], {})
 
 
 class TestAgentGetConnectionManifests(TestCase):
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.get_custom_integration_registry",
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
         return_value={},
     )
     def test_returns_ok_response(self, _mock_registry):
@@ -607,7 +601,7 @@ class TestAgentGetConnectionManifests(TestCase):
         self.assertEqual(response.trace_id, "test-trace")
 
     @patch(
-        "apollo.integrations.custom.custom_proxy_client.get_custom_integration_registry",
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
         side_effect=RuntimeError("boom"),
     )
     def test_returns_error_on_failure(self, _mock_registry):

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -7,9 +7,11 @@ from unittest.mock import Mock, patch, MagicMock
 from apollo.integrations.custom.custom_integration_loader import (
     _discover_custom_integrations,
     load_integration_module,
+    load_manifest,
     load_templates,
     load_capabilities,
 )
+from apollo.agent.agent import Agent
 from apollo.integrations.custom.custom_proxy_client import CustomProxyClient
 
 
@@ -154,6 +156,23 @@ class TestLoadTemplates(TestCase):
     def test_load_templates_no_directory(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             result = load_templates(tmp_dir)
+            self.assertEqual(result, {})
+
+
+class TestLoadManifest(TestCase):
+    def test_load_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = {"connection_type": "custom-integration-abc", "name": "mydb"}
+            with open(os.path.join(tmp_dir, "manifest.json"), "w") as f:
+                json.dump(manifest, f)
+
+            result = load_manifest(tmp_dir)
+
+            self.assertEqual(result, manifest)
+
+    def test_load_manifest_no_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = load_manifest(tmp_dir)
             self.assertEqual(result, {})
 
 
@@ -482,3 +501,118 @@ class TestCustomProxyClient(TestCase):
         )
 
         self.assertEqual(client.wrapped_client, mock_conn)
+
+
+class TestGetConnectionManifests(TestCase):
+    def test_returns_all_integrations(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_integration_dir(
+                tmp_dir,
+                "db1",
+                "custom-integration-aaa",
+                templates={"get_tables.j2": "SELECT * FROM tables"},
+                capabilities={"capabilities": {"supports_metadata": True}},
+            )
+            _create_mock_integration_dir(
+                tmp_dir,
+                "db2",
+                "custom-integration-bbb",
+                templates={"get_schemas.j2": "SELECT * FROM schemas"},
+                capabilities={"capabilities": {"supports_query_logs": False}},
+            )
+
+            with patch(
+                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_connection_manifests()
+
+            self.assertEqual(len(result), 2)
+
+            self.assertIn("custom-integration-aaa", result)
+            aaa = result["custom-integration-aaa"]
+            self.assertEqual(
+                aaa["manifest"]["connection_type"], "custom-integration-aaa"
+            )
+            self.assertEqual(aaa["manifest"]["name"], "db1")
+            self.assertEqual(
+                aaa["capabilities"], {"capabilities": {"supports_metadata": True}}
+            )
+            self.assertEqual(
+                aaa["templates"], {"get_tables.j2": "SELECT * FROM tables"}
+            )
+
+            self.assertIn("custom-integration-bbb", result)
+            bbb = result["custom-integration-bbb"]
+            self.assertEqual(
+                bbb["manifest"]["connection_type"], "custom-integration-bbb"
+            )
+            self.assertEqual(
+                bbb["templates"], {"get_schemas.j2": "SELECT * FROM schemas"}
+            )
+
+    def test_returns_empty_when_no_integrations(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch(
+                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_connection_manifests()
+
+            self.assertEqual(result, {})
+
+    def test_handles_missing_capabilities_and_templates(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_integration_dir(
+                tmp_dir,
+                "db1",
+                "custom-integration-aaa",
+            )
+
+            with patch(
+                "apollo.integrations.custom.custom_integration_loader._CUSTOM_INTEGRATIONS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_integration_loader._custom_integration_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_connection_manifests()
+
+            aaa = result["custom-integration-aaa"]
+            self.assertEqual(
+                aaa["manifest"]["connection_type"], "custom-integration-aaa"
+            )
+            self.assertEqual(aaa["capabilities"], {})
+            self.assertEqual(aaa["templates"], {})
+
+
+class TestAgentGetConnectionManifests(TestCase):
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_integration_registry",
+        return_value={},
+    )
+    def test_returns_ok_response(self, _mock_registry):
+        agent = Agent(None)
+        response = agent.get_connection_manifests(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_result__", response.result)
+        self.assertEqual(response.result["__mcd_result__"], {})
+        self.assertEqual(response.trace_id, "test-trace")
+
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_integration_registry",
+        side_effect=RuntimeError("boom"),
+    )
+    def test_returns_error_on_failure(self, _mock_registry):
+        agent = Agent(None)
+        response = agent.get_connection_manifests(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_error__", response.result)

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch, MagicMock
 
 from apollo.integrations.custom.custom_connector_loader import (
     _discover_custom_connectors,
-    load_integration_module,
+    load_connector_module,
     load_manifest,
     load_templates,
     load_capabilities,
@@ -15,25 +15,25 @@ from apollo.agent.agent import Agent
 from apollo.integrations.custom.custom_proxy_client import CustomProxyClient
 
 
-def _create_mock_integration_dir(
+def _create_mock_connector_dir(
     tmp_dir,
     name,
     connection_type,
     templates=None,
     capabilities=None,
 ):
-    """Helper to create a mock integration directory structure."""
-    integration_dir = os.path.join(tmp_dir, name)
-    os.makedirs(integration_dir, exist_ok=True)
+    """Helper to create a mock connector directory structure."""
+    connector_dir = os.path.join(tmp_dir, name)
+    os.makedirs(connector_dir, exist_ok=True)
 
     # manifest.json
     manifest = {"connection_type": connection_type, "name": name}
-    with open(os.path.join(integration_dir, "manifest.json"), "w") as f:
+    with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
         json.dump(manifest, f)
 
     # integration.py
     integration_code = """
-class BaseIntegration:
+class BaseConnector:
     credentials = {}
     connection = None
     cursor = None
@@ -53,12 +53,12 @@ class BaseIntegration:
     def close_connection(self):
         pass
 """
-    with open(os.path.join(integration_dir, "integration.py"), "w") as f:
+    with open(os.path.join(connector_dir, "integration.py"), "w") as f:
         f.write(integration_code)
 
     # templates/
     if templates:
-        templates_dir = os.path.join(integration_dir, "templates")
+        templates_dir = os.path.join(connector_dir, "templates")
         os.makedirs(templates_dir, exist_ok=True)
         for filename, content in templates.items():
             with open(os.path.join(templates_dir, filename), "w") as f:
@@ -66,16 +66,16 @@ class BaseIntegration:
 
     # capabilities.json
     if capabilities:
-        with open(os.path.join(integration_dir, "capabilities.json"), "w") as f:
+        with open(os.path.join(connector_dir, "capabilities.json"), "w") as f:
             json.dump(capabilities, f)
 
-    return integration_dir
+    return connector_dir
 
 
 class TestCustomConnectorDiscovery(TestCase):
     def test_discovery_reads_manifests(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(tmp_dir, "mydb", "custom-connector-abc1234")
+            _create_mock_connector_dir(tmp_dir, "mydb", "custom-connector-abc1234")
 
             with patch(
                 "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
@@ -91,8 +91,8 @@ class TestCustomConnectorDiscovery(TestCase):
 
     def test_multiple_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(tmp_dir, "db1", "custom-connector-aaa")
-            _create_mock_integration_dir(tmp_dir, "db2", "custom-connector-bbb")
+            _create_mock_connector_dir(tmp_dir, "db1", "custom-connector-aaa")
+            _create_mock_connector_dir(tmp_dir, "db2", "custom-connector-bbb")
 
             with patch(
                 "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
@@ -196,10 +196,10 @@ class TestLoadCapabilities(TestCase):
 class TestCustomProxyClient(TestCase):
     def setUp(self):
         self._mock_module = MagicMock()
-        self._mock_integration = MagicMock()
-        self._mock_module.BaseIntegration.return_value = self._mock_integration
-        self._mock_integration.create_connection.return_value = Mock()
-        self._mock_integration.create_cursor.return_value = Mock()
+        self._mock_connector = MagicMock()
+        self._mock_module.BaseConnector.return_value = self._mock_connector
+        self._mock_connector.create_connection.return_value = Mock()
+        self._mock_connector.create_cursor.return_value = Mock()
 
     @patch(
         "apollo.integrations.custom.custom_proxy_client.load_capabilities",
@@ -209,7 +209,7 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_test_connection(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
@@ -217,13 +217,13 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.test_connection()
 
         self.assertEqual(result, {"success": True})
-        self._mock_integration.create_connection.assert_called_once()
-        self._mock_integration.create_cursor.assert_called_once()
+        self._mock_connector.create_connection.assert_called_once()
+        self._mock_connector.create_cursor.assert_called_once()
 
     @patch(
         "apollo.integrations.custom.custom_proxy_client.load_capabilities",
@@ -233,29 +233,29 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_execute_sql_query(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
         mock_load_module.return_value = self._mock_module
-        self._mock_integration.fetch_all_results.return_value = [
+        self._mock_connector.fetch_all_results.return_value = [
             ["db1"],
             ["db2"],
         ]
-        cursor = self._mock_integration.create_cursor.return_value
+        cursor = self._mock_connector.create_cursor.return_value
         cursor.description = [
             ("name", "varchar", None, None, None, None, None),
         ]
         cursor.rowcount = 2
-        self._mock_integration.cursor = cursor
+        self._mock_connector.cursor = cursor
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.execute_sql_query("SELECT name FROM databases")
 
-        self._mock_integration.execute_query.assert_called_once_with(
+        self._mock_connector.execute_query.assert_called_once_with(
             "SELECT name FROM databases"
         )
         self.assertEqual(result["all_results"], [["db1"], ["db2"]])
@@ -271,24 +271,24 @@ class TestCustomProxyClient(TestCase):
             "get_databases_query_template.j2": "SELECT datname FROM pg_database",
         },
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_databases(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
         mock_load_module.return_value = self._mock_module
-        self._mock_integration.fetch_all_results.return_value = [["db1"], ["db2"]]
-        cursor = self._mock_integration.create_cursor.return_value
+        self._mock_connector.fetch_all_results.return_value = [["db1"], ["db2"]]
+        cursor = self._mock_connector.create_cursor.return_value
         cursor.description = [("datname", "varchar", None, None, None, None, None)]
         cursor.rowcount = 2
-        self._mock_integration.cursor = cursor
+        self._mock_connector.cursor = cursor
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_databases()
 
-        self._mock_integration.execute_query.assert_called_once_with(
+        self._mock_connector.execute_query.assert_called_once_with(
             "SELECT datname FROM pg_database"
         )
         self.assertEqual(result["all_results"], [["db1"], ["db2"]])
@@ -303,27 +303,27 @@ class TestCustomProxyClient(TestCase):
             "get_schemas_query_template.j2": "SELECT schema_name FROM schemas WHERE db = '{{ database_name }}'",
         },
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_schemas(self, mock_load_module, mock_load_templates, mock_load_caps):
         mock_load_module.return_value = self._mock_module
-        self._mock_integration.fetch_all_results.return_value = [
+        self._mock_connector.fetch_all_results.return_value = [
             ["public"],
             ["information_schema"],
         ]
-        cursor = self._mock_integration.create_cursor.return_value
+        cursor = self._mock_connector.create_cursor.return_value
         cursor.description = [
             ("schema_name", "varchar", None, None, None, None, None),
         ]
         cursor.rowcount = 2
-        self._mock_integration.cursor = cursor
+        self._mock_connector.cursor = cursor
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_schemas(database_name="mydb")
 
-        self._mock_integration.execute_query.assert_called_once_with(
+        self._mock_connector.execute_query.assert_called_once_with(
             "SELECT schema_name FROM schemas WHERE db = 'mydb'"
         )
         self.assertEqual(result["all_results"], [["public"], ["information_schema"]])
@@ -338,24 +338,24 @@ class TestCustomProxyClient(TestCase):
             "get_tables_query_template.j2": "SELECT * FROM tables WHERE db = '{{ database_name }}' LIMIT {{ limit }} OFFSET {{ offset }}",
         },
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_tables(self, mock_load_module, mock_load_templates, mock_load_caps):
         mock_load_module.return_value = self._mock_module
-        self._mock_integration.fetch_all_results.return_value = [["t1"], ["t2"]]
-        cursor = self._mock_integration.create_cursor.return_value
+        self._mock_connector.fetch_all_results.return_value = [["t1"], ["t2"]]
+        cursor = self._mock_connector.create_cursor.return_value
         cursor.description = [("table_name", "varchar", None, None, None, None, None)]
         cursor.rowcount = 2
-        self._mock_integration.cursor = cursor
+        self._mock_connector.cursor = cursor
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_tables(
             database_name="mydb", schemas="public", offset=0, limit=100
         )
 
-        self._mock_integration.execute_query.assert_called_once_with(
+        self._mock_connector.execute_query.assert_called_once_with(
             "SELECT * FROM tables WHERE db = 'mydb' LIMIT 100 OFFSET 0"
         )
         self.assertEqual(result["all_results"], [["t1"], ["t2"]])
@@ -370,26 +370,26 @@ class TestCustomProxyClient(TestCase):
             "get_query_logs_query_template.j2": "SELECT * FROM query_log WHERE ts BETWEEN '{{ start_time }}' AND '{{ end_time }}' LIMIT {{ limit }} OFFSET {{ offset }}",
         },
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_fetch_query_logs(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
         mock_load_module.return_value = self._mock_module
-        self._mock_integration.fetch_all_results.return_value = [["q1"], ["q2"]]
-        cursor = self._mock_integration.create_cursor.return_value
+        self._mock_connector.fetch_all_results.return_value = [["q1"], ["q2"]]
+        cursor = self._mock_connector.create_cursor.return_value
         cursor.description = [("query", "varchar", None, None, None, None, None)]
         cursor.rowcount = 2
-        self._mock_integration.cursor = cursor
+        self._mock_connector.cursor = cursor
 
         client = CustomProxyClient(
             credentials={"connect_args": {"host": "localhost"}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.fetch_query_logs(
             start_time="2024-01-01", end_time="2024-01-02", limit=1000, offset=0
         )
 
-        self._mock_integration.execute_query.assert_called_once_with(
+        self._mock_connector.execute_query.assert_called_once_with(
             "SELECT * FROM query_log WHERE ts BETWEEN '2024-01-01' AND '2024-01-02' LIMIT 1000 OFFSET 0"
         )
         self.assertEqual(result["all_results"], [["q1"], ["q2"]])
@@ -402,13 +402,13 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={"get_tables.j2": "SELECT * FROM tables"},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_get_templates(self, mock_load_module, mock_load_templates, mock_load_caps):
         mock_load_module.return_value = self._mock_module
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.get_templates()
 
@@ -422,7 +422,7 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_get_capabilities(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
@@ -430,7 +430,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         result = client.get_capabilities()
 
@@ -444,7 +444,7 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_missing_template_raises(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
@@ -452,7 +452,7 @@ class TestCustomProxyClient(TestCase):
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
 
         with self.assertRaises(ValueError) as ctx:
@@ -467,17 +467,17 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_close(self, mock_load_module, mock_load_templates, mock_load_caps):
         mock_load_module.return_value = self._mock_module
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
         client.close()
 
-        self._mock_integration.close_connection.assert_called_once()
+        self._mock_connector.close_connection.assert_called_once()
 
     @patch(
         "apollo.integrations.custom.custom_proxy_client.load_capabilities",
@@ -487,17 +487,17 @@ class TestCustomProxyClient(TestCase):
         "apollo.integrations.custom.custom_proxy_client.load_templates",
         return_value={},
     )
-    @patch("apollo.integrations.custom.custom_proxy_client.load_integration_module")
+    @patch("apollo.integrations.custom.custom_proxy_client.load_connector_module")
     def test_wrapped_client_returns_connection(
         self, mock_load_module, mock_load_templates, mock_load_caps
     ):
         mock_load_module.return_value = self._mock_module
         mock_conn = Mock()
-        self._mock_integration.create_connection.return_value = mock_conn
+        self._mock_connector.create_connection.return_value = mock_conn
 
         client = CustomProxyClient(
             credentials={"connect_args": {}},
-            integration_dir="/opt/custom-connectors/mydb",
+            connector_dir="/opt/custom-connectors/mydb",
         )
 
         self.assertEqual(client.wrapped_client, mock_conn)
@@ -506,14 +506,14 @@ class TestCustomProxyClient(TestCase):
 class TestGetConnectionManifests(TestCase):
     def test_returns_all_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(
+            _create_mock_connector_dir(
                 tmp_dir,
                 "db1",
                 "custom-connector-aaa",
                 templates={"get_tables.j2": "SELECT * FROM tables"},
                 capabilities={"capabilities": {"supports_metadata": True}},
             )
-            _create_mock_integration_dir(
+            _create_mock_connector_dir(
                 tmp_dir,
                 "db2",
                 "custom-connector-bbb",
@@ -565,7 +565,7 @@ class TestGetConnectionManifests(TestCase):
 
     def test_handles_missing_capabilities_and_templates(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
-            _create_mock_integration_dir(
+            _create_mock_connector_dir(
                 tmp_dir,
                 "db1",
                 "custom-connector-aaa",


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/agent/custom-connectors/manifests` endpoint for discovering all custom integrations installed on the agent
- Returns each connectors `manifest.json`, `capabilities.json`, and `templates/` contents keyed by `connection_type`
- No credentials or known `connection_type` required — designed for discovery/refresh from the data-collector

## Test plan
- [x] Unit tests for `load_manifest` (loader)
- [x] Unit tests for `CustomProxyClient.get_connection_manifests` (static method)
- [x] Unit tests for `Agent.get_connection_manifests` (success + error paths)
- [ ] Manually tested locally against running agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)