### PR TITLE
feat(YET-856): scope SFDC a360/token to dataspace for query connections

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 
 # configure the amount of time connections are cached in memory
 # a value < 0 is used to disable caching
-_CACHE_EXPIRATION_SECONDS = int(os.getenv(CLIENT_CACHE_EXPIRATION_SECONDS_ENV_VAR, "60"))
+_CACHE_EXPIRATION_SECONDS = int(
+    os.getenv(CLIENT_CACHE_EXPIRATION_SECONDS_ENV_VAR, "60")
+)
 
 
 def _get_proxy_client_bigquery(
@@ -438,7 +440,9 @@ class ProxyClientFactory:
             if client:
                 logger.info(f"Using cached client for {connection_type}")
             else:
-                client = cls._create_proxy_client(connection_type, credentials, platform)
+                client = cls._create_proxy_client(
+                    connection_type, credentials, platform
+                )
                 logger.info(f"Caching {connection_type} client")
                 cls._cache_client(key, client)
             return client
@@ -473,7 +477,9 @@ class ProxyClientFactory:
         if factory_method:
             return factory_method(credentials, platform=platform)
         else:
-            raise AgentError(f"Connection type not supported by this agent: {connection_type}")
+            raise AgentError(
+                f"Connection type not supported by this agent: {connection_type}"
+            )
 
     @staticmethod
     def _get_cache_key(connection_type: str, credentials: Optional[Dict]) -> str:
@@ -503,7 +509,10 @@ class ProxyClientFactory:
         entry = cls._clients_cache.get(key)
 
         # check that entry has not expired
-        if not entry or (datetime.now() - entry.created_time).seconds > _CACHE_EXPIRATION_SECONDS:
+        if (
+            not entry
+            or (datetime.now() - entry.created_time).seconds > _CACHE_EXPIRATION_SECONDS
+        ):
             # dispose client and connection, so we don't have two connections open at the same time
             if entry:
                 cls._dispose_cached_client(key)

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -21,9 +21,7 @@ logger = logging.getLogger(__name__)
 
 # configure the amount of time connections are cached in memory
 # a value < 0 is used to disable caching
-_CACHE_EXPIRATION_SECONDS = int(
-    os.getenv(CLIENT_CACHE_EXPIRATION_SECONDS_ENV_VAR, "60")
-)
+_CACHE_EXPIRATION_SECONDS = int(os.getenv(CLIENT_CACHE_EXPIRATION_SECONDS_ENV_VAR, "60"))
 
 
 def _get_proxy_client_bigquery(
@@ -296,6 +294,7 @@ def _get_proxy_client_salesforce_data_cloud(
     client_secret = connect_args.get("client_secret")
     core_token = connect_args.get("core_token")
     refresh_token = connect_args.get("refresh_token")
+    dataspace = connect_args.get("dataspace")
 
     if not all([domain, client_id, client_secret]):
         raise ValueError("Missing required connection parameters")
@@ -306,6 +305,7 @@ def _get_proxy_client_salesforce_data_cloud(
         client_secret=client_secret,
         core_token=core_token,
         refresh_token=refresh_token,
+        dataspace=dataspace,
     )
     return SalesforceDataCloudProxyClient(credentials=credentials)
 
@@ -438,9 +438,7 @@ class ProxyClientFactory:
             if client:
                 logger.info(f"Using cached client for {connection_type}")
             else:
-                client = cls._create_proxy_client(
-                    connection_type, credentials, platform
-                )
+                client = cls._create_proxy_client(connection_type, credentials, platform)
                 logger.info(f"Caching {connection_type} client")
                 cls._cache_client(key, client)
             return client
@@ -475,9 +473,7 @@ class ProxyClientFactory:
         if factory_method:
             return factory_method(credentials, platform=platform)
         else:
-            raise AgentError(
-                f"Connection type not supported by this agent: {connection_type}"
-            )
+            raise AgentError(f"Connection type not supported by this agent: {connection_type}")
 
     @staticmethod
     def _get_cache_key(connection_type: str, credentials: Optional[Dict]) -> str:
@@ -507,10 +503,7 @@ class ProxyClientFactory:
         entry = cls._clients_cache.get(key)
 
         # check that entry has not expired
-        if (
-            not entry
-            or (datetime.now() - entry.created_time).seconds > _CACHE_EXPIRATION_SECONDS
-        ):
+        if not entry or (datetime.now() - entry.created_time).seconds > _CACHE_EXPIRATION_SECONDS:
             # dispose client and connection, so we don't have two connections open at the same time
             if entry:
                 cls._dispose_cached_client(key)

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -264,7 +264,9 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                         "exchange_response_body": body,
                     },
                 )
-                detail = f" (HTTP {status}, Salesforce response: {body})" if body else ""
+                detail = (
+                    f" (HTTP {status}, Salesforce response: {body})" if body else ""
+                )
                 raise RuntimeError(
                     f"Token exchange failed for dataspace '{dataspace}': "
                     f"OAuth response missing key {e}{detail} — "

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -283,8 +283,27 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 f"Salesforce Data Cloud: fetching tables (unscoped, "
                 f"domain={self._credentials.domain})"
             )
+            # If the base connection was created with a dataspace (for query execution),
+            # use a fresh unscoped connection here so that list_tables(None) always
+            # returns the default-dataspace view regardless of how this client was
+            # instantiated.  This prevents a future caller from accidentally getting
+            # dataspace-scoped results while believing the fetch is unscoped.
+            if self._credentials.dataspace:
+                unscoped_conn: SalesforceDataCloudConnection | None = (
+                    SalesforceDataCloudConnection(
+                        f"https://{self._credentials.domain}",
+                        client_id=self._credentials.client_id,
+                        client_secret=self._credentials.client_secret,
+                        core_token=None,
+                        refresh_token=None,
+                        dataspace=None,
+                    )
+                )
+            else:
+                unscoped_conn = None
+            conn_to_use = unscoped_conn or self._connection
             try:
-                tables = self._connection.list_tables()
+                tables = conn_to_use.list_tables()
             except SalesforceCDPError as e:
                 raise RuntimeError(
                     f"Token exchange failed: {e} — verify credentials are valid"
@@ -294,6 +313,9 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                     f"Token exchange failed: OAuth response missing key {e} — "
                     f"verify credentials are valid"
                 ) from e
+            finally:
+                if unscoped_conn is not None:
+                    unscoped_conn.close()
             logger.info(
                 "Salesforce Data Cloud: fetched tables (unscoped)",
                 extra={"table_count": len(tables)},

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -177,6 +177,10 @@ class SalesforceDataCloudCredentials:
     # Accepted for backwards compatibility; iteration over dataspaces is handled
     # by the data-collector, which calls list_tables(dataspace=X) once per dataspace.
     dataspaces: list[str] | None = None
+    # Single dataspace scope for query execution (profiling, monitors, validation).
+    # When set, the a360/token exchange is scoped to this dataspace so queries
+    # against tables in non-default dataspaces succeed.
+    dataspace: str | None = None
 
 
 class SalesforceDataCloudProxyClient(BaseDbProxyClient):
@@ -189,6 +193,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             client_secret=credentials.client_secret,
             core_token=credentials.core_token,
             refresh_token=credentials.refresh_token,
+            dataspace=credentials.dataspace,
         )
 
     @property
@@ -259,9 +264,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                         "exchange_response_body": body,
                     },
                 )
-                detail = (
-                    f" (HTTP {status}, Salesforce response: {body})" if body else ""
-                )
+                detail = f" (HTTP {status}, Salesforce response: {body})" if body else ""
                 raise RuntimeError(
                     f"Token exchange failed for dataspace '{dataspace}': "
                     f"OAuth response missing key {e}{detail} — "

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -288,14 +288,18 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             # returns the default-dataspace view regardless of how this client was
             # instantiated.  This prevents a future caller from accidentally getting
             # dataspace-scoped results while believing the fetch is unscoped.
+            #
+            # Preserve the original auth tokens (core_token / refresh_token) so we
+            # reuse any pre-fetched credentials rather than forcing an unnecessary
+            # client-credentials re-flow.  Only dataspace is cleared to remove scoping.
             if self._credentials.dataspace:
                 unscoped_conn: SalesforceDataCloudConnection | None = (
                     SalesforceDataCloudConnection(
                         f"https://{self._credentials.domain}",
                         client_id=self._credentials.client_id,
                         client_secret=self._credentials.client_secret,
-                        core_token=None,
-                        refresh_token=None,
+                        core_token=self._credentials.core_token,
+                        refresh_token=self._credentials.refresh_token,
                         dataspace=None,
                     )
                 )

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -158,7 +158,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             callback=self.metadata_endpoint,
         )
 
-        self.query_endpoint = Mock(return_value=(200, {}, json.dumps(self.data_response)))
+        self.query_endpoint = Mock(
+            return_value=(200, {}, json.dumps(self.data_response))
+        )
         self.mock_responses.add_callback(
             method=responses.POST,
             url="https://test.salesforce.com/api/v2/query",
@@ -181,7 +183,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
+        self.assertEqual(
+            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
+        )
 
     def test_init_with_client_credentials_flow(self):
         # New DC path: only client_id/client_secret, no core_token.
@@ -202,7 +206,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
+        self.assertEqual(
+            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
+        )
 
     def test_init_with_refresh_token(self):
         # Backward compat: old DCs sent refresh_token="required_but_not_used".
@@ -224,7 +230,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
+        self.assertEqual(
+            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
+        )
 
     def test_list_tables(self):
         operation = {
@@ -247,7 +255,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             table = next(t for t in tables if t.get("name") == mock_table["name"])
             self.assertEqual(len(table["fields"]), len(mock_table["fields"]))
             for mock_field in mock_table["fields"]:
-                field = next(f for f in table["fields"] if f.get("name") == mock_field["name"])
+                field = next(
+                    f for f in table["fields"] if f.get("name") == mock_field["name"]
+                )
                 self.assertEqual(field.get("type"), mock_field["type"])
 
         # Verify that the metadata was cached and not re-fetched for fetch_columns
@@ -412,7 +422,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         # goes through _token_by_client_creds_flow and raises SalesforceCDPError.
         credentials = {**self.credentials}
         credentials["connect_args"] = {
-            k: v for k, v in self.credentials["connect_args"].items() if k != "core_token"
+            k: v
+            for k, v in self.credentials["connect_args"].items()
+            if k != "core_token"
         }
 
         response = self.agent.execute_operation(
@@ -491,7 +503,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             method=responses.POST,
             url="https://test.salesforce.com/services/a360/token",
             status=200,
-            body=json.dumps({"error": "invalid_dataspace", "message": "Dataspace not found"}),
+            body=json.dumps(
+                {"error": "invalid_dataspace", "message": "Dataspace not found"}
+            ),
         )
 
         operation = {
@@ -507,7 +521,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
 
         credentials = {**self.credentials}
         credentials["connect_args"] = {
-            k: v for k, v in self.credentials["connect_args"].items() if k != "core_token"
+            k: v
+            for k, v in self.credentials["connect_args"].items()
+            if k != "core_token"
         }
 
         response = self.agent.execute_operation(
@@ -607,7 +623,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             method=responses.POST,
             url="https://test.salesforce.com/services/a360/token",
             status=200,
-            body=json.dumps({"error": "invalid_dataspace", "message": "Dataspace not found"}),
+            body=json.dumps(
+                {"error": "invalid_dataspace", "message": "Dataspace not found"}
+            ),
         )
 
         client = SalesforceDataCloudProxyClient(
@@ -772,7 +790,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         self.assertFalse(response.is_error)
 
         # The a360/token POST must have been called with dataspace=unified_knowledge
-        self.assertGreater(len(a360_requests), 0, "Expected at least one a360/token call")
+        self.assertGreater(
+            len(a360_requests), 0, "Expected at least one a360/token call"
+        )
         a360_request = a360_requests[0]
         query_params = parse_qs(urlparse(a360_request.url).query)
         self.assertEqual(
@@ -846,7 +866,9 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         self.assertFalse(response.is_error)
 
         # The a360/token POST must NOT include a dataspace param
-        self.assertGreater(len(a360_requests), 0, "Expected at least one a360/token call")
+        self.assertGreater(
+            len(a360_requests), 0, "Expected at least one a360/token call"
+        )
         a360_request = a360_requests[0]
         query_params = parse_qs(urlparse(a360_request.url).query)
         self.assertNotIn(

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -158,9 +158,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             callback=self.metadata_endpoint,
         )
 
-        self.query_endpoint = Mock(
-            return_value=(200, {}, json.dumps(self.data_response))
-        )
+        self.query_endpoint = Mock(return_value=(200, {}, json.dumps(self.data_response)))
         self.mock_responses.add_callback(
             method=responses.POST,
             url="https://test.salesforce.com/api/v2/query",
@@ -183,9 +181,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(
-            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
-        )
+        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
 
     def test_init_with_client_credentials_flow(self):
         # New DC path: only client_id/client_secret, no core_token.
@@ -206,9 +202,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(
-            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
-        )
+        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
 
     def test_init_with_refresh_token(self):
         # Backward compat: old DCs sent refresh_token="required_but_not_used".
@@ -230,9 +224,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
 
         self.assertFalse(response.is_error)
-        self.assertEqual(
-            response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud"
-        )
+        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], "salesforce-data-cloud")
 
     def test_list_tables(self):
         operation = {
@@ -255,9 +247,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             table = next(t for t in tables if t.get("name") == mock_table["name"])
             self.assertEqual(len(table["fields"]), len(mock_table["fields"]))
             for mock_field in mock_table["fields"]:
-                field = next(
-                    f for f in table["fields"] if f.get("name") == mock_field["name"]
-                )
+                field = next(f for f in table["fields"] if f.get("name") == mock_field["name"])
                 self.assertEqual(field.get("type"), mock_field["type"])
 
         # Verify that the metadata was cached and not re-fetched for fetch_columns
@@ -422,9 +412,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         # goes through _token_by_client_creds_flow and raises SalesforceCDPError.
         credentials = {**self.credentials}
         credentials["connect_args"] = {
-            k: v
-            for k, v in self.credentials["connect_args"].items()
-            if k != "core_token"
+            k: v for k, v in self.credentials["connect_args"].items() if k != "core_token"
         }
 
         response = self.agent.execute_operation(
@@ -503,9 +491,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             method=responses.POST,
             url="https://test.salesforce.com/services/a360/token",
             status=200,
-            body=json.dumps(
-                {"error": "invalid_dataspace", "message": "Dataspace not found"}
-            ),
+            body=json.dumps({"error": "invalid_dataspace", "message": "Dataspace not found"}),
         )
 
         operation = {
@@ -521,9 +507,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
 
         credentials = {**self.credentials}
         credentials["connect_args"] = {
-            k: v
-            for k, v in self.credentials["connect_args"].items()
-            if k != "core_token"
+            k: v for k, v in self.credentials["connect_args"].items() if k != "core_token"
         }
 
         response = self.agent.execute_operation(
@@ -623,9 +607,7 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             method=responses.POST,
             url="https://test.salesforce.com/services/a360/token",
             status=200,
-            body=json.dumps(
-                {"error": "invalid_dataspace", "message": "Dataspace not found"}
-            ),
+            body=json.dumps({"error": "invalid_dataspace", "message": "Dataspace not found"}),
         )
 
         client = SalesforceDataCloudProxyClient(
@@ -715,3 +697,160 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         self.assertIn("[REDACTED]", redacted)
         # Non-sensitive fields must still be present
         self.assertIn("expires_in", redacted)
+
+    def test_query_connection_scoped_to_dataspace(self):
+        """
+        When `dataspace` is included in connect_args, the a360/token exchange must include
+        it as a query parameter so queries against tables in non-default dataspaces succeed.
+
+        Without this, the token is scoped to the base tenant and Salesforce returns:
+          NOT_FOUND: DataSourceEntity with developerName = <table> and tenantId = a360/prod/<id> is not found
+        """
+        from urllib.parse import urlparse, parse_qs
+
+        a360_requests = []
+
+        def capturing_a360_endpoint(request):
+            a360_requests.append(request)
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "access_token": self.api_token,
+                        "expires_in": 3600,
+                        "instance_url": "test.salesforce.com",
+                    }
+                ),
+            )
+
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/a360/token"
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            callback=capturing_a360_endpoint,
+        )
+
+        credentials = {
+            "connect_args": {
+                **self.credentials["connect_args"],
+                "dataspace": "unified_knowledge",
+            }
+        }
+
+        sql_query = "SELECT Id FROM abc_fit_tests__dll LIMIT 1"
+        commands = [
+            {"method": "cursor", "store": "_cursor"},
+            {"args": [sql_query], "method": "execute", "target": "_cursor"},
+            {"method": "fetchall", "store": "tmp_1", "target": "_cursor"},
+            {"method": "description", "store": "tmp_2", "target": "_cursor"},
+            {"method": "close", "target": "_cursor"},
+            {
+                "kwargs": {
+                    "all_results": {"__reference__": "tmp_1"},
+                    "description": {"__reference__": "tmp_2"},
+                },
+                "method": "build_dict",
+                "target": "__utils",
+            },
+        ]
+        operation = {
+            "commands": commands,
+            "skip_cache": True,
+            "trace_id": "test-dataspace-scoped-query",
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_query_scoped",
+            operation_dict=operation,
+            credentials=credentials,
+        )
+
+        self.assertFalse(response.is_error)
+
+        # The a360/token POST must have been called with dataspace=unified_knowledge
+        self.assertGreater(len(a360_requests), 0, "Expected at least one a360/token call")
+        a360_request = a360_requests[0]
+        query_params = parse_qs(urlparse(a360_request.url).query)
+        self.assertEqual(
+            query_params.get("dataspace"),
+            ["unified_knowledge"],
+            "a360/token POST must include dataspace=unified_knowledge query param",
+        )
+
+    def test_query_connection_unscoped_when_no_dataspace(self):
+        """
+        When `dataspace` is absent from connect_args (default / legacy path), the a360/token
+        exchange must NOT include a dataspace param — existing customers are unaffected.
+        """
+        from urllib.parse import urlparse, parse_qs
+
+        a360_requests = []
+
+        def capturing_a360_endpoint(request):
+            a360_requests.append(request)
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "access_token": self.api_token,
+                        "expires_in": 3600,
+                        "instance_url": "test.salesforce.com",
+                    }
+                ),
+            )
+
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/a360/token"
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            callback=capturing_a360_endpoint,
+        )
+
+        # Use default credentials — no dataspace field
+        sql_query = "SELECT Id FROM Account LIMIT 1"
+        commands = [
+            {"method": "cursor", "store": "_cursor"},
+            {"args": [sql_query], "method": "execute", "target": "_cursor"},
+            {"method": "fetchall", "store": "tmp_1", "target": "_cursor"},
+            {"method": "description", "store": "tmp_2", "target": "_cursor"},
+            {"method": "close", "target": "_cursor"},
+            {
+                "kwargs": {
+                    "all_results": {"__reference__": "tmp_1"},
+                    "description": {"__reference__": "tmp_2"},
+                },
+                "method": "build_dict",
+                "target": "__utils",
+            },
+        ]
+        operation = {
+            "commands": commands,
+            "skip_cache": True,
+            "trace_id": "test-unscoped-query",
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_query_unscoped",
+            operation_dict=operation,
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error)
+
+        # The a360/token POST must NOT include a dataspace param
+        self.assertGreater(len(a360_requests), 0, "Expected at least one a360/token call")
+        a360_request = a360_requests[0]
+        query_params = parse_qs(urlparse(a360_request.url).query)
+        self.assertNotIn(
+            "dataspace",
+            query_params,
+            "Unscoped path must not include dataspace in a360/token POST",
+        )

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -876,3 +876,84 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             query_params,
             "Unscoped path must not include dataspace in a360/token POST",
         )
+
+    def test_list_tables_unscoped_even_when_client_has_dataspace(self):
+        """
+        When list_tables(dataspace=None) is called on a proxy client that was
+        instantiated with a dataspace (i.e. a query-execution client), the
+        a360/token exchange must NOT include a dataspace param.  Without this
+        guard a future caller could accidentally receive dataspace-scoped table
+        results while believing the fetch was unscoped.
+        """
+        from urllib.parse import urlparse, parse_qs
+
+        a360_requests = []
+
+        def capturing_a360_endpoint(request):
+            a360_requests.append(request)
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "access_token": self.api_token,
+                        "expires_in": 3600,
+                        "instance_url": "test.salesforce.com",
+                    }
+                ),
+            )
+
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/a360/token"
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            callback=capturing_a360_endpoint,
+        )
+
+        # Credentials include a dataspace (as injected by the monolith for query jobs)
+        scoped_credentials = {
+            "connect_args": {
+                "domain": "test.salesforce.com",
+                "client_id": "test_client_id",
+                "client_secret": "test_client_secret",
+                "core_token": "test_core_token",
+                "dataspace": "unified_knowledge",
+            }
+        }
+
+        commands = [
+            {
+                "method": "list_tables",
+                "store": "tables",
+                "kwargs": {"dataspace": None},
+            },
+        ]
+        operation = {
+            "commands": commands,
+            "skip_cache": True,
+            "trace_id": "test-list-tables-unscoped-on-scoped-client",
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_tables_unscoped_on_scoped_client",
+            operation_dict=operation,
+            credentials=scoped_credentials,
+        )
+
+        self.assertFalse(response.is_error)
+
+        # Even though the client was created with dataspace=unified_knowledge,
+        # the list_tables(None) call must use an unscoped a360/token exchange
+        self.assertGreater(
+            len(a360_requests), 0, "Expected at least one a360/token call"
+        )
+        for req in a360_requests:
+            query_params = parse_qs(urlparse(req.url).query)
+            self.assertNotIn(
+                "dataspace",
+                query_params,
+                "list_tables(None) on a scoped client must not include dataspace in a360/token POST",
+            )


### PR DESCRIPTION
## Summary
- Add `dataspace: str | None` to `SalesforceDataCloudCredentials` so the per-dataspace token scope flows through to the connection constructor
- Extract `dataspace` from `connect_args` in `proxy_client_factory.py` and wire it to credentials
- When `dataspace` is set, `SalesforceDataCloudConnection` passes it to `SalesforceCDPConnection.__init__`, which includes it in the `/services/a360/token` POST — scoping the token so queries against non-default dataspaces (e.g. `unified_knowledge`) succeed

**Part of a 3-repo fix** — see also data-collector and monolith-django PRs. The monolith injects `dataspace` into connection credentials at dispatch time; data-collector forwards it in `connect_args`; this repo consumes it.

## Test plan
- [ ] `test_query_connection_scoped_to_dataspace` — verifies `dataspace` param appears in the a360/token POST when set in `connect_args`
- [ ] `test_query_connection_unscoped_when_no_dataspace` — verifies no `dataspace` param when absent
- [ ] All 17 existing tests continue to pass

## Context
Linear: [YET-856](https://linear.app/montecarlo/issue/YET-856)

Root cause: profiling/monitoring/validation queries against Salesforce Data Cloud tables in non-default dataspaces (e.g. `unified_knowledge`) fail with `NOT_FOUND: DataSourceEntity ... is not found` because the connection uses an unscoped a360/token. The fix scopes the token to the target dataspace at query dispatch time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)