### PR TITLE
Add the ability to pass through and validate custom CTP configs

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -449,7 +449,7 @@ class Agent:
         operation_name: str,
         operation_dict: Optional[Dict],
         credentials: Optional[Dict],
-        custom_ctp: Optional[Dict] = None,
+        ctp_config: Optional[Dict] = None,
     ) -> AgentResponse:
         """
         Executes an operation for the given connection type using the provided credentials.
@@ -480,7 +480,7 @@ class Agent:
             credentials,
             operation,
             lambda client: self._execute(client, operation_name, operation),
-            custom_ctp=custom_ctp,
+            ctp_config=ctp_config,
         )
 
     def execute_script(
@@ -534,7 +534,7 @@ class Agent:
         credentials: Optional[Dict],
         operation: AgentOperation,
         func: Callable[[BaseProxyClient], Any],
-        custom_ctp: Optional[Dict] = None,
+        ctp_config: Optional[Dict] = None,
     ):
         with self._inject_log_context(
             f"{connection_type}/{operation_name}", operation.trace_id
@@ -547,7 +547,7 @@ class Agent:
                     credentials,
                     operation.skip_cache,
                     self.platform,
-                    custom_ctp=custom_ctp,
+                    ctp_config=ctp_config,
                 )
                 response = self._execute_client_operation(
                     connection_type, client, operation_name, operation, func

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -449,6 +449,7 @@ class Agent:
         operation_name: str,
         operation_dict: Optional[Dict],
         credentials: Optional[Dict],
+        custom_ctp: Optional[Dict] = None,
     ) -> AgentResponse:
         """
         Executes an operation for the given connection type using the provided credentials.
@@ -479,6 +480,7 @@ class Agent:
             credentials,
             operation,
             lambda client: self._execute(client, operation_name, operation),
+            custom_ctp=custom_ctp,
         )
 
     def execute_script(
@@ -532,6 +534,7 @@ class Agent:
         credentials: Optional[Dict],
         operation: AgentOperation,
         func: Callable[[BaseProxyClient], Any],
+        custom_ctp: Optional[Dict] = None,
     ):
         with self._inject_log_context(
             f"{connection_type}/{operation_name}", operation.trace_id
@@ -540,7 +543,11 @@ class Agent:
             client: Optional[BaseProxyClient] = None
             try:
                 client = ProxyClientFactory.get_proxy_client(
-                    connection_type, credentials, operation.skip_cache, self.platform
+                    connection_type,
+                    credentials,
+                    operation.skip_cache,
+                    self.platform,
+                    custom_ctp=custom_ctp,
                 )
                 response = self._execute_client_operation(
                     connection_type, client, operation_name, operation, func

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -422,7 +422,9 @@ class ProxyClientFactory:
     ) -> BaseProxyClient:
         # skip_cache is a flag sent by the client, and can be used to force a new client to be created
         # it defaults to False
-        if skip_cache:
+        # ctp_config is not included in the cache key, so bypass the cache when a custom CTP is
+        # provided to avoid serving a previously cached client with different resolved credentials
+        if skip_cache or ctp_config:
             try:
                 return cls._create_proxy_client(
                     connection_type, credentials, platform, ctp_config=ctp_config

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -426,7 +426,7 @@ class ProxyClientFactory:
         # it defaults to False
         # ctp_config is not included in the cache key, so bypass the cache when a custom CTP is
         # provided to avoid serving a previously cached client with different resolved credentials
-        if skip_cache or ctp_config:
+        if skip_cache or ctp_config is not None:
             try:
                 return cls._create_proxy_client(
                     connection_type, credentials, platform, ctp_config=ctp_config
@@ -478,7 +478,7 @@ class ProxyClientFactory:
     ) -> BaseProxyClient:
         if credentials:
             credentials = decode_dictionary(credentials)
-        if ctp_config and credentials:
+        if ctp_config is not None and credentials:
             credentials = CtpRegistry.resolve_custom(
                 connection_type, credentials, ctp_config, context={"platform": platform}
             )

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -418,12 +418,15 @@ class ProxyClientFactory:
         credentials: Optional[Dict],
         skip_cache: bool,
         platform: str,
+        custom_ctp: Optional[Dict] = None,
     ) -> BaseProxyClient:
         # skip_cache is a flag sent by the client, and can be used to force a new client to be created
         # it defaults to False
         if skip_cache:
             try:
-                return cls._create_proxy_client(connection_type, credentials, platform)
+                return cls._create_proxy_client(
+                    connection_type, credentials, platform, custom_ctp=custom_ctp
+                )
             except Exception:
                 logger.exception(f"Failed to create {connection_type} client")
                 raise
@@ -439,7 +442,7 @@ class ProxyClientFactory:
                 logger.info(f"Using cached client for {connection_type}")
             else:
                 client = cls._create_proxy_client(
-                    connection_type, credentials, platform
+                    connection_type, credentials, platform, custom_ctp=custom_ctp
                 )
                 logger.info(f"Caching {connection_type} client")
                 cls._cache_client(key, client)
@@ -463,11 +466,19 @@ class ProxyClientFactory:
 
     @classmethod
     def _create_proxy_client(
-        cls, connection_type: str, credentials: Optional[Dict], platform: str
+        cls,
+        connection_type: str,
+        credentials: Optional[Dict],
+        platform: str,
+        custom_ctp: Optional[Dict] = None,
     ) -> BaseProxyClient:
         if credentials:
             credentials = decode_dictionary(credentials)
-        if credentials and CtpRegistry.get(connection_type):
+        if custom_ctp and credentials:
+            credentials = CtpRegistry.resolve_custom(
+                connection_type, credentials, custom_ctp, context={"platform": platform}
+            )
+        elif credentials and CtpRegistry.get(connection_type):
             credentials = CtpRegistry.resolve(
                 connection_type, credentials, context={"platform": platform}
             )

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -418,14 +418,14 @@ class ProxyClientFactory:
         credentials: Optional[Dict],
         skip_cache: bool,
         platform: str,
-        custom_ctp: Optional[Dict] = None,
+        ctp_config: Optional[Dict] = None,
     ) -> BaseProxyClient:
         # skip_cache is a flag sent by the client, and can be used to force a new client to be created
         # it defaults to False
         if skip_cache:
             try:
                 return cls._create_proxy_client(
-                    connection_type, credentials, platform, custom_ctp=custom_ctp
+                    connection_type, credentials, platform, ctp_config=ctp_config
                 )
             except Exception:
                 logger.exception(f"Failed to create {connection_type} client")
@@ -442,7 +442,7 @@ class ProxyClientFactory:
                 logger.info(f"Using cached client for {connection_type}")
             else:
                 client = cls._create_proxy_client(
-                    connection_type, credentials, platform, custom_ctp=custom_ctp
+                    connection_type, credentials, platform, ctp_config=ctp_config
                 )
                 logger.info(f"Caching {connection_type} client")
                 cls._cache_client(key, client)
@@ -470,13 +470,13 @@ class ProxyClientFactory:
         connection_type: str,
         credentials: Optional[Dict],
         platform: str,
-        custom_ctp: Optional[Dict] = None,
+        ctp_config: Optional[Dict] = None,
     ) -> BaseProxyClient:
         if credentials:
             credentials = decode_dictionary(credentials)
-        if custom_ctp and credentials:
+        if ctp_config and credentials:
             credentials = CtpRegistry.resolve_custom(
-                connection_type, credentials, custom_ctp, context={"platform": platform}
+                connection_type, credentials, ctp_config, context={"platform": platform}
             )
         elif credentials and CtpRegistry.get(connection_type):
             credentials = CtpRegistry.resolve(

--- a/apollo/integrations/ctp/defaults/databricks.py
+++ b/apollo/integrations/ctp/defaults/databricks.py
@@ -50,10 +50,13 @@ DATABRICKS_DEFAULT_CTP = CtpConfig(
             "http_path": "{{ raw.http_path }}",
             # PAT auth — absent when using OAuth (step contributes credentials_provider instead)
             "access_token": "{{ raw.access_token | default(none) }}",
-            "_use_arrow_native_complex_types": "{{ raw._use_arrow_native_complex_types | default(false) }}",
+            "_use_arrow_native_complex_types": "{{ raw._use_arrow_native_complex_types | default(none) }}",
             "_user_agent_entry": "{{ raw._user_agent_entry | default(none) }}",
         },
     ),
+    # Disable Arrow native complex types — required for correct behaviour with the
+    # Databricks SQL connector; injected as a default so custom CTP configs inherit it.
+    connect_args_defaults={"_use_arrow_native_complex_types": False},
 )
 
 CtpRegistry.register("databricks", DATABRICKS_DEFAULT_CTP)

--- a/apollo/integrations/ctp/defaults/hive.py
+++ b/apollo/integrations/ctp/defaults/hive.py
@@ -51,6 +51,8 @@ HIVE_DEFAULT_CTP = CtpConfig(
             "use_ssl": "{{ raw.use_ssl | default(none) }}",
         },
     ),
+    # 14min30s timeout — just under the DC Lambda limit; overridden by raw.timeout if mapped.
+    connect_args_defaults={"timeout": 870},
 )
 
 

--- a/apollo/integrations/ctp/defaults/oracle.py
+++ b/apollo/integrations/ctp/defaults/oracle.py
@@ -66,10 +66,11 @@ ORACLE_DEFAULT_CTP = CtpConfig(
             "dsn": "{{ raw.dsn | default(none) }}",
             "user": "{{ raw.user | default(none) }}",
             "password": "{{ raw.password | default(none) }}",
-            # Proxy client default is 1 (keepalive every minute); CTP matches that behaviour
-            "expire_time": "{{ raw.expire_time | default(1) }}",
+            "expire_time": "{{ raw.expire_time | default(none) }}",
         },
     ),
+    # Keep-alive every minute; required for AWS PrivateLink connections.
+    connect_args_defaults={"expire_time": 1},
 )
 
 from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402

--- a/apollo/integrations/ctp/defaults/postgres.py
+++ b/apollo/integrations/ctp/defaults/postgres.py
@@ -59,6 +59,14 @@ POSTGRES_DEFAULT_CTP = CtpConfig(
             "sslmode": "{{ raw.ssl_mode | default(none) }}",
         },
     ),
+    # TCP keepalives required for AWS PrivateLink; injected as defaults so custom
+    # CTP configs inherit them without having to redeclare them.
+    connect_args_defaults={
+        "keepalives": 1,
+        "keepalives_idle": 30,
+        "keepalives_interval": 10,
+        "keepalives_count": 5,
+    },
 )
 
 from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402

--- a/apollo/integrations/ctp/defaults/presto.py
+++ b/apollo/integrations/ctp/defaults/presto.py
@@ -46,14 +46,17 @@ PRESTO_DEFAULT_CTP = CtpConfig(
             "catalog": "{{ raw.catalog | default(none) }}",
             "schema": "{{ raw.schema | default(none) }}",
             "request_timeout": "{{ raw.request_timeout | default(none) }}",
-            "http_scheme": "{{ raw.http_scheme | default('http') }}",
-            "max_attempts": 3,
+            "http_scheme": "{{ raw.http_scheme | default(none) }}",
             # auth is omitted from the mapper — the step above contributes it via
             # field_map when raw.auth is present. When absent, auth is not in connect_args.
             # ssl_options is passed through for proxy-side _http_session.verify patching.
             "ssl_options": "{{ raw.ssl_options | default(none) }}",
         },
     ),
+    connect_args_defaults={
+        "http_scheme": "http",  # default scheme; overridden by raw.http_scheme if mapped
+        "max_attempts": 3,
+    },
 )
 
 CtpRegistry.register("presto", PRESTO_DEFAULT_CTP)

--- a/apollo/integrations/ctp/defaults/redshift.py
+++ b/apollo/integrations/ctp/defaults/redshift.py
@@ -62,7 +62,7 @@ REDSHIFT_DEFAULT_CTP = CtpConfig(
     # TCP keepalives required for AWS PrivateLink; injected as defaults so custom
     # CTP configs inherit them without having to redeclare them.
     connect_args_defaults={
-        "connect_timeout": 5,
+        "connect_timeout": 30,
         "keepalives": 1,
         "keepalives_idle": 30,
         "keepalives_interval": 10,

--- a/apollo/integrations/ctp/defaults/redshift.py
+++ b/apollo/integrations/ctp/defaults/redshift.py
@@ -54,16 +54,20 @@ REDSHIFT_DEFAULT_CTP = CtpConfig(
             "user": "{{ raw.user | default('awsuser') }}",
             "password": "{{ raw.password }}",
             "connect_timeout": "{{ raw.connect_timeout | default(none) }}",
-            # DC hardcodes these keepalive values for all Redshift connections
-            "keepalives": 1,
-            "keepalives_idle": 30,
-            "keepalives_interval": 10,
-            "keepalives_count": 5,
             # statement_timeout in ms; derived from query_timeout_in_seconds when provided
             "options": "{{ '-c statement_timeout=' ~ (raw.query_timeout_in_seconds | int * 1000) if raw.query_timeout_in_seconds is defined else none }}",
             "sslmode": "{{ raw.ssl_mode | default(none) }}",
         },
     ),
+    # TCP keepalives required for AWS PrivateLink; injected as defaults so custom
+    # CTP configs inherit them without having to redeclare them.
+    connect_args_defaults={
+        "connect_timeout": 5,
+        "keepalives": 1,
+        "keepalives_idle": 30,
+        "keepalives_interval": 10,
+        "keepalives_count": 5,
+    },
 )
 
 from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402

--- a/apollo/integrations/ctp/defaults/snowflake.py
+++ b/apollo/integrations/ctp/defaults/snowflake.py
@@ -74,7 +74,7 @@ SNOWFLAKE_DEFAULT_CTP = CtpConfig(
             "schema": "{{ raw.schema | default(none) }}",
             "role": "{{ raw.role | default(none) }}",
             "login_timeout": "{{ raw.login_timeout | default(none) }}",
-            "application": "{{ raw.application | default(none) }}",
+            "application": "{{ raw.application | default(none) }}",  # overrides connect_args_defaults when set
             "session_parameters": "{{ raw.session_parameters | default(none) }}",
             # Auth fields — omit when absent so the connector selects the auth mode
             # from whichever field is present (password / private_key / token).
@@ -87,6 +87,9 @@ SNOWFLAKE_DEFAULT_CTP = CtpConfig(
             "authenticator": "{{ raw.authenticator | default(none) }}",
         },
     ),
+    # Partner application name for Snowflake's usage tracking; always "Monte Carlo"
+    # unless overridden explicitly via raw.application in a custom CTP config.
+    connect_args_defaults={"application": "Monte Carlo"},
 )
 
 CtpRegistry.register("snowflake", SNOWFLAKE_DEFAULT_CTP)

--- a/apollo/integrations/ctp/defaults/starburst_enterprise.py
+++ b/apollo/integrations/ctp/defaults/starburst_enterprise.py
@@ -63,13 +63,15 @@ STARBURST_ENTERPRISE_DEFAULT_CTP = CtpConfig(
             "port": "{{ raw.port }}",  # DC input has port as string e.g. "8443"; mapper coerces str→int
             "user": "{{ raw.user }}",
             "password": "{{ raw.password }}",
-            "http_scheme": "https",
             "catalog": "{{ raw.catalog | default(none) }}",
             "schema": "{{ raw.schema | default(none) }}",
             # Pass through verify when DC already resolved it (step wins on collision for flat creds)
             "verify": "{{ raw.verify | default(none) }}",
         },
     ),
+    # Starburst Enterprise always uses HTTPS; injected as a default so custom CTP
+    # configs inherit it without having to redeclare it.
+    connect_args_defaults={"http_scheme": "https"},
 )
 
 from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402

--- a/apollo/integrations/ctp/defaults/starburst_galaxy.py
+++ b/apollo/integrations/ctp/defaults/starburst_galaxy.py
@@ -63,11 +63,13 @@ STARBURST_GALAXY_DEFAULT_CTP = CtpConfig(
             "port": "{{ raw.port }}",  # DC casts to int: int(port or 443); mapper coerces str→int
             "user": "{{ raw.user }}",
             "password": "{{ raw.password }}",
-            "http_scheme": "https",
             "catalog": "{{ raw.catalog | default(none) }}",
             "schema": "{{ raw.schema | default(none) }}",
         },
     ),
+    # Starburst Galaxy always uses HTTPS; injected as a default so custom CTP
+    # configs inherit it without having to redeclare it.
+    connect_args_defaults={"http_scheme": "https"},
 )
 
 from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402

--- a/apollo/integrations/ctp/mapper.py
+++ b/apollo/integrations/ctp/mapper.py
@@ -70,16 +70,23 @@ class Mapper:
                     message=f"Missing required fields: {sorted(missing)}",
                 )
 
-            # Coerce known fields to their declared types; unknown fields pass through.
+            # Reject unknown keys — passing unrecognised args to the driver silently
+            # masks typos and can cause connection failures that are hard to diagnose.
+            allowed_keys = (
+                config.schema.__required_keys__ | config.schema.__optional_keys__
+            )
+            unknown = result.keys() - allowed_keys
+            if unknown:
+                raise CtpPipelineError(
+                    stage="mapper_validation",
+                    message=f"Unknown fields not in schema {config.schema.__name__}: {sorted(unknown)}",
+                )
+
             schema_annotations = typing.get_type_hints(
                 config.schema, include_extras=True
             )
             result = {
-                key: (
-                    _coerce(value, schema_annotations[key])
-                    if key in schema_annotations
-                    else value
-                )
+                key: _coerce(value, schema_annotations[key])
                 for key, value in result.items()
             }
 

--- a/apollo/integrations/ctp/models.py
+++ b/apollo/integrations/ctp/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -14,6 +16,21 @@ class TransformStep:
         default_factory=dict
     )  # contributed to client_args only if this step executes
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TransformStep:
+        missing = {"type", "input", "output"} - data.keys()
+        if missing:
+            raise ValueError(
+                f"TransformStep missing required fields: {sorted(missing)}"
+            )
+        return cls(
+            type=data["type"],
+            input=data["input"],
+            output=data["output"],
+            when=data.get("when"),
+            field_map=data.get("field_map", {}),
+        )
+
 
 @dataclass
 class MapperConfig:
@@ -22,12 +39,37 @@ class MapperConfig:
     schema: type | None = None
     passthrough: bool = False
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MapperConfig:
+        missing = {"name", "field_map"} - data.keys()
+        if missing:
+            raise ValueError(f"MapperConfig missing required fields: {sorted(missing)}")
+        return cls(
+            name=data["name"],
+            field_map=data["field_map"],
+            # schema is always None when deserializing from JSON —
+            # it is injected at runtime from the registered CTP for the connection type
+            schema=None,
+            passthrough=data.get("passthrough", False),
+        )
+
 
 @dataclass
 class CtpConfig:
     name: str
     steps: list[TransformStep]
     mapper: MapperConfig
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CtpConfig:
+        missing = {"name", "steps", "mapper"} - data.keys()
+        if missing:
+            raise ValueError(f"CtpConfig missing required fields: {sorted(missing)}")
+        return cls(
+            name=data["name"],
+            steps=[TransformStep.from_dict(s) for s in data["steps"]],
+            mapper=MapperConfig.from_dict(data["mapper"]),
+        )
 
 
 @dataclass

--- a/apollo/integrations/ctp/models.py
+++ b/apollo/integrations/ctp/models.py
@@ -23,12 +23,21 @@ class TransformStep:
             raise ValueError(
                 f"TransformStep missing required fields: {sorted(missing)}"
             )
+        if not isinstance(data["type"], str):
+            raise ValueError("TransformStep 'type' must be a str")
+        if not isinstance(data["input"], dict):
+            raise ValueError("TransformStep 'input' must be a dict")
+        if not isinstance(data["output"], dict):
+            raise ValueError("TransformStep 'output' must be a dict")
+        field_map = data.get("field_map", {})
+        if not isinstance(field_map, dict):
+            raise ValueError("TransformStep 'field_map' must be a dict")
         return cls(
             type=data["type"],
             input=data["input"],
             output=data["output"],
             when=data.get("when"),
-            field_map=data.get("field_map", {}),
+            field_map=field_map,
         )
 
 
@@ -74,11 +83,19 @@ class CtpConfig:
     def from_dict(cls, data: dict[str, Any]) -> CtpConfig:
         if "mapper" not in data:
             raise ValueError("CtpConfig missing required field: 'mapper'")
+        steps = data.get("steps", [])
+        if not isinstance(steps, list):
+            raise ValueError("CtpConfig 'steps' must be a list")
+        if not all(isinstance(s, dict) for s in steps):
+            raise ValueError("CtpConfig 'steps' must be a list of dicts")
+        connect_args_defaults = data.get("connect_args_defaults", {})
+        if not isinstance(connect_args_defaults, dict):
+            raise ValueError("CtpConfig 'connect_args_defaults' must be a dict")
         return cls(
             mapper=MapperConfig.from_dict(data["mapper"]),
             name=data.get("name", ""),
-            steps=[TransformStep.from_dict(s) for s in data.get("steps", [])],
-            connect_args_defaults=data.get("connect_args_defaults", {}),
+            steps=[TransformStep.from_dict(s) for s in steps],
+            connect_args_defaults=connect_args_defaults,
         )
 
 

--- a/apollo/integrations/ctp/models.py
+++ b/apollo/integrations/ctp/models.py
@@ -68,6 +68,7 @@ class CtpConfig:
     mapper: MapperConfig
     name: str = ""
     steps: list[TransformStep] = field(default_factory=list)
+    connect_args_defaults: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CtpConfig:
@@ -77,6 +78,7 @@ class CtpConfig:
             mapper=MapperConfig.from_dict(data["mapper"]),
             name=data.get("name", ""),
             steps=[TransformStep.from_dict(s) for s in data.get("steps", [])],
+            connect_args_defaults=data.get("connect_args_defaults", {}),
         )
 
 

--- a/apollo/integrations/ctp/models.py
+++ b/apollo/integrations/ctp/models.py
@@ -34,41 +34,49 @@ class TransformStep:
 
 @dataclass
 class MapperConfig:
-    name: str
     field_map: dict[str, Any]
+    name: str = ""
     schema: type | None = None
     passthrough: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MapperConfig:
-        missing = {"name", "field_map"} - data.keys()
-        if missing:
-            raise ValueError(f"MapperConfig missing required fields: {sorted(missing)}")
+        if "field_map" in data:
+            # Full format: {field_map: {...}, name?: "...", passthrough?: bool}
+            field_map = data["field_map"]
+            name = data.get("name", "")
+            passthrough = data.get("passthrough", False)
+        else:
+            # Shorthand: the entire dict is the field_map (no name or passthrough)
+            field_map = data
+            name = ""
+            passthrough = False
+        if not isinstance(field_map, dict):
+            raise ValueError("MapperConfig 'field_map' must be a dict")
         return cls(
-            name=data["name"],
-            field_map=data["field_map"],
+            field_map=field_map,
+            name=name,
             # schema is always None when deserializing from JSON —
             # it is injected at runtime from the registered CTP for the connection type
             schema=None,
-            passthrough=data.get("passthrough", False),
+            passthrough=passthrough,
         )
 
 
 @dataclass
 class CtpConfig:
-    name: str
-    steps: list[TransformStep]
     mapper: MapperConfig
+    name: str = ""
+    steps: list[TransformStep] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CtpConfig:
-        missing = {"name", "steps", "mapper"} - data.keys()
-        if missing:
-            raise ValueError(f"CtpConfig missing required fields: {sorted(missing)}")
+        if "mapper" not in data:
+            raise ValueError("CtpConfig missing required field: 'mapper'")
         return cls(
-            name=data["name"],
-            steps=[TransformStep.from_dict(s) for s in data["steps"]],
             mapper=MapperConfig.from_dict(data["mapper"]),
+            name=data.get("name", ""),
+            steps=[TransformStep.from_dict(s) for s in data.get("steps", [])],
         )
 
 

--- a/apollo/integrations/ctp/pipeline.py
+++ b/apollo/integrations/ctp/pipeline.py
@@ -34,6 +34,11 @@ class CtpPipeline:
             result = self._mapper.execute(
                 config.mapper, state, step_field_maps=step_field_maps
             )
+            # Merge connector-level defaults under the mapper output so that
+            # static constants (e.g. http_scheme, keepalives) survive CTP
+            # replacement even when a custom mapper omits them.  Mapper wins.
+            if config.connect_args_defaults:
+                result = {**config.connect_args_defaults, **result}
         finally:
             # Scrub credential state regardless of success or failure so that raw
             # credentials and derived secrets (tokens, keys) cannot leak into

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -80,6 +80,13 @@ class CtpRegistry:
         registered = cls._registry.get(connection_type)
         if registered is not None:
             config.mapper.schema = registered.mapper.schema
+            # Inherit connector-level defaults from the registered config so custom
+            # mappers automatically get static constants (e.g. http_scheme, keepalives).
+            # Custom config's own connect_args_defaults take precedence over registered ones.
+            config.connect_args_defaults = {
+                **registered.connect_args_defaults,
+                **config.connect_args_defaults,
+            }
         raw_or_connect_args = credentials.get(_ATTR_CONNECT_ARGS, credentials)
         if not isinstance(raw_or_connect_args, dict):
             return credentials

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -66,7 +66,7 @@ class CtpRegistry:
         cls,
         connection_type: str,
         credentials: dict[str, Any],
-        custom_ctp: dict[str, Any],
+        ctp_config: dict[str, Any],
         context: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Resolve credentials using a caller-supplied CTP config dict.
@@ -76,7 +76,7 @@ class CtpRegistry:
         Follows the same connect_args unwrap-and-run path as resolve().
         """
         _ensure_initialized()
-        config = CtpConfig.from_dict(custom_ctp)
+        config = CtpConfig.from_dict(ctp_config)
         registered = cls._registry.get(connection_type)
         if registered is not None:
             config.mapper.schema = registered.mapper.schema

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -62,6 +62,34 @@ class CtpRegistry:
         return cls._registry.get(connection_type)
 
     @classmethod
+    def resolve_custom(
+        cls,
+        connection_type: str,
+        credentials: dict[str, Any],
+        custom_ctp: dict[str, Any],
+        context: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve credentials using a caller-supplied CTP config dict.
+
+        The TypedDict schema from the registered default for connection_type is
+        injected into the custom config's mapper so the output contract is preserved.
+        Follows the same connect_args unwrap-and-run path as resolve().
+        """
+        _ensure_initialized()
+        config = CtpConfig.from_dict(custom_ctp)
+        registered = cls._registry.get(connection_type)
+        if registered is not None:
+            config.mapper.schema = registered.mapper.schema
+        raw_or_connect_args = credentials.get(_ATTR_CONNECT_ARGS, credentials)
+        if not isinstance(raw_or_connect_args, dict):
+            return credentials
+        return {
+            _ATTR_CONNECT_ARGS: CtpPipeline().execute(
+                config, raw_or_connect_args, context=context or {}
+            )
+        }
+
+    @classmethod
     def resolve(
         cls,
         connection_type: str,

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -79,11 +79,11 @@ def validate_ctp_config(
                 if err:
                     errors.append(err)
 
-    # 5. Schema coverage: mapper field_map must cover all TypedDict required keys.
-    # If steps are present they may also contribute keys, so missing keys are a
-    # warning rather than a hard failure in that case.
+    # 5. Schema coverage: mapper field_map must cover all TypedDict required keys,
+    # and must not contain keys outside the schema (required or optional).
     if config.mapper.schema is not None:
         required = config.mapper.schema.__required_keys__
+        allowed = required | config.mapper.schema.__optional_keys__
         provided = set(config.mapper.field_map.keys())
         missing = required - provided
         if missing:
@@ -96,5 +96,10 @@ def validate_ctp_config(
                 errors.append(
                     f"Mapper field_map is missing required keys: {sorted(missing)}"
                 )
+        unknown = provided - allowed
+        if unknown:
+            errors.append(
+                f"Mapper field_map contains unknown keys not in schema: {sorted(unknown)}"
+            )
 
     return {"valid": len(errors) == 0, "errors": errors}

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -1,0 +1,100 @@
+# apollo/integrations/ctp/validator.py
+"""Structural validation for custom CTP configs.
+
+Validates a caller-supplied CtpConfig dict without executing the pipeline:
+  - Deserializes via CtpConfig.from_dict()
+  - Injects the TypedDict schema from the registered CTP for the connection type
+  - Verifies that all transform step types are registered
+  - Checks Jinja2 template syntax in field_map values and step when-expressions
+  - Confirms the mapper field_map covers all TypedDict required keys
+"""
+from typing import Any
+
+from jinja2 import Environment, TemplateSyntaxError
+
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.models import CtpConfig
+from apollo.integrations.ctp.registry import CtpRegistry
+from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+_syntax_env = Environment()
+
+
+def _check_template_syntax(template: str, location: str) -> str | None:
+    try:
+        _syntax_env.parse(template)
+        return None
+    except TemplateSyntaxError as e:
+        return f"Template syntax error in {location}: {e.message}"
+
+
+def validate_ctp_config(
+    connection_type: str,
+    custom_ctp: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate a custom CTP config dict structurally without executing the pipeline.
+
+    Returns ``{"valid": True, "errors": []}`` on success, or
+    ``{"valid": False, "errors": [...]}`` with one entry per problem found.
+    """
+    errors: list[str] = []
+
+    # 1. Deserialize
+    try:
+        config = CtpConfig.from_dict(custom_ctp)
+    except ValueError as e:
+        return {"valid": False, "errors": [str(e)]}
+
+    # 2. Inject schema from the registered CTP so required-key coverage can be checked
+    registered = CtpRegistry.get(connection_type)
+    if registered is not None:
+        config.mapper.schema = registered.mapper.schema
+
+    # 3. Verify all transform step types are registered
+    for step in config.steps:
+        try:
+            TransformRegistry.get(step.type)
+        except CtpPipelineError as e:
+            errors.append(str(e))
+
+    # 4. Check Jinja2 template syntax in mapper field_map values
+    for key, template in config.mapper.field_map.items():
+        if isinstance(template, str) and ("{{" in template or "{%" in template):
+            err = _check_template_syntax(template, f"mapper.field_map[{key!r}]")
+            if err:
+                errors.append(err)
+
+    # Check Jinja2 syntax in step field_map values and when-expressions
+    for step in config.steps:
+        if step.when:
+            when_template = f"{{% if {step.when} %}}True{{% else %}}False{{% endif %}}"
+            err = _check_template_syntax(when_template, f"step '{step.type}' when")
+            if err:
+                errors.append(err)
+        for key, template in step.field_map.items():
+            if isinstance(template, str) and ("{{" in template or "{%" in template):
+                err = _check_template_syntax(
+                    template, f"step '{step.type}' field_map[{key!r}]"
+                )
+                if err:
+                    errors.append(err)
+
+    # 5. Schema coverage: mapper field_map must cover all TypedDict required keys.
+    # If steps are present they may also contribute keys, so missing keys are a
+    # warning rather than a hard failure in that case.
+    if config.mapper.schema is not None:
+        required = config.mapper.schema.__required_keys__
+        provided = set(config.mapper.field_map.keys())
+        missing = required - provided
+        if missing:
+            if config.steps:
+                errors.append(
+                    f"Mapper field_map may be missing required keys "
+                    f"(steps may provide them): {sorted(missing)}"
+                )
+            else:
+                errors.append(
+                    f"Mapper field_map is missing required keys: {sorted(missing)}"
+                )
+
+    return {"valid": len(errors) == 0, "errors": errors}

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -30,7 +30,7 @@ def _check_template_syntax(template: str, location: str) -> str | None:
 
 def validate_ctp_config(
     connection_type: str,
-    custom_ctp: dict[str, Any],
+    ctp_config: dict[str, Any],
 ) -> dict[str, Any]:
     """Validate a custom CTP config dict structurally without executing the pipeline.
 
@@ -41,7 +41,7 @@ def validate_ctp_config(
 
     # 1. Deserialize
     try:
-        config = CtpConfig.from_dict(custom_ctp)
+        config = CtpConfig.from_dict(ctp_config)
     except ValueError as e:
         return {"valid": False, "errors": [str(e)]}
 

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -10,14 +10,15 @@ Validates a caller-supplied CtpConfig dict without executing the pipeline:
 """
 from typing import Any
 
-from jinja2 import Environment, TemplateSyntaxError
+from jinja2 import TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
 
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.models import CtpConfig
 from apollo.integrations.ctp.registry import CtpRegistry
 from apollo.integrations.ctp.transforms.registry import TransformRegistry
 
-_syntax_env = Environment()
+_syntax_env = SandboxedEnvironment()
 
 
 def _check_template_syntax(template: str, location: str) -> str | None:

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -44,6 +44,14 @@ def validate_ctp_config(
     warnings: list[str] = []
 
     # 1. Deserialize
+    if not isinstance(ctp_config, dict):
+        return {
+            "valid": False,
+            "errors": [
+                f"ctp_config must be a JSON object, got {type(ctp_config).__name__}"
+            ],
+            "warnings": [],
+        }
     try:
         config = CtpConfig.from_dict(ctp_config)
     except ValueError as e:

--- a/apollo/integrations/ctp/validator.py
+++ b/apollo/integrations/ctp/validator.py
@@ -35,16 +35,19 @@ def validate_ctp_config(
 ) -> dict[str, Any]:
     """Validate a custom CTP config dict structurally without executing the pipeline.
 
-    Returns ``{"valid": True, "errors": []}`` on success, or
-    ``{"valid": False, "errors": [...]}`` with one entry per problem found.
+    Returns ``{"valid": True, "errors": [], "warnings": []}`` on success, or
+    ``{"valid": False, "errors": [...], "warnings": [...]}`` with one entry per
+    problem found.  Missing required keys that may be covered by steps are reported
+    as warnings rather than errors and do not affect ``valid``.
     """
     errors: list[str] = []
+    warnings: list[str] = []
 
     # 1. Deserialize
     try:
         config = CtpConfig.from_dict(ctp_config)
     except ValueError as e:
-        return {"valid": False, "errors": [str(e)]}
+        return {"valid": False, "errors": [str(e)], "warnings": []}
 
     # 2. Inject schema from the registered CTP so required-key coverage can be checked
     registered = CtpRegistry.get(connection_type)
@@ -89,7 +92,7 @@ def validate_ctp_config(
         missing = required - provided
         if missing:
             if config.steps:
-                errors.append(
+                warnings.append(
                     f"Mapper field_map may be missing required keys "
                     f"(steps may provide them): {sorted(missing)}"
                 )
@@ -103,4 +106,13 @@ def validate_ctp_config(
                 f"Mapper field_map contains unknown keys not in schema: {sorted(unknown)}"
             )
 
-    return {"valid": len(errors) == 0, "errors": errors}
+        # 6. Unknown-key check for each step's field_map
+        for step in config.steps:
+            step_unknown = set(step.field_map.keys()) - allowed
+            if step_unknown:
+                errors.append(
+                    f"Step '{step.type}' field_map contains unknown keys not in schema: "
+                    f"{sorted(step_unknown)}"
+                )
+
+    return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -16,6 +16,7 @@ from apollo.common.agent.redact_formatter import RedactFormatterWrapper
 from apollo.agent.settings import VERSION
 from apollo.agent.utils import AgentUtils
 from apollo.credentials.factory import CredentialsFactory
+from apollo.integrations.ctp.validator import validate_ctp_config
 
 app = Flask(__name__)
 Compress(app)
@@ -222,6 +223,57 @@ def execute_agent_operation(
     return agent.execute_operation(
         connection_type, operation_name, operation, credentials, custom_ctp=custom_ctp
     )
+
+
+@app.route("/api/v1/ctp/validate/<connection_type>", methods=["POST"])  # type: ignore
+def ctp_validate(connection_type: str) -> Tuple[Dict, int]:
+    """
+    Validate a custom CTP config for a given connection type.
+
+    Structural validation only: deserialization, transform-type existence, Jinja2
+    template syntax, and required TypedDict key coverage. Does not execute the
+    pipeline or create a proxy client.
+    ---
+    tags:
+        - Agent Operations
+    produces:
+        - application/json
+    parameters:
+        - in: path
+          name: connection_type
+          required: true
+          description: The connection type whose registered TypedDict schema is used for validation.
+          schema:
+              type: string
+              example: databricks-rest
+        - in: body
+          name: body
+          schema:
+            id: CtpValidateRequest
+            required:
+                - custom_ctp
+            properties:
+                custom_ctp:
+                    type: object
+                    description: The CTP config to validate (name, steps, mapper).
+    responses:
+        200:
+            description: Validation result.
+            schema:
+                properties:
+                    valid:
+                        type: boolean
+                    errors:
+                        type: array
+                        items:
+                            type: string
+    """
+    json_request: Dict = request.json or {}
+    custom_ctp = json_request.get("custom_ctp")
+    if not custom_ctp:
+        return {"valid": False, "errors": ["custom_ctp is required"]}, 400
+    result = validate_ctp_config(connection_type, custom_ctp)
+    return result, 200
 
 
 @app.route("/api/v1/agent/execute_script/<connection_type>", methods=["POST"])  # type: ignore

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -218,10 +218,10 @@ def execute_agent_operation(
         )
 
     operation = json_request.get("operation")
-    custom_ctp = json_request.get("custom_ctp")
+    ctp_config = json_request.get("ctp_config")
 
     return agent.execute_operation(
-        connection_type, operation_name, operation, credentials, custom_ctp=custom_ctp
+        connection_type, operation_name, operation, credentials, ctp_config=ctp_config
     )
 
 
@@ -251,9 +251,9 @@ def ctp_validate(connection_type: str) -> Tuple[Dict, int]:
           schema:
             id: CtpValidateRequest
             required:
-                - custom_ctp
+                - ctp_config
             properties:
-                custom_ctp:
+                ctp_config:
                     type: object
                     description: The CTP config to validate (name, steps, mapper).
     responses:
@@ -269,10 +269,10 @@ def ctp_validate(connection_type: str) -> Tuple[Dict, int]:
                             type: string
     """
     json_request: Dict = request.json or {}
-    custom_ctp = json_request.get("custom_ctp")
-    if not custom_ctp:
-        return {"valid": False, "errors": ["custom_ctp is required"]}, 400
-    result = validate_ctp_config(connection_type, custom_ctp)
+    ctp_config = json_request.get("ctp_config")
+    if not ctp_config:
+        return {"valid": False, "errors": ["ctp_config is required"]}, 400
+    result = validate_ctp_config(connection_type, ctp_config)
     return result, 200
 
 

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -267,8 +267,24 @@ def ctp_validate(connection_type: str) -> Tuple[Dict, int]:
                         type: array
                         items:
                             type: string
+                    warnings:
+                        type: array
+                        items:
+                            type: string
+        400:
+            description: Invalid or missing request body.
+            schema:
+                properties:
+                    valid:
+                        type: boolean
+                    errors:
+                        type: array
+                        items:
+                            type: string
     """
-    json_request: Dict = request.json or {}
+    if not request.is_json or not isinstance(request.json, dict):
+        return {"valid": False, "errors": ["Request body must be a JSON object"]}, 400
+    json_request: Dict = request.json
     ctp_config = json_request.get("ctp_config")
     if ctp_config is None:
         return {"valid": False, "errors": ["ctp_config is required"]}, 400

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -217,9 +217,10 @@ def execute_agent_operation(
         )
 
     operation = json_request.get("operation")
+    custom_ctp = json_request.get("custom_ctp")
 
     return agent.execute_operation(
-        connection_type, operation_name, operation, credentials
+        connection_type, operation_name, operation, credentials, custom_ctp=custom_ctp
     )
 
 

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -270,7 +270,7 @@ def ctp_validate(connection_type: str) -> Tuple[Dict, int]:
     """
     json_request: Dict = request.json or {}
     ctp_config = json_request.get("ctp_config")
-    if not ctp_config:
+    if ctp_config is None:
         return {"valid": False, "errors": ["ctp_config is required"]}, 400
     result = validate_ctp_config(connection_type, ctp_config)
     return result, 200

--- a/tests/ctp/test_mapper.py
+++ b/tests/ctp/test_mapper.py
@@ -139,15 +139,17 @@ class TestMapperSchemaValidation(TestCase):
         self.assertEqual("mapper_validation", ctx.exception.stage)
         self.assertIn("port", str(ctx.exception))
 
-    def test_unknown_field_passes_through(self):
-        # Fields not in the schema are not coerced but are allowed through — driver catches any error.
+    def test_unknown_field_raises(self):
+        # Fields not in the schema are rejected — prevents typos from silently passing bad args to the driver.
         mapper, config = self._mapper(
             {"host": "{{ raw.host }}", "port": "{{ raw.port }}", "bad_key": "value"},
             schema=_MinimalSchema,
         )
         state = PipelineState(raw={"host": "localhost", "port": 5432})
-        result = mapper.execute(config, state)
-        self.assertEqual("value", result["bad_key"])
+        with self.assertRaises(CtpPipelineError) as ctx:
+            mapper.execute(config, state)
+        self.assertEqual("mapper_validation", ctx.exception.stage)
+        self.assertIn("bad_key", str(ctx.exception))
 
     def test_string_port_coerced_to_int(self):
         # Port arrives as string (DC-style); schema says int → mapper coerces.
@@ -176,8 +178,8 @@ class TestMapperSchemaValidation(TestCase):
         self.assertIsInstance(result["port"], int)
         self.assertEqual(5432, result["port"])
 
-    def test_unknown_field_not_coerced(self):
-        # Unknown fields are passed through as-is without type coercion.
+    def test_unknown_field_raises_regardless_of_value_type(self):
+        # Unknown fields are rejected even when their values wouldn't need coercion.
         mapper, config = self._mapper(
             {
                 "host": "{{ raw.host }}",
@@ -187,8 +189,10 @@ class TestMapperSchemaValidation(TestCase):
             schema=_MinimalSchema,
         )
         state = PipelineState(raw={"host": "h", "port": 5432, "extra": "some_string"})
-        result = mapper.execute(config, state)
-        self.assertEqual("some_string", result["extra"])
+        with self.assertRaises(CtpPipelineError) as ctx:
+            mapper.execute(config, state)
+        self.assertEqual("mapper_validation", ctx.exception.stage)
+        self.assertIn("extra", str(ctx.exception))
 
     def test_passthrough_skips_schema_validation(self):
         # passthrough=True with a schema that would fail (missing required keys)

--- a/tests/ctp/test_models.py
+++ b/tests/ctp/test_models.py
@@ -1,11 +1,35 @@
 # tests/ctp/test_models.py
+from dataclasses import asdict
 from unittest import TestCase
+
 from apollo.integrations.ctp.models import (
     CtpConfig,
     MapperConfig,
     PipelineState,
     TransformStep,
 )
+
+_STEP_DICT = {
+    "type": "resolve_databricks_token",
+    "input": {"workspace_url": "{{ raw.databricks_workspace_url }}"},
+    "output": {"token": "databricks_rest_token"},
+    "when": "raw.databricks_token is defined",
+    "field_map": {"token": "{{ derived.databricks_rest_token }}"},
+}
+
+_MAPPER_DICT = {
+    "name": "my_mapper",
+    "field_map": {
+        "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+        "token": "{{ raw.token | default(none) }}",
+    },
+}
+
+_CTP_DICT = {
+    "name": "my-custom-ctp",
+    "steps": [_STEP_DICT],
+    "mapper": _MAPPER_DICT,
+}
 
 
 class TestCtpModels(TestCase):
@@ -44,3 +68,124 @@ class TestCtpModels(TestCase):
     def test_transform_step_field_map_defaults_empty(self):
         step = TransformStep(type="tmp_file_write", input={}, output={})
         self.assertEqual({}, step.field_map)
+
+
+class TestTransformStepFromDict(TestCase):
+    def test_required_fields(self):
+        step = TransformStep.from_dict(_STEP_DICT)
+        self.assertEqual("resolve_databricks_token", step.type)
+        self.assertEqual(
+            {"workspace_url": "{{ raw.databricks_workspace_url }}"}, step.input
+        )
+        self.assertEqual({"token": "databricks_rest_token"}, step.output)
+
+    def test_optional_when(self):
+        step = TransformStep.from_dict(_STEP_DICT)
+        self.assertEqual("raw.databricks_token is defined", step.when)
+
+    def test_when_defaults_to_none(self):
+        data = {k: v for k, v in _STEP_DICT.items() if k != "when"}
+        step = TransformStep.from_dict(data)
+        self.assertIsNone(step.when)
+
+    def test_field_map_defaults_to_empty(self):
+        data = {k: v for k, v in _STEP_DICT.items() if k != "field_map"}
+        step = TransformStep.from_dict(data)
+        self.assertEqual({}, step.field_map)
+
+    def test_missing_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict(
+                {k: v for k, v in _STEP_DICT.items() if k != "type"}
+            )
+        self.assertIn("type", str(ctx.exception))
+
+    def test_missing_input_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict(
+                {k: v for k, v in _STEP_DICT.items() if k != "input"}
+            )
+        self.assertIn("input", str(ctx.exception))
+
+    def test_missing_output_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict(
+                {k: v for k, v in _STEP_DICT.items() if k != "output"}
+            )
+        self.assertIn("output", str(ctx.exception))
+
+
+class TestMapperConfigFromDict(TestCase):
+    def test_required_fields(self):
+        mapper = MapperConfig.from_dict(_MAPPER_DICT)
+        self.assertEqual("my_mapper", mapper.name)
+        self.assertEqual(_MAPPER_DICT["field_map"], mapper.field_map)
+
+    def test_schema_always_none(self):
+        # schema is not deserialized — injected at runtime from the registered CTP
+        mapper = MapperConfig.from_dict(_MAPPER_DICT)
+        self.assertIsNone(mapper.schema)
+
+    def test_passthrough_defaults_to_false(self):
+        mapper = MapperConfig.from_dict(_MAPPER_DICT)
+        self.assertFalse(mapper.passthrough)
+
+    def test_passthrough_true(self):
+        mapper = MapperConfig.from_dict({**_MAPPER_DICT, "passthrough": True})
+        self.assertTrue(mapper.passthrough)
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            MapperConfig.from_dict(
+                {k: v for k, v in _MAPPER_DICT.items() if k != "name"}
+            )
+        self.assertIn("name", str(ctx.exception))
+
+    def test_missing_field_map_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            MapperConfig.from_dict(
+                {k: v for k, v in _MAPPER_DICT.items() if k != "field_map"}
+            )
+        self.assertIn("field_map", str(ctx.exception))
+
+
+class TestCtpConfigFromDict(TestCase):
+    def test_full_config(self):
+        ctp = CtpConfig.from_dict(_CTP_DICT)
+        self.assertEqual("my-custom-ctp", ctp.name)
+        self.assertEqual(1, len(ctp.steps))
+        self.assertEqual("resolve_databricks_token", ctp.steps[0].type)
+        self.assertEqual("my_mapper", ctp.mapper.name)
+
+    def test_empty_steps(self):
+        ctp = CtpConfig.from_dict({**_CTP_DICT, "steps": []})
+        self.assertEqual([], ctp.steps)
+
+    def test_missing_name_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "name"})
+        self.assertIn("name", str(ctx.exception))
+
+    def test_missing_steps_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "steps"})
+        self.assertIn("steps", str(ctx.exception))
+
+    def test_missing_mapper_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "mapper"})
+        self.assertIn("mapper", str(ctx.exception))
+
+    def test_invalid_step_raises(self):
+        with self.assertRaises(ValueError):
+            CtpConfig.from_dict({**_CTP_DICT, "steps": [{"type": "something"}]})
+
+    def test_round_trip(self):
+        ctp = CtpConfig.from_dict(_CTP_DICT)
+        serialized = asdict(ctp)
+        # schema is always None in JSON form — remove before round-tripping
+        del serialized["mapper"]["schema"]
+        ctp2 = CtpConfig.from_dict(serialized)
+        self.assertEqual(ctp.name, ctp2.name)
+        self.assertEqual(ctp.steps[0].type, ctp2.steps[0].type)
+        self.assertEqual(ctp.mapper.field_map, ctp2.mapper.field_map)

--- a/tests/ctp/test_models.py
+++ b/tests/ctp/test_models.py
@@ -134,19 +134,28 @@ class TestMapperConfigFromDict(TestCase):
         mapper = MapperConfig.from_dict({**_MAPPER_DICT, "passthrough": True})
         self.assertTrue(mapper.passthrough)
 
-    def test_missing_name_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            MapperConfig.from_dict(
-                {k: v for k, v in _MAPPER_DICT.items() if k != "name"}
-            )
-        self.assertIn("name", str(ctx.exception))
+    def test_name_defaults_to_empty(self):
+        mapper = MapperConfig.from_dict(
+            {k: v for k, v in _MAPPER_DICT.items() if k != "name"}
+        )
+        self.assertEqual("", mapper.name)
 
-    def test_missing_field_map_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            MapperConfig.from_dict(
-                {k: v for k, v in _MAPPER_DICT.items() if k != "field_map"}
-            )
-        self.assertIn("field_map", str(ctx.exception))
+    def test_flat_dict_shorthand(self):
+        # Mapper can be a flat {key: template} dict — no 'field_map' wrapper required
+        flat = {"host": "{{ raw.hostname }}", "port": "{{ raw.port }}"}
+        mapper = MapperConfig.from_dict(flat)
+        self.assertEqual(flat, mapper.field_map)
+        self.assertEqual("", mapper.name)
+        self.assertFalse(mapper.passthrough)
+
+    def test_dict_without_field_map_key_treated_as_shorthand(self):
+        # A dict without a 'field_map' key is treated as a flat shorthand — the whole
+        # dict becomes the field_map. There is no longer a "missing field_map" error.
+        mapper = MapperConfig.from_dict(
+            {k: v for k, v in _MAPPER_DICT.items() if k != "field_map"}
+        )
+        # _MAPPER_DICT without field_map is {"name": "my_mapper"}, treated as field_map
+        self.assertEqual({"name": "my_mapper"}, mapper.field_map)
 
 
 class TestCtpConfigFromDict(TestCase):
@@ -161,15 +170,25 @@ class TestCtpConfigFromDict(TestCase):
         ctp = CtpConfig.from_dict({**_CTP_DICT, "steps": []})
         self.assertEqual([], ctp.steps)
 
-    def test_missing_name_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "name"})
-        self.assertIn("name", str(ctx.exception))
+    def test_name_defaults_to_empty(self):
+        ctp = CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "name"})
+        self.assertEqual("", ctp.name)
 
-    def test_missing_steps_raises(self):
-        with self.assertRaises(ValueError) as ctx:
-            CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "steps"})
-        self.assertIn("steps", str(ctx.exception))
+    def test_steps_default_to_empty_list(self):
+        ctp = CtpConfig.from_dict({k: v for k, v in _CTP_DICT.items() if k != "steps"})
+        self.assertEqual([], ctp.steps)
+
+    def test_mapper_only_config(self):
+        # Minimal valid config: just a mapper (flat shorthand)
+        ctp = CtpConfig.from_dict(
+            {"mapper": {"host": "{{ raw.hostname }}", "port": "{{ raw.port }}"}}
+        )
+        self.assertEqual("", ctp.name)
+        self.assertEqual([], ctp.steps)
+        self.assertEqual(
+            {"host": "{{ raw.hostname }}", "port": "{{ raw.port }}"},
+            ctp.mapper.field_map,
+        )
 
     def test_missing_mapper_raises(self):
         with self.assertRaises(ValueError) as ctx:

--- a/tests/ctp/test_models.py
+++ b/tests/ctp/test_models.py
@@ -114,6 +114,26 @@ class TestTransformStepFromDict(TestCase):
             )
         self.assertIn("output", str(ctx.exception))
 
+    def test_non_str_type_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict({**_STEP_DICT, "type": 123})
+        self.assertIn("type", str(ctx.exception))
+
+    def test_non_dict_input_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict({**_STEP_DICT, "input": "bad"})
+        self.assertIn("input", str(ctx.exception))
+
+    def test_non_dict_output_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict({**_STEP_DICT, "output": ["bad"]})
+        self.assertIn("output", str(ctx.exception))
+
+    def test_non_dict_field_map_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            TransformStep.from_dict({**_STEP_DICT, "field_map": ["bad"]})
+        self.assertIn("field_map", str(ctx.exception))
+
 
 class TestMapperConfigFromDict(TestCase):
     def test_required_fields(self):
@@ -198,6 +218,21 @@ class TestCtpConfigFromDict(TestCase):
     def test_invalid_step_raises(self):
         with self.assertRaises(ValueError):
             CtpConfig.from_dict({**_CTP_DICT, "steps": [{"type": "something"}]})
+
+    def test_steps_not_a_list_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({**_CTP_DICT, "steps": {"type": "something"}})
+        self.assertIn("steps", str(ctx.exception))
+
+    def test_steps_not_a_list_of_dicts_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({**_CTP_DICT, "steps": ["not-a-dict"]})
+        self.assertIn("steps", str(ctx.exception))
+
+    def test_connect_args_defaults_not_a_dict_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            CtpConfig.from_dict({**_CTP_DICT, "connect_args_defaults": ["bad"]})
+        self.assertIn("connect_args_defaults", str(ctx.exception))
 
     def test_round_trip(self):
         ctp = CtpConfig.from_dict(_CTP_DICT)

--- a/tests/ctp/test_snowflake_ctp.py
+++ b/tests/ctp/test_snowflake_ctp.py
@@ -142,12 +142,13 @@ class TestSnowflakeCtp(TestCase):
             "schema",
             "role",
             "login_timeout",
-            "application",
             "session_parameters",
             "token",
             "authenticator",
         ):
             self.assertNotIn(field, args, f"expected {field!r} to be absent")
+        # application is always injected as "Monte Carlo" via connect_args_defaults
+        self.assertEqual("Monte Carlo", args["application"])
 
     # ── OAuth via token acquisition ───────────────────────────────────
 

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -263,6 +263,24 @@ class TestValidateCtp(TestCase):
         self.assertFalse(result["valid"])
         self.assertTrue(any("token" in e for e in result["errors"]))
 
+    def test_unknown_mapper_keys_returns_error(self):
+        """A mapper field_map with keys not in the TypedDict schema is flagged."""
+        ctp_with_unknown_key = {
+            "name": "unknown-key-ctp",
+            "steps": [],
+            "mapper": {
+                "name": "m",
+                "field_map": {
+                    "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+                    "token": "{{ raw.custom_token }}",
+                    "passwordx": "{{ raw.bad }}",  # not in DatabricksRestClientArgs
+                },
+            },
+        }
+        result = validate_ctp_config("databricks-rest", ctp_with_unknown_key)
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("passwordx" in e for e in result["errors"]))
+
     def test_unknown_connection_type_validates_without_schema(self):
         """An unknown connection type has no schema to inject — valid if well-formed."""
         result = validate_ctp_config("unknown-type", _CUSTOM_CTP)

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -292,3 +292,65 @@ class TestValidateCtp(TestCase):
         self.assertFalse(result["valid"])
         self.assertIsInstance(result["errors"], list)
         self.assertTrue(len(result["errors"]) > 0)
+
+    def test_missing_required_key_with_steps_is_warning_not_error(self):
+        """When a required key is absent from top-level field_map but steps are present,
+        the result is valid=True with a warning (not an error)."""
+        ctp_with_step_covering_token = {
+            "name": "step-covered-ctp",
+            # Step contributes "token" via its own field_map at runtime.
+            "steps": [
+                {
+                    "type": "resolve_databricks_token",
+                    "when": "raw.databricks_token is defined",
+                    "input": {
+                        "workspace_url": "{{ raw.databricks_workspace_url }}",
+                        "databricks_token": "{{ raw.databricks_token }}",
+                    },
+                    "output": {"token": "resolved_token"},
+                    "field_map": {"token": "{{ derived.resolved_token }}"},
+                }
+            ],
+            "mapper": {
+                "name": "m",
+                "field_map": {
+                    # "token" intentionally omitted — step provides it
+                    "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+                },
+            },
+        }
+        result = validate_ctp_config("databricks-rest", ctp_with_step_covering_token)
+        self.assertTrue(result["valid"])
+        self.assertEqual([], result["errors"])
+        self.assertTrue(any("token" in w for w in result["warnings"]))
+
+    def test_step_field_map_unknown_key_returns_error(self):
+        """A step field_map containing a key not in the TypedDict schema is flagged."""
+        ctp_with_bad_step_key = {
+            "name": "bad-step-key-ctp",
+            "steps": [
+                {
+                    "type": "resolve_databricks_token",
+                    "when": "raw.databricks_token is defined",
+                    "input": {
+                        "workspace_url": "{{ raw.databricks_workspace_url }}",
+                        "databricks_token": "{{ raw.databricks_token }}",
+                    },
+                    "output": {"token": "resolved_token"},
+                    "field_map": {
+                        "token": "{{ derived.resolved_token }}",
+                        "not_a_real_key": "{{ raw.something }}",  # unknown
+                    },
+                }
+            ],
+            "mapper": {
+                "name": "m",
+                "field_map": {
+                    "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+                    "token": "{{ raw.token | default(none) }}",
+                },
+            },
+        }
+        result = validate_ctp_config("databricks-rest", ctp_with_bad_step_key)
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("not_a_real_key" in e for e in result["errors"]))

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -1,4 +1,4 @@
-# tests/test_custom_ctp.py
+# tests/test_ctp_config.py
 """Integration tests for custom CTP support in execute_operation.
 
 Uses the databricks-rest connection type as the test vehicle because it has a
@@ -71,7 +71,7 @@ _CUSTOM_CTP_MISSING_TOKEN = {
 
 
 class TestCustomCtpExecution(TestCase):
-    """Full agent → proxy client path with a custom_ctp supplied."""
+    """Full agent → proxy client path with a ctp_config supplied."""
 
     def setUp(self) -> None:
         self._agent = Agent(LoggingUtils())
@@ -83,7 +83,7 @@ class TestCustomCtpExecution(TestCase):
         return mock_response
 
     @patch("requests.request")
-    def test_custom_ctp_used_instead_of_default(self, mock_request):
+    def test_ctp_config_used_instead_of_default(self, mock_request):
         """Custom CTP pipeline runs in place of the registered default."""
         self._mock_http_success(mock_request)
 
@@ -92,7 +92,7 @@ class TestCustomCtpExecution(TestCase):
             "start_warehouse",
             _OPERATION,
             _CUSTOM_CREDENTIALS,
-            custom_ctp=_CUSTOM_CTP,
+            ctp_config=_CUSTOM_CTP,
         )
 
         self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
@@ -104,7 +104,7 @@ class TestCustomCtpExecution(TestCase):
         )
 
     @patch("requests.request")
-    def test_custom_ctp_schema_injected_enforces_required_fields(self, mock_request):
+    def test_ctp_config_schema_injected_enforces_required_fields(self, mock_request):
         """TypedDict schema is injected from the registered CTP; missing required fields raise."""
         # DatabricksRestClientArgs requires "token" — the bad CTP omits it.
         response = self._agent.execute_operation(
@@ -112,15 +112,15 @@ class TestCustomCtpExecution(TestCase):
             "start_warehouse",
             _OPERATION,
             _CUSTOM_CREDENTIALS,
-            custom_ctp=_CUSTOM_CTP_MISSING_TOKEN,
+            ctp_config=_CUSTOM_CTP_MISSING_TOKEN,
         )
 
         self.assertIsNotNone(response.result.get(ATTRIBUTE_NAME_ERROR))
         self.assertIn("token", response.result.get(ATTRIBUTE_NAME_ERROR, ""))
 
     @patch("requests.request")
-    def test_absent_custom_ctp_uses_registered_default(self, mock_request):
-        """When custom_ctp is absent the registered default pipeline runs unchanged."""
+    def test_absent_ctp_config_uses_registered_default(self, mock_request):
+        """When ctp_config is absent the registered default pipeline runs unchanged."""
         self._mock_http_success(mock_request)
 
         response = self._agent.execute_operation(
@@ -140,7 +140,7 @@ class TestCustomCtpExecution(TestCase):
         )
 
     @patch("requests.request")
-    def test_custom_ctp_with_pre_shaped_connect_args(self, mock_request):
+    def test_ctp_config_with_pre_shaped_connect_args(self, mock_request):
         """DC pre-shaped connect_args are unwrapped before the custom pipeline runs."""
         self._mock_http_success(mock_request)
 
@@ -149,7 +149,7 @@ class TestCustomCtpExecution(TestCase):
             "start_warehouse",
             _OPERATION,
             {"connect_args": _CUSTOM_CREDENTIALS},
-            custom_ctp=_CUSTOM_CTP,
+            ctp_config=_CUSTOM_CTP,
         )
 
         self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -1,4 +1,4 @@
-# tests/test_ctp_config.py
+# tests/test_custom_ctp.py
 """Integration tests for custom CTP support in execute_operation.
 
 Uses the databricks-rest connection type as the test vehicle because it has a
@@ -292,6 +292,15 @@ class TestValidateCtp(TestCase):
         self.assertFalse(result["valid"])
         self.assertIsInstance(result["errors"], list)
         self.assertTrue(len(result["errors"]) > 0)
+
+    def test_non_dict_ctp_config_returns_error(self):
+        """Non-dict ctp_config returns valid=False without raising."""
+        for bad_value in (["a", "list"], "a string", 42, None):
+            with self.subTest(value=bad_value):
+                result = validate_ctp_config("databricks-rest", bad_value)
+                self.assertFalse(result["valid"])
+                self.assertTrue(len(result["errors"]) > 0)
+                self.assertEqual([], result["warnings"])
 
     def test_missing_required_key_with_steps_is_warning_not_error(self):
         """When a required key is absent from top-level field_map but steps are present,

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -16,6 +16,7 @@ from apollo.common.agent.constants import (
     ATTRIBUTE_NAME_RESULT,
 )
 from apollo.integrations.ctp.registry import CtpRegistry
+from apollo.integrations.ctp.validator import validate_ctp_config
 
 _WORKSPACE_URL = "https://adb-123.azuredatabricks.net"
 _CUSTOM_TOKEN = "custom-pipeline-token"
@@ -197,3 +198,79 @@ class TestCustomCtpSchemaInjection(TestCase):
             _CUSTOM_CTP,
         )
         self.assertIs(credentials, result)
+
+
+class TestValidateCtp(TestCase):
+    """Unit tests for validate_ctp_config."""
+
+    def test_valid_ctp_returns_valid_true(self):
+        """A well-formed custom CTP for a registered type passes validation."""
+        result = validate_ctp_config("databricks-rest", _CUSTOM_CTP)
+        self.assertTrue(result["valid"])
+        self.assertEqual([], result["errors"])
+
+    def test_missing_required_field_returns_error(self):
+        """CtpConfig.from_dict raises when a required top-level field is absent."""
+        result = validate_ctp_config("databricks-rest", {"name": "bad", "steps": []})
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("mapper" in e for e in result["errors"]))
+
+    def test_unknown_transform_type_returns_error(self):
+        """An unregistered transform type in steps is flagged."""
+        ctp_with_bad_step = {
+            "name": "bad-step-ctp",
+            "steps": [
+                {
+                    "type": "does-not-exist",
+                    "input": {},
+                    "output": {},
+                }
+            ],
+            "mapper": {
+                "name": "m",
+                "field_map": {
+                    "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+                    "token": "{{ raw.custom_token }}",
+                },
+            },
+        }
+        result = validate_ctp_config("databricks-rest", ctp_with_bad_step)
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("does-not-exist" in e for e in result["errors"]))
+
+    def test_bad_jinja2_syntax_returns_error(self):
+        """A malformed Jinja2 template in field_map is flagged."""
+        bad_template_ctp = {
+            "name": "bad-template-ctp",
+            "steps": [],
+            "mapper": {
+                "name": "m",
+                "field_map": {
+                    "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+                    "token": "{{ raw.custom_token ",  # missing closing }}
+                },
+            },
+        }
+        result = validate_ctp_config("databricks-rest", bad_template_ctp)
+        self.assertFalse(result["valid"])
+        self.assertTrue(
+            any("token" in e and "syntax" in e.lower() for e in result["errors"])
+        )
+
+    def test_missing_required_schema_keys_returns_error(self):
+        """A mapper that omits TypedDict required keys (no steps) is flagged."""
+        result = validate_ctp_config("databricks-rest", _CUSTOM_CTP_MISSING_TOKEN)
+        self.assertFalse(result["valid"])
+        self.assertTrue(any("token" in e for e in result["errors"]))
+
+    def test_unknown_connection_type_validates_without_schema(self):
+        """An unknown connection type has no schema to inject — valid if well-formed."""
+        result = validate_ctp_config("unknown-type", _CUSTOM_CTP)
+        self.assertTrue(result["valid"])
+
+    def test_missing_ctp_required_fields_returns_error_list(self):
+        """validate_ctp_config returns a list with the deserialization error."""
+        result = validate_ctp_config("databricks-rest", {})
+        self.assertFalse(result["valid"])
+        self.assertIsInstance(result["errors"], list)
+        self.assertTrue(len(result["errors"]) > 0)

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -1,0 +1,199 @@
+# tests/test_custom_ctp.py
+"""Integration tests for custom CTP support in execute_operation.
+
+Uses the databricks-rest connection type as the test vehicle because it has a
+simple CTP (PAT → token) and a well-defined TypedDict output contract.
+"""
+from unittest import TestCase
+from unittest.mock import create_autospec, patch
+
+from requests import Response
+
+from apollo.agent.agent import Agent
+from apollo.agent.logging_utils import LoggingUtils
+from apollo.common.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+)
+from apollo.integrations.ctp.registry import CtpRegistry
+
+_WORKSPACE_URL = "https://adb-123.azuredatabricks.net"
+_CUSTOM_TOKEN = "custom-pipeline-token"
+
+_OPERATION = {
+    "trace_id": "custom-ctp-test",
+    "skip_cache": True,
+    "commands": [
+        {
+            "method": "do_request",
+            "kwargs": {
+                "url": f"{_WORKSPACE_URL}/api/2.0/sql/warehouses/abc/start",
+                "http_method": "POST",
+            },
+        }
+    ],
+}
+
+# Credentials use a non-standard field name ("custom_token") that the
+# registered default CTP would not recognize — proves the custom pipeline ran.
+_CUSTOM_CREDENTIALS = {
+    "databricks_workspace_url": _WORKSPACE_URL,
+    "custom_token": _CUSTOM_TOKEN,
+}
+
+# Custom CTP: no steps, mapper reads "custom_token" instead of "databricks_token".
+_CUSTOM_CTP = {
+    "name": "custom-databricks-rest",
+    "steps": [],
+    "mapper": {
+        "name": "custom_mapper",
+        "field_map": {
+            "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+            "token": "{{ raw.custom_token }}",
+        },
+    },
+}
+
+# Custom CTP that deliberately omits "token" from its mapper output —
+# used to verify the TypedDict schema is injected and enforced.
+_CUSTOM_CTP_MISSING_TOKEN = {
+    "name": "bad-custom-ctp",
+    "steps": [],
+    "mapper": {
+        "name": "bad_mapper",
+        "field_map": {
+            "databricks_workspace_url": "{{ raw.databricks_workspace_url }}",
+            # token intentionally absent
+        },
+    },
+}
+
+
+class TestCustomCtpExecution(TestCase):
+    """Full agent → proxy client path with a custom_ctp supplied."""
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    def _mock_http_success(self, mock_request):
+        mock_response = create_autospec(Response)
+        mock_response.json.return_value = {"result": "ok"}
+        mock_request.return_value = mock_response
+        return mock_response
+
+    @patch("requests.request")
+    def test_custom_ctp_used_instead_of_default(self, mock_request):
+        """Custom CTP pipeline runs in place of the registered default."""
+        self._mock_http_success(mock_request)
+
+        response = self._agent.execute_operation(
+            "databricks-rest",
+            "start_warehouse",
+            _OPERATION,
+            _CUSTOM_CREDENTIALS,
+            custom_ctp=_CUSTOM_CTP,
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertIn(ATTRIBUTE_NAME_RESULT, response.result)
+        # The custom CTP reads custom_token — verify it reached the HTTP call
+        self.assertEqual(
+            f"Bearer {_CUSTOM_TOKEN}",
+            mock_request.call_args[1]["headers"]["Authorization"],
+        )
+
+    @patch("requests.request")
+    def test_custom_ctp_schema_injected_enforces_required_fields(self, mock_request):
+        """TypedDict schema is injected from the registered CTP; missing required fields raise."""
+        # DatabricksRestClientArgs requires "token" — the bad CTP omits it.
+        response = self._agent.execute_operation(
+            "databricks-rest",
+            "start_warehouse",
+            _OPERATION,
+            _CUSTOM_CREDENTIALS,
+            custom_ctp=_CUSTOM_CTP_MISSING_TOKEN,
+        )
+
+        self.assertIsNotNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertIn("token", response.result.get(ATTRIBUTE_NAME_ERROR, ""))
+
+    @patch("requests.request")
+    def test_absent_custom_ctp_uses_registered_default(self, mock_request):
+        """When custom_ctp is absent the registered default pipeline runs unchanged."""
+        self._mock_http_success(mock_request)
+
+        response = self._agent.execute_operation(
+            "databricks-rest",
+            "start_warehouse",
+            _OPERATION,
+            {
+                "databricks_workspace_url": _WORKSPACE_URL,
+                "databricks_token": "dapi-pat",
+            },
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(
+            "Bearer dapi-pat",
+            mock_request.call_args[1]["headers"]["Authorization"],
+        )
+
+    @patch("requests.request")
+    def test_custom_ctp_with_pre_shaped_connect_args(self, mock_request):
+        """DC pre-shaped connect_args are unwrapped before the custom pipeline runs."""
+        self._mock_http_success(mock_request)
+
+        response = self._agent.execute_operation(
+            "databricks-rest",
+            "start_warehouse",
+            _OPERATION,
+            {"connect_args": _CUSTOM_CREDENTIALS},
+            custom_ctp=_CUSTOM_CTP,
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(
+            f"Bearer {_CUSTOM_TOKEN}",
+            mock_request.call_args[1]["headers"]["Authorization"],
+        )
+
+
+class TestCustomCtpSchemaInjection(TestCase):
+    """Unit tests for CtpRegistry.resolve_custom schema injection."""
+
+    def test_schema_injected_from_registered_ctp(self):
+        """resolve_custom injects the TypedDict schema from the registered default."""
+        registered = CtpRegistry.get("databricks-rest")
+        self.assertIsNotNone(registered)
+
+        result = CtpRegistry.resolve_custom(
+            "databricks-rest",
+            _CUSTOM_CREDENTIALS,
+            _CUSTOM_CTP,
+        )
+        self.assertIn("connect_args", result)
+        self.assertEqual(_CUSTOM_TOKEN, result["connect_args"]["token"])
+        self.assertEqual(
+            _WORKSPACE_URL, result["connect_args"]["databricks_workspace_url"]
+        )
+
+    def test_schema_injected_for_unknown_connection_type(self):
+        """resolve_custom works without a registered CTP — no schema injection, no error."""
+        result = CtpRegistry.resolve_custom(
+            "unknown-type",
+            _CUSTOM_CREDENTIALS,
+            _CUSTOM_CTP,
+        )
+        self.assertIn("connect_args", result)
+        self.assertEqual(_CUSTOM_TOKEN, result["connect_args"]["token"])
+
+    def test_non_dict_connect_args_returned_unchanged(self):
+        """Legacy ODBC string passthrough is preserved even with a custom CTP."""
+        odbc = "DRIVER={SQL Server};SERVER=db.example.com"
+        credentials = {"connect_args": odbc}
+        result = CtpRegistry.resolve_custom(
+            "sql-server",
+            credentials,
+            _CUSTOM_CTP,
+        )
+        self.assertIs(credentials, result)

--- a/tests/test_proxy_client_factory.py
+++ b/tests/test_proxy_client_factory.py
@@ -38,7 +38,9 @@ class ProxyClientFactoryTests(TestCase):
             credentials=None,
         )
         # two invocations, a single client created
-        mock_create_client.assert_called_once_with("test_type", None, agent.platform)
+        mock_create_client.assert_called_once_with(
+            "test_type", None, agent.platform, ctp_config=None
+        )
 
     @patch.object(Agent, "_execute_client_operation")
     @patch.object(ProxyClientFactory, "_create_proxy_client")
@@ -69,7 +71,7 @@ class ProxyClientFactoryTests(TestCase):
         # two invocations, two clients created
         mock_create_client.assert_has_calls(
             [
-                call("test_type", None, agent.platform),
-                call("test_type", None, agent.platform),
+                call("test_type", None, agent.platform, ctp_config=None),
+                call("test_type", None, agent.platform, ctp_config=None),
             ]
         )

--- a/tests/test_redshift_client.py
+++ b/tests/test_redshift_client.py
@@ -32,6 +32,7 @@ _RS_EXPECTED_CONNECT_ARGS = {
     "dbname": "db1",
     "user": "u",
     "password": "p",
+    "connect_timeout": 5,
     "keepalives": 1,
     "keepalives_idle": 30,
     "keepalives_interval": 10,

--- a/tests/test_redshift_client.py
+++ b/tests/test_redshift_client.py
@@ -32,7 +32,7 @@ _RS_EXPECTED_CONNECT_ARGS = {
     "dbname": "db1",
     "user": "u",
     "password": "p",
-    "connect_timeout": 5,
+    "connect_timeout": 30,
     "keepalives": 1,
     "keepalives_idle": 30,
     "keepalives_interval": 10,

--- a/tests/test_snowflake_client.py
+++ b/tests/test_snowflake_client.py
@@ -16,6 +16,8 @@ from apollo.agent.logging_utils import LoggingUtils
 from apollo.agent.proxy_client_factory import ProxyClientFactory
 
 _SF_CREDENTIALS = {"user": "u", "password": "p", "account": "a", "warehouse": "w"}
+# Expected connect() kwargs after CTP applies connect_args_defaults (application injected).
+_SF_EXPECTED_CONNECT_ARGS = {**_SF_CREDENTIALS, "application": "Monte Carlo"}
 
 
 class SnowflakeClientTests(TestCase):
@@ -48,7 +50,11 @@ class SnowflakeClientTests(TestCase):
         )
         self.assertIsNotNone(client)
         mock_connect.assert_called_once_with(
-            user="u", private_key=private_key, account="a", warehouse="w"
+            application="Monte Carlo",
+            user="u",
+            account="a",
+            warehouse="w",
+            private_key=private_key,
         )
 
     @patch("snowflake.connector.connect")
@@ -198,7 +204,7 @@ class SnowflakeClientTests(TestCase):
         self.assertTrue(ATTRIBUTE_NAME_RESULT in response.result)
         result = response.result.get(ATTRIBUTE_NAME_RESULT)
 
-        mock_connect.assert_called_with(**_SF_CREDENTIALS)
+        mock_connect.assert_called_with(**_SF_EXPECTED_CONNECT_ARGS)
         self._mock_cursor.execute.assert_has_calls(
             [
                 call(query, None),


### PR DESCRIPTION
## Summary

- Threads a per-request `ctp_config` through `execute_operation` → `ProxyClientFactory`, enabling custom Jinja2 credential transform pipelines to be passed from the monolith alongside each DC operation
- Adds a `POST /api/v1/ctp/validate/<connection_type>` endpoint for structural validation of custom CTP configs (deserialization, transform type existence, Jinja2 syntax, TypedDict key coverage) without executing against real credentials
- Adds `connect_args_defaults` to `CtpConfig` so connector-level constants (keepalives, timeouts, `http_scheme`, etc.) are injected under the mapper output — ensuring custom CTPs don't silently drop required driver params

## Key Decisions

- **Client cache bypassed when `ctp_config` is present** — two requests with identical credentials but different CTP configs would otherwise share a cached client built from the wrong resolved credentials
- **`connect_args_defaults` merge strategy: mapper wins** — the defaults are applied under the mapper output so a custom config can always override them; registered pipeline defaults are inherited into custom configs via `CtpRegistry.resolve_custom`
- **Unknown keys in `field_map` are errors** — unknown keys passed through silently to the driver before, masking typos like `passwordx`; now rejected at both map-time and validation-time
- **Step-covered missing required keys are warnings, not errors** — if `config.steps` is non-empty, a key missing from the top-level `field_map` may be provided at runtime by a transform step, so `valid` stays `True`
- **Jinja2 syntax validation uses `SandboxedEnvironment`** — prevents template expressions from accessing arbitrary Python internals during the structural check

## Test plan

- [ ] Unit tests cover: `CtpConfig`/`MapperConfig` deserialization, flat mapper shorthand, `connect_args_defaults` merge, unknown-key rejection, validator endpoint happy/error paths, cache bypass
- [ ] E2E: configure a custom CTP config on a connection in dev, verify credentials are transformed and DC operations succeed
- [ ] Validate endpoint: send a malformed config, confirm structured errors are returned