### PR TITLE
fix(YET-711): read timeout params from connect_args, not top-level credentials

### DIFF
--- a/apollo/integrations/db/CLAUDE.md
+++ b/apollo/integrations/db/CLAUDE.md
@@ -23,7 +23,7 @@ Several clients use `pyodbc` (fabric, azure_database, sql_server). They share:
 - `_handle_datetimeoffset(dto_value)` — converts the raw bytes to a timezone-aware `datetime`
 - `_process_description(col)` — overrides base class to use `col[1].__name__` (pyodbc returns
   the Python type object, not a type code)
-- Default timeouts: `login_timeout=15s`, `query_timeout_in_seconds=840s` (14 minutes)
+- Default timeouts: `login_timeout=15s`, `query_timeout_in_seconds=840s` (14 minutes). These keys are passed inside `connect_args` and popped before the dict is serialized to an ODBC string.
 
 These are shared via `TSqlBaseDbProxyClient` in `tsql_base_db_proxy_client.py`, which all three clients inherit from.
 

--- a/apollo/integrations/db/fabric_proxy_client.py
+++ b/apollo/integrations/db/fabric_proxy_client.py
@@ -37,7 +37,7 @@ class MsFabricProxyClient(TSqlBaseDbProxyClient):
     spec, e.g. ``{"Driver": "{ODBC Driver 17 for SQL Server}", "Server": "..."}`` becomes
     ``"Driver={ODBC Driver 17 for SQL Server};Server=..."``.
 
-    Optional credential keys:
+    Optional ``connect_args`` keys (popped before serialization):
     - ``login_timeout``: seconds to wait when establishing a connection (default 15).
     - ``query_timeout_in_seconds``: seconds to wait for a query result (default 840).
     """
@@ -57,21 +57,23 @@ class MsFabricProxyClient(TSqlBaseDbProxyClient):
                 f"{_ATTR_CONNECT_ARGS} must be a dict, "
                 f"got {type(connect_args).__name__}"
             )
+        login_timeout = connect_args.pop(
+            "login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS
+        )
+        query_timeout = connect_args.pop(
+            "query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS
+        )
         connection_string = ";".join(
             f"{k}={_odbc_escape(str(v))}" for k, v in connect_args.items()
         )
         self._connection = pyodbc.connect(
             connection_string,
-            timeout=credentials.get(
-                "login_timeout", self._DEFAULT_LOGIN_TIMEOUT_IN_SECONDS
-            ),
+            timeout=login_timeout,
         )
         self._connection.add_output_converter(
             self._DATETIMEOFFSET_SQL_TYPE_CODE, self._handle_datetimeoffset
         )
-        self._connection.timeout = credentials.get(
-            "query_timeout_in_seconds", self._DEFAULT_QUERY_TIMEOUT_IN_SECONDS
-        )
+        self._connection.timeout = query_timeout
 
     @property
     def wrapped_client(self):

--- a/tests/test_ms_fabric_client.py
+++ b/tests/test_ms_fabric_client.py
@@ -62,22 +62,21 @@ class MsFabricProxyClientTests(TestCase):
 
     @patch("pyodbc.connect")
     def test_login_timeout_from_credentials(self, mock_connect):
-        """login_timeout in credentials overrides the default."""
+        """login_timeout in connect_args overrides the default."""
         mock_connect.return_value = self._mock_connection
         MsFabricProxyClient(
-            credentials={"connect_args": _CONNECT_ARGS_DICT, "login_timeout": 30},
+            credentials={"connect_args": {**_CONNECT_ARGS_DICT, "login_timeout": 30}},
             platform="test",
         )
         mock_connect.assert_called_once_with(_EXPECTED_ODBC_STRING, timeout=30)
 
     @patch("pyodbc.connect")
     def test_query_timeout_from_credentials(self, mock_connect):
-        """query_timeout_in_seconds in credentials overrides the default."""
+        """query_timeout_in_seconds in connect_args overrides the default."""
         mock_connect.return_value = self._mock_connection
         client = MsFabricProxyClient(
             credentials={
-                "connect_args": _CONNECT_ARGS_DICT,
-                "query_timeout_in_seconds": 120,
+                "connect_args": {**_CONNECT_ARGS_DICT, "query_timeout_in_seconds": 120},
             },
             platform="test",
         )


### PR DESCRIPTION
## What

`login_timeout` and `query_timeout_in_seconds` were previously read from the top-level `credentials` dict, but they belong inside `connect_args` alongside the other connection parameters.

More importantly, they ended up in the connection string.

Tests updated to pass timeout keys inside `connect_args`, and `CLAUDE.md` updated to document the correct location.

Closes [YET-711](https://linear.app/montecarlodata/issue/YET-711/apollo-agent-changes-for-ms-fabric)