### PR TITLE
fix(ctp): add missing HTTP transport fields to Hive CTP

### DIFF
--- a/apollo/integrations/ctp/defaults/hive.py
+++ b/apollo/integrations/ctp/defaults/hive.py
@@ -49,6 +49,9 @@ HIVE_DEFAULT_CTP = CtpConfig(
             "user": "{{ raw.user | default(none) }}",
             "password": "{{ raw.password | default(none) }}",
             "use_ssl": "{{ raw.use_ssl | default(none) }}",
+            "use_http_transport": "{{ raw.use_http_transport | default(none) }}",
+            "http_path": "{{ raw.http_path | default(none) }}",
+            "kerberos_service_name": "{{ raw.kerberos_service_name | default(none) }}",
         },
     ),
 )

--- a/tests/ctp/test_hive_ctp.py
+++ b/tests/ctp/test_hive_ctp.py
@@ -39,3 +39,45 @@ class TestHiveCtp(TestCase):
         self.assertNotIn("user", result)
         self.assertNotIn("database", result)
         self.assertNotIn("auth_mechanism", result)
+        self.assertNotIn("use_http_transport", result)
+        self.assertNotIn("http_path", result)
+        self.assertNotIn("kerberos_service_name", result)
+
+    def test_resolve_http_mode_credentials(self):
+        """HTTP/Databricks mode fields must survive the CTP pipeline."""
+        result = CtpPipeline().execute(
+            HIVE_DEFAULT_CTP,
+            {
+                "host": "workspace.cloud.databricks.com",
+                "port": 443,
+                "use_http_transport": True,
+                "http_path": "sql/protocolv1/o/123456/cluster-id",
+                "use_ssl": True,
+                "user": "token",
+                "password": "dapi-secret",
+                "auth_mechanism": "PLAIN",
+                "timeout": 870,
+            },
+        )
+        self.assertEqual("workspace.cloud.databricks.com", result["host"])
+        self.assertEqual(443, result["port"])
+        self.assertIs(True, result["use_http_transport"])
+        self.assertEqual("sql/protocolv1/o/123456/cluster-id", result["http_path"])
+        self.assertIs(True, result["use_ssl"])
+        self.assertEqual("token", result["user"])
+        self.assertEqual("dapi-secret", result["password"])
+        self.assertEqual("PLAIN", result["auth_mechanism"])
+
+    def test_resolve_kerberos_credentials(self):
+        result = CtpPipeline().execute(
+            HIVE_DEFAULT_CTP,
+            {
+                "host": "hive-server",
+                "port": 10000,
+                "auth_mechanism": "GSSAPI",
+                "kerberos_service_name": "hive",
+            },
+        )
+        self.assertEqual("hive-server", result["host"])
+        self.assertEqual("GSSAPI", result["auth_mechanism"])
+        self.assertEqual("hive", result["kerberos_service_name"])


### PR DESCRIPTION
## Summary

- The Hive CTP `field_map` only mapped 8 of the ~18 fields in `HiveClientArgs`, silently dropping `use_http_transport`, `http_path`, and `kerberos_service_name` when credentials passed through the pipeline
- Without `use_http_transport`, impyla defaults to binary Thrift instead of HTTP transport — breaking all HTTP-mode and Databricks-mode Spark connections routed through the agent
- Without `http_path`, the connection cannot route to the correct Spark SQL endpoint (e.g. `sql/protocolv1/o/<workspace>/<cluster>`)
- This caused queries through the agent to return empty results while the same queries worked directly from the data-collector, with misleading error messages ("Query must return at least one value")

## Root cause

The Hive CTP was registered in `90798db` (2026-04-02) with a `field_map` that only covered binary-mode connection parameters. HTTP/Databricks mode parameters (`use_http_transport`, `http_path`) and Kerberos parameters (`kerberos_service_name`) were declared in the `HiveClientArgs` TypedDict schema but not in the mapper — so the mapper produced output without them, and the schema validation didn't flag the omission since they're `NotRequired`.

## Test plan

- [x] Existing CTP tests pass (349 passed)
- [x] New test: HTTP/Databricks mode credentials survive the pipeline with all fields intact
- [x] New test: Kerberos credentials survive the pipeline
- [x] New test: missing optional fields (including new ones) are correctly omitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)