### PR TITLE
feat: Informatica CTP support — resolve_informatica_session transform + auth-agnostic proxy client

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -342,6 +342,16 @@ def _get_proxy_client_starburst_enterprise(
     return StarburstEnterpriseProxyClient(credentials=credentials, platform=platform)
 
 
+def _get_proxy_client_informatica(
+    credentials: Optional[Dict], **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.http.informatica_proxy_client import (
+        InformaticaProxyClient,
+    )
+
+    return InformaticaProxyClient(credentials=credentials)
+
+
 def _get_proxy_client_db2(
     credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
@@ -400,6 +410,7 @@ _CLIENT_FACTORY_MAPPING = {
     "clickhouse": _get_proxy_client_clickhouse,
     "starburst-galaxy": _get_proxy_client_starburst_galaxy,
     "starburst-enterprise": _get_proxy_client_starburst_enterprise,
+    "informatica": _get_proxy_client_informatica,
 }
 
 

--- a/apollo/integrations/ctp/defaults/informatica.py
+++ b/apollo/integrations/ctp/defaults/informatica.py
@@ -1,28 +1,45 @@
 from typing import NotRequired, Required, TypedDict
 
-from apollo.integrations.ctp.models import CtpConfig, MapperConfig
+from apollo.integrations.ctp.models import CtpConfig, MapperConfig, TransformStep
 
 
 class InformaticaClientArgs(TypedDict):
-    username: Required[str]
-    password: Required[str]
-    # V2 or V3 auth. Defaults to "v3" inside InformaticaProxyClient when absent.
-    informatica_auth: NotRequired[str]
-    # Login base URL. Defaults to https://dm-us.informaticacloud.com when absent.
-    base_url: NotRequired[str]
+    # Pre-resolved session produced by the resolve_informatica_session transform.
+    # The proxy client is auth-method agnostic — it only needs these two values.
+    session_id: Required[str]
+    api_base_url: Required[str]
 
 
 INFORMATICA_DEFAULT_CTP = CtpConfig(
     name="informatica-default",
-    steps=[],
+    steps=[
+        # Skipped when session_id is already present (DC pre-shaped path or custom CTP
+        # config that resolved the session upstream). When running, supports both
+        # username/password (V2 or V3) and JWT loginOAuth modes.
+        TransformStep(
+            type="resolve_informatica_session",
+            when="raw.session_id is not defined",
+            input={
+                "username": "{{ raw.username | default(none) }}",
+                "password": "{{ raw.password | default(none) }}",
+                "informatica_auth": "{{ raw.informatica_auth | default(none) }}",
+                "base_url": "{{ raw.base_url | default(none) }}",
+                "jwt_token": "{{ raw.jwt_token | default(none) }}",
+                "org_id": "{{ raw.org_id | default(none) }}",
+            },
+            output={
+                "session_id": "informatica_session_id",
+                "api_base_url": "informatica_api_base_url",
+            },
+        )
+    ],
     mapper=MapperConfig(
         name="informatica_client_args",
         schema=InformaticaClientArgs,
         field_map={
-            "username": "{{ raw.username }}",
-            "password": "{{ raw.password }}",
-            "informatica_auth": "{{ raw.informatica_auth | default(none) }}",
-            "base_url": "{{ raw.base_url | default(none) }}",
+            # When the step ran: read from derived. When pre-resolved: fall back to raw.
+            "session_id": "{{ derived.informatica_session_id | default(raw.session_id) }}",
+            "api_base_url": "{{ derived.informatica_api_base_url | default(raw.api_base_url) }}",
         },
     ),
 )

--- a/apollo/integrations/ctp/defaults/informatica.py
+++ b/apollo/integrations/ctp/defaults/informatica.py
@@ -1,0 +1,33 @@
+from typing import NotRequired, Required, TypedDict
+
+from apollo.integrations.ctp.models import CtpConfig, MapperConfig
+
+
+class InformaticaClientArgs(TypedDict):
+    username: Required[str]
+    password: Required[str]
+    # V2 or V3 auth. Defaults to "v3" inside InformaticaProxyClient when absent.
+    informatica_auth: NotRequired[str]
+    # Login base URL. Defaults to https://dm-us.informaticacloud.com when absent.
+    base_url: NotRequired[str]
+
+
+INFORMATICA_DEFAULT_CTP = CtpConfig(
+    name="informatica-default",
+    steps=[],
+    mapper=MapperConfig(
+        name="informatica_client_args",
+        schema=InformaticaClientArgs,
+        field_map={
+            "username": "{{ raw.username }}",
+            "password": "{{ raw.password }}",
+            "informatica_auth": "{{ raw.informatica_auth | default(none) }}",
+            "base_url": "{{ raw.base_url | default(none) }}",
+        },
+    ),
+)
+
+
+from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402
+
+CtpRegistry.register("informatica", INFORMATICA_DEFAULT_CTP)

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -22,9 +22,9 @@ def _discover() -> None:
     import apollo.integrations.ctp.defaults.dremio  # noqa: F401
     import apollo.integrations.ctp.defaults.fabric  # noqa: F401
     import apollo.integrations.ctp.defaults.git  # noqa: F401
+    import apollo.integrations.ctp.defaults.hive  # noqa: F401
     import apollo.integrations.ctp.defaults.http  # noqa: F401
     import apollo.integrations.ctp.defaults.informatica  # noqa: F401
-    import apollo.integrations.ctp.defaults.hive  # noqa: F401
     import apollo.integrations.ctp.defaults.motherduck  # noqa: F401
     import apollo.integrations.ctp.defaults.presto  # noqa: F401
     import apollo.integrations.ctp.defaults.snowflake  # noqa: F401

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -23,6 +23,7 @@ def _discover() -> None:
     import apollo.integrations.ctp.defaults.fabric  # noqa: F401
     import apollo.integrations.ctp.defaults.git  # noqa: F401
     import apollo.integrations.ctp.defaults.http  # noqa: F401
+    import apollo.integrations.ctp.defaults.informatica  # noqa: F401
     import apollo.integrations.ctp.defaults.hive  # noqa: F401
     import apollo.integrations.ctp.defaults.motherduck  # noqa: F401
     import apollo.integrations.ctp.defaults.presto  # noqa: F401

--- a/apollo/integrations/ctp/transforms/registry.py
+++ b/apollo/integrations/ctp/transforms/registry.py
@@ -21,6 +21,7 @@ def _discover() -> None:
     import apollo.integrations.ctp.transforms.resolve_databricks_oauth  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_databricks_token  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_redshift_credentials  # noqa: F401
+    import apollo.integrations.ctp.transforms.resolve_informatica_session  # noqa: F401
 
 
 def _ensure_initialized() -> None:

--- a/apollo/integrations/ctp/transforms/registry.py
+++ b/apollo/integrations/ctp/transforms/registry.py
@@ -20,8 +20,8 @@ def _discover() -> None:
     import apollo.integrations.ctp.transforms.resolve_msal_token  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_databricks_oauth  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_databricks_token  # noqa: F401
-    import apollo.integrations.ctp.transforms.resolve_redshift_credentials  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_informatica_session  # noqa: F401
+    import apollo.integrations.ctp.transforms.resolve_redshift_credentials  # noqa: F401
 
 
 def _ensure_initialized() -> None:

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -192,7 +192,7 @@ class ResolveInformaticaSessionTransform(Transform):
         try:
             response = requests.post(
                 f"{base_url}{_V3_LOGIN_PATH}",
-                data={"username": username, "password": password},
+                json={"username": username, "password": password},
             )
             response.raise_for_status()
             body = response.json()

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -18,12 +18,23 @@ _DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
 def _login_failure_detail(exc: Exception) -> str:
     """Return a safe, diagnostic detail string for a login exception.
 
-    Includes HTTP status code for HTTPError (safe — response body is never
-    included), or the exception class name for other errors. Credentials are
-    never present in either form.
+    Includes HTTP status code and Informatica error text for HTTPError (safe —
+    response body never contains credentials), or the exception class name for
+    other errors.
     """
     if isinstance(exc, requests.HTTPError) and exc.response is not None:
-        return f"HTTP {exc.response.status_code}"
+        detail = f"HTTP {exc.response.status_code}"
+        try:
+            body = exc.response.json()
+            # Informatica error responses use "@type" and "message" or top-level "message"
+            message = body.get("message") or body.get("error")
+            if message:
+                detail += f": {message}"
+        except Exception:
+            text = (exc.response.text or "")[:200].strip()
+            if text:
+                detail += f": {text}"
+        return detail
     return type(exc).__name__
 
 

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import requests
 
 from apollo.integrations.ctp.errors import CtpPipelineError
@@ -13,6 +11,7 @@ _V3_LOGIN_PATH = "/saas/public/core/v3/login"
 _JWT_LOGIN_PATH = "/ma/api/v2/user/loginOAuth"
 _INTEGRATION_CLOUD_PRODUCT_NAME = "Integration Cloud"
 _DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
+_LOGIN_TIMEOUT = 30  # seconds — matches the OAuth transform convention
 
 
 def _login_failure_detail(exc: Exception) -> str:
@@ -171,6 +170,7 @@ class ResolveInformaticaSessionTransform(Transform):
             response = requests.post(
                 f"{base_url}{_V2_LOGIN_PATH}",
                 data={"username": username, "password": password},
+                timeout=_LOGIN_TIMEOUT,
             )
             response.raise_for_status()
             body = response.json()
@@ -204,6 +204,7 @@ class ResolveInformaticaSessionTransform(Transform):
             response = requests.post(
                 f"{base_url}{_V3_LOGIN_PATH}",
                 json={"username": username, "password": password},
+                timeout=_LOGIN_TIMEOUT,
             )
             response.raise_for_status()
             body = response.json()
@@ -253,6 +254,7 @@ class ResolveInformaticaSessionTransform(Transform):
             response = requests.post(
                 f"{base_url}{_JWT_LOGIN_PATH}",
                 json={"orgId": org_id, "oauthToken": jwt_token},
+                timeout=_LOGIN_TIMEOUT,
             )
             response.raise_for_status()
             body = response.json()

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -1,0 +1,257 @@
+from typing import Optional
+
+import requests
+
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.models import PipelineState, TransformStep
+from apollo.integrations.ctp.template import TemplateEngine
+from apollo.integrations.ctp.transforms.base import Transform
+from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+_V2_LOGIN_PATH = "/ma/api/v2/user/login"
+_V3_LOGIN_PATH = "/saas/public/core/v3/login"
+_JWT_LOGIN_PATH = "/ma/api/v2/user/loginOAuth"
+_INTEGRATION_CLOUD_PRODUCT_NAME = "Integration Cloud"
+_DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
+
+
+class ResolveInformaticaSessionTransform(Transform):
+    """Exchange Informatica credentials for a session ID and API base URL.
+
+    Supports two auth modes (determined by which input keys are present):
+
+    **Password mode** (V2 or V3 username/password login):
+        Requires: username, password
+        Optional: informatica_auth ("v2" | "v3", default "v3"), base_url
+
+        - "v2": POST /ma/api/v2/user/login → {serverUrl, icSessionId}
+        - "v3": POST /saas/public/core/v3/login → {products[Integration Cloud].baseApiUrl,
+          userInfo.sessionId}
+
+    **JWT mode** (POST /ma/api/v2/user/loginOAuth — requires SAML configured org-wide):
+        Requires: jwt_token, org_id
+        Optional: base_url
+
+        The JWT is a short-lived access token from the customer's IDP (Okta, Azure AD, etc.)
+        obtained via ROPC grant. The loginOAuth response has the same shape as V2 login,
+        so api_base_url and session_id are extracted identically.
+
+    Step input keys:
+        base_url        (optional): login base URL — defaults to https://dm-us.informaticacloud.com
+        username        (password mode): Informatica username
+        password        (password mode): Informatica password
+        informatica_auth (password mode, optional): "v2" or "v3" (default "v3")
+        jwt_token       (JWT mode): short-lived JWT from the customer's IDP
+        org_id          (JWT mode): Informatica organization ID
+
+    Step output keys:
+        session_id:   derived key where the icSessionId string is stored
+        api_base_url: derived key where the API base URL string is stored
+    """
+
+    optional_input_keys = (
+        "base_url",
+        "username",
+        "password",
+        "informatica_auth",
+        "jwt_token",
+        "org_id",
+    )
+    required_output_keys = ("session_id", "api_base_url")
+    optional_output_keys = ()
+
+    def _execute(self, step: TransformStep, state: PipelineState) -> None:
+        base_url = (
+            TemplateEngine.render(step.input.get("base_url", "{{ none }}"), state)
+            or _DEFAULT_BASE_URL
+        ).rstrip("/")
+
+        jwt_token = TemplateEngine.render(
+            step.input.get("jwt_token", "{{ none }}"), state
+        )
+
+        if jwt_token:
+            api_base_url, session_id = self._login_jwt(
+                base_url=base_url,
+                org_id=self._require(
+                    step, state, "org_id", "required with 'jwt_token'"
+                ),
+                jwt_token=jwt_token,
+                step_name=step.type,
+            )
+        else:
+            username = self._require(
+                step,
+                state,
+                "username",
+                "required in password mode (no 'jwt_token' provided)",
+            )
+            password = self._require(
+                step,
+                state,
+                "password",
+                "required in password mode (no 'jwt_token' provided)",
+            )
+            informatica_auth = (
+                TemplateEngine.render(
+                    step.input.get("informatica_auth", "{{ none }}"), state
+                )
+                or "v3"
+            )
+
+            if informatica_auth == "v2":
+                api_base_url, session_id = self._login_v2(
+                    base_url, username, password, step.type
+                )
+            elif informatica_auth == "v3":
+                api_base_url, session_id = self._login_v3(
+                    base_url, username, password, step.type
+                )
+            else:
+                raise CtpPipelineError(
+                    stage="transform_execute",
+                    step_name=step.type,
+                    message=(
+                        f"Unsupported 'informatica_auth' value: '{informatica_auth}'. "
+                        "Expected 'v2' or 'v3'."
+                    ),
+                )
+
+        state.derived[step.output["session_id"]] = session_id
+        state.derived[step.output["api_base_url"]] = api_base_url
+
+    @staticmethod
+    def _require(
+        step: TransformStep,
+        state: PipelineState,
+        key: str,
+        reason: str,
+    ) -> str:
+        value = TemplateEngine.render(step.input.get(key, "{{ none }}"), state)
+        if not value:
+            raise CtpPipelineError(
+                stage="transform_execute",
+                step_name=step.type,
+                message=f"'{key}' is {reason}",
+            )
+        return value
+
+    @staticmethod
+    def _login_v2(
+        base_url: str,
+        username: str,
+        password: str,
+        step_name: str,
+    ) -> tuple[str, str]:
+        """POST /ma/api/v2/user/login → (api_base_url, session_id)."""
+        try:
+            response = requests.post(
+                f"{base_url}{_V2_LOGIN_PATH}",
+                data={"username": username, "password": password},
+            )
+            response.raise_for_status()
+            body = response.json()
+            server_url = body.get("serverUrl")
+            session_id = body.get("icSessionId")
+            if not server_url or not session_id:
+                raise CtpPipelineError(
+                    stage="transform_execute",
+                    step_name=step_name,
+                    message="V2 login response missing 'serverUrl' or 'icSessionId'",
+                )
+            return server_url, session_id
+        except CtpPipelineError:
+            raise
+        except Exception as exc:
+            raise CtpPipelineError(
+                stage="transform_execute",
+                step_name=step_name,
+                message="Informatica V2 login failed",
+            ) from exc
+
+    @staticmethod
+    def _login_v3(
+        base_url: str,
+        username: str,
+        password: str,
+        step_name: str,
+    ) -> tuple[str, str]:
+        """POST /saas/public/core/v3/login → (api_base_url, session_id)."""
+        try:
+            response = requests.post(
+                f"{base_url}{_V3_LOGIN_PATH}",
+                data={"username": username, "password": password},
+            )
+            response.raise_for_status()
+            body = response.json()
+            products = body.get("products") or []
+            api_base_url = next(
+                (
+                    p.get("baseApiUrl")
+                    for p in products
+                    if p.get("name") == _INTEGRATION_CLOUD_PRODUCT_NAME
+                ),
+                None,
+            )
+            user_info = body.get("userInfo") or {}
+            session_id = user_info.get("sessionId")
+            if not api_base_url or not session_id:
+                raise CtpPipelineError(
+                    stage="transform_execute",
+                    step_name=step_name,
+                    message=(
+                        "V3 login response missing Integration Cloud 'baseApiUrl' "
+                        "or 'userInfo.sessionId'"
+                    ),
+                )
+            return api_base_url, session_id
+        except CtpPipelineError:
+            raise
+        except Exception as exc:
+            raise CtpPipelineError(
+                stage="transform_execute",
+                step_name=step_name,
+                message="Informatica V3 login failed",
+            ) from exc
+
+    @staticmethod
+    def _login_jwt(
+        base_url: str,
+        org_id: str,
+        jwt_token: str,
+        step_name: str,
+    ) -> tuple[str, str]:
+        """POST /ma/api/v2/user/loginOAuth → (api_base_url, session_id).
+
+        The loginOAuth response has the same {serverUrl, icSessionId} shape as V2 login,
+        so extraction is identical.
+        """
+        try:
+            response = requests.post(
+                f"{base_url}{_JWT_LOGIN_PATH}",
+                json={"orgId": org_id, "oauthToken": jwt_token},
+            )
+            response.raise_for_status()
+            body = response.json()
+            server_url = body.get("serverUrl")
+            session_id = body.get("icSessionId")
+            if not server_url or not session_id:
+                raise CtpPipelineError(
+                    stage="transform_execute",
+                    step_name=step_name,
+                    message="JWT loginOAuth response missing 'serverUrl' or 'icSessionId'",
+                )
+            return server_url, session_id
+        except CtpPipelineError:
+            raise
+        except Exception as exc:
+            raise CtpPipelineError(
+                stage="transform_execute",
+                step_name=step_name,
+                message="Informatica JWT login failed",
+            ) from exc
+
+
+TransformRegistry.register(
+    "resolve_informatica_session", ResolveInformaticaSessionTransform
+)

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -15,6 +15,18 @@ _INTEGRATION_CLOUD_PRODUCT_NAME = "Integration Cloud"
 _DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
 
 
+def _login_failure_detail(exc: Exception) -> str:
+    """Return a safe, diagnostic detail string for a login exception.
+
+    Includes HTTP status code for HTTPError (safe — response body is never
+    included), or the exception class name for other errors. Credentials are
+    never present in either form.
+    """
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return f"HTTP {exc.response.status_code}"
+    return type(exc).__name__
+
+
 class ResolveInformaticaSessionTransform(Transform):
     """Exchange Informatica credentials for a session ID and API base URL.
 
@@ -166,7 +178,7 @@ class ResolveInformaticaSessionTransform(Transform):
             raise CtpPipelineError(
                 stage="transform_execute",
                 step_name=step_name,
-                message="Informatica V2 login failed",
+                message=f"Informatica V2 login failed: {_login_failure_detail(exc)}",
             ) from exc
 
     @staticmethod
@@ -211,7 +223,7 @@ class ResolveInformaticaSessionTransform(Transform):
             raise CtpPipelineError(
                 stage="transform_execute",
                 step_name=step_name,
-                message="Informatica V3 login failed",
+                message=f"Informatica V3 login failed: {_login_failure_detail(exc)}",
             ) from exc
 
     @staticmethod
@@ -248,7 +260,7 @@ class ResolveInformaticaSessionTransform(Transform):
             raise CtpPipelineError(
                 stage="transform_execute",
                 step_name=step_name,
-                message="Informatica JWT login failed",
+                message=f"Informatica JWT login failed: {_login_failure_detail(exc)}",
             ) from exc
 
 

--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -1,41 +1,28 @@
-import logging
 from typing import Any, Dict, List, Optional, Tuple
-
-import requests
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.http.http_proxy_client import HttpProxyClient
 
-logger = logging.getLogger(__name__)
-
 _ATTR_CONNECT_ARGS = "connect_args"
-
-_DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
-_DEFAULT_AUTH_VERSION = "v3"
-
-_V2_LOGIN_PATH = "/ma/api/v2/user/login"
-_V3_LOGIN_PATH = "/saas/public/core/v3/login"
-
-_INTEGRATION_CLOUD_PRODUCT_NAME = "Integration Cloud"
-
-
-class InformaticaLoginError(Exception):
-    pass
 
 
 class InformaticaProxyClient(BaseProxyClient):
     """
     Proxy client for Informatica Cloud connections.
 
-    Performs V2 or V3 login in __init__ using form-encoded credentials, then exposes
-    do_http_request() for API calls authenticated with the session ID returned by login.
+    Expects connect_args (produced by the CTP pipeline, specifically the
+    resolve_informatica_session transform) to contain a pre-resolved session:
 
-    Expected credentials shape:
-        credentials["connect_args"]:
-            username          (required)
-            password          (required)
-            informatica_auth  (optional, "v2" or "v3", default "v3")
-            base_url          (optional login base URL, default "https://dm-us.informaticacloud.com")
+        connect_args:
+            session_id    (required): icSessionId from the Informatica login response
+            api_base_url  (required): API base URL from the Informatica login response
+
+    All authentication — V2 password, V3 password, or JWT loginOAuth — is handled
+    upstream in the CTP pipeline. This client is auth-method agnostic.
+
+    The icSessionId header is always used for API calls regardless of how the session
+    was obtained. This is intentional: the DC currently calls only V2 API endpoints,
+    which require icSessionId (not INFA-SESSION-ID).
     """
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
@@ -46,29 +33,22 @@ class InformaticaProxyClient(BaseProxyClient):
 
         connect_args: Dict[str, Any] = credentials[_ATTR_CONNECT_ARGS]
 
-        username = connect_args.get("username")
-        password = connect_args.get("password")
-        if not username or not password:
+        session_id = connect_args.get("session_id")
+        api_base_url = connect_args.get("api_base_url")
+
+        if not session_id:
             raise ValueError(
-                "Informatica agent client requires 'username' and 'password' in connect_args"
+                "Informatica agent client requires 'session_id' in connect_args"
+            )
+        if not api_base_url:
+            raise ValueError(
+                "Informatica agent client requires 'api_base_url' in connect_args"
             )
 
-        auth_version: str = connect_args.get("informatica_auth", _DEFAULT_AUTH_VERSION)
-        login_base_url: str = connect_args.get("base_url", _DEFAULT_BASE_URL).rstrip(
-            "/"
-        )
+        self._api_base_url: str = api_base_url.rstrip("/")
 
-        if auth_version == "v2":
-            self._api_base_url, session_id = self._login_v2(
-                login_base_url, username, password
-            )
-        else:
-            self._api_base_url, session_id = self._login_v3(
-                login_base_url, username, password
-            )
-
-        # icSessionId is used for all API calls regardless of auth version — this is coupled
-        # to V2 API usage, not the auth version.
+        # icSessionId is used for all API calls — this is coupled to V2 API usage,
+        # not the auth method used to obtain the session.
         http_credentials: Dict[str, Any] = {
             "token": session_id,
             "auth_header": "icSessionId",
@@ -79,77 +59,6 @@ class InformaticaProxyClient(BaseProxyClient):
     @property
     def wrapped_client(self):
         return None
-
-    # -------------------------------------------------------------------------
-    # Login helpers
-    # -------------------------------------------------------------------------
-
-    @staticmethod
-    def _login_v2(login_base_url: str, username: str, password: str) -> Tuple[str, str]:
-        """
-        Performs V2 login and returns (api_base_url, session_id).
-        Raises InformaticaLoginError on failure.
-        """
-        url = f"{login_base_url}{_V2_LOGIN_PATH}"
-        response = requests.post(url, data={"username": username, "password": password})
-        try:
-            response.raise_for_status()
-            body = response.json()
-            server_url = body.get("serverUrl")
-            session_id = body.get("icSessionId")
-            if not server_url or not session_id:
-                raise InformaticaLoginError(
-                    "Informatica V2 login failed: response did not contain expected "
-                    "serverUrl or icSessionId"
-                )
-            return server_url, session_id
-        except InformaticaLoginError:
-            raise
-        except Exception as exc:
-            raise InformaticaLoginError(
-                "Informatica V2 login failed: unexpected error during login"
-            ) from exc
-
-    @staticmethod
-    def _login_v3(login_base_url: str, username: str, password: str) -> Tuple[str, str]:
-        """
-        Performs V3 login and returns (api_base_url, session_id).
-        Raises InformaticaLoginError on failure.
-        """
-        url = f"{login_base_url}{_V3_LOGIN_PATH}"
-        response = requests.post(url, data={"username": username, "password": password})
-        try:
-            response.raise_for_status()
-            body = response.json()
-
-            products = body.get("products") or []
-            api_base_url = next(
-                (
-                    p.get("baseApiUrl")
-                    for p in products
-                    if p.get("name") == _INTEGRATION_CLOUD_PRODUCT_NAME
-                ),
-                None,
-            )
-            user_info = body.get("userInfo") or {}
-            session_id = user_info.get("sessionId")
-
-            if not api_base_url or not session_id:
-                raise InformaticaLoginError(
-                    "Informatica V3 login failed: response did not contain expected "
-                    "Integration Cloud baseApiUrl or userInfo.sessionId"
-                )
-            return api_base_url, session_id
-        except InformaticaLoginError:
-            raise
-        except Exception as exc:
-            raise InformaticaLoginError(
-                "Informatica V3 login failed: unexpected error during login"
-            ) from exc
-
-    # -------------------------------------------------------------------------
-    # HTTP request
-    # -------------------------------------------------------------------------
 
     def do_http_request(
         self,
@@ -192,10 +101,6 @@ class InformaticaProxyClient(BaseProxyClient):
             retry_status_code_ranges=retry_status_code_ranges,
             data=data,
         )
-
-    # -------------------------------------------------------------------------
-    # Error handling - delegate to HttpProxyClient for HTTP errors
-    # -------------------------------------------------------------------------
 
     def get_error_type(self, error: Exception) -> Optional[str]:
         http_error_type = self._http_client.get_error_type(error)

--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -1,0 +1,210 @@
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.http.http_proxy_client import HttpProxyClient
+
+logger = logging.getLogger(__name__)
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+_DEFAULT_BASE_URL = "https://dm-us.informaticacloud.com"
+_DEFAULT_AUTH_VERSION = "v3"
+
+_V2_LOGIN_PATH = "/ma/api/v2/user/login"
+_V3_LOGIN_PATH = "/saas/public/core/v3/login"
+
+_INTEGRATION_CLOUD_PRODUCT_NAME = "Integration Cloud"
+
+
+class InformaticaLoginError(Exception):
+    pass
+
+
+class InformaticaProxyClient(BaseProxyClient):
+    """
+    Proxy client for Informatica Cloud connections.
+
+    Performs V2 or V3 login in __init__ using form-encoded credentials, then exposes
+    do_http_request() for API calls authenticated with the session ID returned by login.
+
+    Expected credentials shape:
+        credentials["connect_args"]:
+            username          (required)
+            password          (required)
+            informatica_auth  (optional, "v2" or "v3", default "v3")
+            base_url          (optional login base URL, default "https://dm-us.informaticacloud.com")
+    """
+
+    def __init__(self, credentials: Optional[Dict], **kwargs: Any):
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Informatica agent client requires {_ATTR_CONNECT_ARGS} in credentials"
+            )
+
+        connect_args: Dict[str, Any] = credentials[_ATTR_CONNECT_ARGS]
+
+        username = connect_args.get("username")
+        password = connect_args.get("password")
+        if not username or not password:
+            raise ValueError(
+                "Informatica agent client requires 'username' and 'password' in connect_args"
+            )
+
+        auth_version: str = connect_args.get("informatica_auth", _DEFAULT_AUTH_VERSION)
+        login_base_url: str = connect_args.get("base_url", _DEFAULT_BASE_URL).rstrip(
+            "/"
+        )
+
+        if auth_version == "v2":
+            self._api_base_url, session_id = self._login_v2(
+                login_base_url, username, password
+            )
+        else:
+            self._api_base_url, session_id = self._login_v3(
+                login_base_url, username, password
+            )
+
+        # icSessionId is used for all API calls regardless of auth version — this is coupled
+        # to V2 API usage, not the auth version.
+        http_credentials: Dict[str, Any] = {
+            "token": session_id,
+            "auth_header": "icSessionId",
+            "auth_type": "",  # empty string → send token as-is, no "Bearer " prefix
+        }
+        self._http_client = HttpProxyClient(credentials=http_credentials)
+
+    @property
+    def wrapped_client(self):
+        return None
+
+    # -------------------------------------------------------------------------
+    # Login helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _login_v2(login_base_url: str, username: str, password: str) -> Tuple[str, str]:
+        """
+        Performs V2 login and returns (api_base_url, session_id).
+        Raises InformaticaLoginError on failure.
+        """
+        url = f"{login_base_url}{_V2_LOGIN_PATH}"
+        response = requests.post(url, data={"username": username, "password": password})
+        try:
+            response.raise_for_status()
+            body = response.json()
+            server_url = body.get("serverUrl")
+            session_id = body.get("icSessionId")
+            if not server_url or not session_id:
+                raise InformaticaLoginError(
+                    "Informatica V2 login failed: response did not contain expected "
+                    "serverUrl or icSessionId"
+                )
+            return server_url, session_id
+        except InformaticaLoginError:
+            raise
+        except Exception as exc:
+            raise InformaticaLoginError(
+                "Informatica V2 login failed: unexpected error during login"
+            ) from exc
+
+    @staticmethod
+    def _login_v3(login_base_url: str, username: str, password: str) -> Tuple[str, str]:
+        """
+        Performs V3 login and returns (api_base_url, session_id).
+        Raises InformaticaLoginError on failure.
+        """
+        url = f"{login_base_url}{_V3_LOGIN_PATH}"
+        response = requests.post(url, data={"username": username, "password": password})
+        try:
+            response.raise_for_status()
+            body = response.json()
+
+            products = body.get("products") or []
+            api_base_url = next(
+                (
+                    p.get("baseApiUrl")
+                    for p in products
+                    if p.get("name") == _INTEGRATION_CLOUD_PRODUCT_NAME
+                ),
+                None,
+            )
+            user_info = body.get("userInfo") or {}
+            session_id = user_info.get("sessionId")
+
+            if not api_base_url or not session_id:
+                raise InformaticaLoginError(
+                    "Informatica V3 login failed: response did not contain expected "
+                    "Integration Cloud baseApiUrl or userInfo.sessionId"
+                )
+            return api_base_url, session_id
+        except InformaticaLoginError:
+            raise
+        except Exception as exc:
+            raise InformaticaLoginError(
+                "Informatica V3 login failed: unexpected error during login"
+            ) from exc
+
+    # -------------------------------------------------------------------------
+    # HTTP request
+    # -------------------------------------------------------------------------
+
+    def do_http_request(
+        self,
+        path: str,
+        http_method: str = "GET",
+        payload: Optional[Dict] = None,
+        content_type: Optional[str] = None,
+        timeout: Optional[int] = None,
+        additional_headers: Optional[Dict] = None,
+        params: Optional[Dict] = None,
+        retry_status_code_ranges: Optional[List[Tuple]] = None,
+        data: Optional[str] = None,
+    ) -> Any:
+        """
+        Execute an HTTP request against the Informatica API base URL.
+
+        :param path: Path to append to the API base URL (e.g., "/v2/jobs"). Must start with "/".
+        :param http_method: HTTP method (GET, POST, PUT, DELETE, etc.)
+        :param payload: Optional JSON payload for the request body
+        :param content_type: Optional Content-Type header value
+        :param timeout: Optional timeout in seconds
+        :param additional_headers: Optional additional headers
+        :param params: Optional query string parameters
+        :param retry_status_code_ranges: Optional status code ranges that trigger retry
+        :param data: Optional raw data for the request body
+        :return: JSON response (dict or list) or empty dict for empty responses
+        """
+        if not path.startswith("/"):
+            path = f"/{path}"
+        url = f"{self._api_base_url}{path}"
+
+        return self._http_client.do_request(
+            url=url,
+            http_method=http_method,
+            payload=payload,
+            content_type=content_type,
+            timeout=timeout,
+            additional_headers=additional_headers,
+            params=params,
+            retry_status_code_ranges=retry_status_code_ranges,
+            data=data,
+        )
+
+    # -------------------------------------------------------------------------
+    # Error handling - delegate to HttpProxyClient for HTTP errors
+    # -------------------------------------------------------------------------
+
+    def get_error_type(self, error: Exception) -> Optional[str]:
+        http_error_type = self._http_client.get_error_type(error)
+        if http_error_type:
+            return http_error_type
+        return super().get_error_type(error=error)
+
+    def get_error_extra_attributes(self, error: Exception) -> Optional[Dict]:
+        http_attrs = self._http_client.get_error_extra_attributes(error)
+        if http_attrs:
+            return http_attrs
+        return super().get_error_extra_attributes(error=error)

--- a/tests/ctp/test_informatica_ctp.py
+++ b/tests/ctp/test_informatica_ctp.py
@@ -1,0 +1,95 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from apollo.agent.proxy_client_factory import ProxyClientFactory
+from apollo.integrations.ctp.defaults.informatica import INFORMATICA_DEFAULT_CTP
+from apollo.integrations.ctp.pipeline import CtpPipeline
+from apollo.integrations.ctp.registry import CtpRegistry
+
+
+class TestInformaticaCtpRegistered(TestCase):
+    def test_registered(self):
+        """CtpRegistry.get("informatica") must return a config — not None.
+
+        If this fails, the import inside _discover() is missing from registry.py.
+        """
+        self.assertIsNotNone(CtpRegistry.get("informatica"))
+
+
+class TestInformaticaCtpMapper(TestCase):
+    """Verify the default mapper produces the correct connect_args shape."""
+
+    def test_resolve_v2_flat_credentials(self):
+        """V2 flat credentials are mapped to expected connect_args keys."""
+        result = CtpPipeline().execute(
+            INFORMATICA_DEFAULT_CTP,
+            {
+                "username": "svc_user",
+                "password": "s3cr3t",
+                "informatica_auth": "v2",
+                "base_url": "https://dm-eu.informaticacloud.com",
+            },
+        )
+        self.assertEqual("svc_user", result["username"])
+        self.assertEqual("s3cr3t", result["password"])
+        self.assertEqual("v2", result["informatica_auth"])
+        self.assertEqual("https://dm-eu.informaticacloud.com", result["base_url"])
+
+    def test_resolve_v3_flat_credentials(self):
+        """V3 flat credentials are mapped; informatica_auth and base_url present."""
+        result = CtpPipeline().execute(
+            INFORMATICA_DEFAULT_CTP,
+            {
+                "username": "svc_user",
+                "password": "s3cr3t",
+                "informatica_auth": "v3",
+            },
+        )
+        self.assertEqual("svc_user", result["username"])
+        self.assertEqual("s3cr3t", result["password"])
+        self.assertEqual("v3", result["informatica_auth"])
+
+    def test_resolve_minimal_credentials(self):
+        """Only username and password are required; optional fields absent when not provided."""
+        result = CtpPipeline().execute(
+            INFORMATICA_DEFAULT_CTP,
+            {
+                "username": "svc_user",
+                "password": "s3cr3t",
+            },
+        )
+        self.assertEqual("svc_user", result["username"])
+        self.assertEqual("s3cr3t", result["password"])
+        # Optional fields absent (None values are filtered by the mapper)
+        self.assertNotIn("informatica_auth", result)
+        self.assertNotIn("base_url", result)
+
+
+class TestInformaticaCtpFactoryResolution(TestCase):
+    """Verify CTP pipeline runs before InformaticaProxyClient is instantiated."""
+
+    def test_flat_credentials_resolved_to_connect_args_before_client_creation(self):
+        """Flat credentials are wrapped in connect_args by CTP before the factory is called."""
+        flat = {
+            "username": "svc_user",
+            "password": "s3cr3t",
+            "informatica_auth": "v3",
+        }
+        captured = {}
+
+        def fake_factory(credentials, **kwargs):
+            captured["credentials"] = credentials
+            raise StopIteration  # bail before attempting real network calls
+
+        with patch(
+            "apollo.agent.proxy_client_factory._CLIENT_FACTORY_MAPPING",
+            {"informatica": fake_factory},
+        ):
+            with self.assertRaises(StopIteration):
+                ProxyClientFactory._create_proxy_client("informatica", flat, "local")
+
+        self.assertIn("connect_args", captured["credentials"])
+        connect_args = captured["credentials"]["connect_args"]
+        self.assertEqual("svc_user", connect_args["username"])
+        self.assertEqual("s3cr3t", connect_args["password"])
+        self.assertEqual("v3", connect_args["informatica_auth"])

--- a/tests/ctp/test_informatica_ctp.py
+++ b/tests/ctp/test_informatica_ctp.py
@@ -88,6 +88,25 @@ class TestInformaticaCtpPipeline(TestCase):
         self.assertEqual("session-v3-xyz", result["session_id"])
 
 
+class TestInformaticaCtpPreResolvedPath(TestCase):
+    """Verify the when= guard skips login when session_id is already present."""
+
+    @patch("requests.post")
+    def test_pre_resolved_session_skips_login_step(self, mock_post):
+        """When session_id is present in raw, the resolve_informatica_session step is skipped."""
+        result = CtpPipeline().execute(
+            INFORMATICA_DEFAULT_CTP,
+            {
+                "session_id": "pre-existing-session",
+                "api_base_url": "https://na1.informaticacloud.com",
+            },
+        )
+
+        mock_post.assert_not_called()
+        self.assertEqual("pre-existing-session", result["session_id"])
+        self.assertEqual("https://na1.informaticacloud.com", result["api_base_url"])
+
+
 class TestInformaticaCtpFactoryResolution(TestCase):
     """Verify CTP pipeline runs before InformaticaProxyClient is instantiated."""
 

--- a/tests/ctp/test_informatica_ctp.py
+++ b/tests/ctp/test_informatica_ctp.py
@@ -1,42 +1,66 @@
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from apollo.agent.proxy_client_factory import ProxyClientFactory
 from apollo.integrations.ctp.defaults.informatica import INFORMATICA_DEFAULT_CTP
 from apollo.integrations.ctp.pipeline import CtpPipeline
 from apollo.integrations.ctp.registry import CtpRegistry
 
+# Canned Informatica login responses used across tests
+_V2_LOGIN_RESPONSE = {
+    "serverUrl": "https://na1.informaticacloud.com",
+    "icSessionId": "session-v2-abc",
+}
+_V3_LOGIN_RESPONSE = {
+    "products": [
+        {"name": "Integration Cloud", "baseApiUrl": "https://eu1.informaticacloud.com"},
+    ],
+    "userInfo": {"sessionId": "session-v3-xyz"},
+}
+
+
+def _mock_post(body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = body
+    resp.raise_for_status.return_value = None
+    return resp
+
 
 class TestInformaticaCtpRegistered(TestCase):
     def test_registered(self):
-        """CtpRegistry.get("informatica") must return a config — not None.
-
-        If this fails, the import inside _discover() is missing from registry.py.
-        """
+        """CtpRegistry.get("informatica") must return a config — not None."""
         self.assertIsNotNone(CtpRegistry.get("informatica"))
 
 
-class TestInformaticaCtpMapper(TestCase):
-    """Verify the default mapper produces the correct connect_args shape."""
+class TestInformaticaCtpPipeline(TestCase):
+    """Verify the default CTP pipeline resolves credentials to session_id + api_base_url."""
 
-    def test_resolve_v2_flat_credentials(self):
-        """V2 flat credentials are mapped to expected connect_args keys."""
+    @patch("requests.post")
+    def test_v2_credentials_produce_session_and_base_url(self, mock_post):
+        """V2 credentials flow through resolve_informatica_session and produce connect_args."""
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
         result = CtpPipeline().execute(
             INFORMATICA_DEFAULT_CTP,
             {
                 "username": "svc_user",
                 "password": "s3cr3t",
                 "informatica_auth": "v2",
-                "base_url": "https://dm-eu.informaticacloud.com",
+                "base_url": "https://dm-us.informaticacloud.com",
             },
         )
-        self.assertEqual("svc_user", result["username"])
-        self.assertEqual("s3cr3t", result["password"])
-        self.assertEqual("v2", result["informatica_auth"])
-        self.assertEqual("https://dm-eu.informaticacloud.com", result["base_url"])
 
-    def test_resolve_v3_flat_credentials(self):
-        """V3 flat credentials are mapped; informatica_auth and base_url present."""
+        self.assertEqual("session-v2-abc", result["session_id"])
+        self.assertEqual("https://na1.informaticacloud.com", result["api_base_url"])
+        # Raw credentials must not appear in connect_args
+        self.assertNotIn("username", result)
+        self.assertNotIn("password", result)
+
+    @patch("requests.post")
+    def test_v3_credentials_produce_session_and_base_url(self, mock_post):
+        """V3 credentials flow through resolve_informatica_session and produce connect_args."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
         result = CtpPipeline().execute(
             INFORMATICA_DEFAULT_CTP,
             {
@@ -45,36 +69,36 @@ class TestInformaticaCtpMapper(TestCase):
                 "informatica_auth": "v3",
             },
         )
-        self.assertEqual("svc_user", result["username"])
-        self.assertEqual("s3cr3t", result["password"])
-        self.assertEqual("v3", result["informatica_auth"])
 
-    def test_resolve_minimal_credentials(self):
-        """Only username and password are required; optional fields absent when not provided."""
+        self.assertEqual("session-v3-xyz", result["session_id"])
+        self.assertEqual("https://eu1.informaticacloud.com", result["api_base_url"])
+
+    @patch("requests.post")
+    def test_minimal_credentials_default_to_v3(self, mock_post):
+        """Credentials without informatica_auth default to V3 login."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
         result = CtpPipeline().execute(
             INFORMATICA_DEFAULT_CTP,
-            {
-                "username": "svc_user",
-                "password": "s3cr3t",
-            },
+            {"username": "svc_user", "password": "s3cr3t"},
         )
-        self.assertEqual("svc_user", result["username"])
-        self.assertEqual("s3cr3t", result["password"])
-        # Optional fields absent (None values are filtered by the mapper)
-        self.assertNotIn("informatica_auth", result)
-        self.assertNotIn("base_url", result)
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/saas/public/core/v3/login", login_url)
+        self.assertEqual("session-v3-xyz", result["session_id"])
 
 
 class TestInformaticaCtpFactoryResolution(TestCase):
     """Verify CTP pipeline runs before InformaticaProxyClient is instantiated."""
 
-    def test_flat_credentials_resolved_to_connect_args_before_client_creation(self):
-        """Flat credentials are wrapped in connect_args by CTP before the factory is called."""
-        flat = {
-            "username": "svc_user",
-            "password": "s3cr3t",
-            "informatica_auth": "v3",
-        }
+    @patch("requests.post")
+    def test_flat_credentials_resolved_to_connect_args_before_client_creation(
+        self, mock_post
+    ):
+        """Flat credentials are resolved by CTP to session_id+api_base_url before the factory."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        flat = {"username": "svc_user", "password": "s3cr3t", "informatica_auth": "v3"}
         captured = {}
 
         def fake_factory(credentials, **kwargs):
@@ -90,6 +114,10 @@ class TestInformaticaCtpFactoryResolution(TestCase):
 
         self.assertIn("connect_args", captured["credentials"])
         connect_args = captured["credentials"]["connect_args"]
-        self.assertEqual("svc_user", connect_args["username"])
-        self.assertEqual("s3cr3t", connect_args["password"])
-        self.assertEqual("v3", connect_args["informatica_auth"])
+        self.assertEqual("session-v3-xyz", connect_args["session_id"])
+        self.assertEqual(
+            "https://eu1.informaticacloud.com", connect_args["api_base_url"]
+        )
+        # Raw credentials must not reach the proxy client
+        self.assertNotIn("username", connect_args)
+        self.assertNotIn("password", connect_args)

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -1,0 +1,508 @@
+"""
+Tests for the resolve_informatica_session CTP transform.
+
+Covers all three auth modes (V2 password, V3 password, JWT loginOAuth),
+error paths, and credential safety.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.models import PipelineState, TransformStep
+from apollo.integrations.ctp.transforms.registry import TransformRegistry
+from apollo.integrations.ctp.transforms.resolve_informatica_session import (
+    ResolveInformaticaSessionTransform,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "https://dm-us.informaticacloud.com"
+_API_BASE_URL_V2 = "https://na1.informaticacloud.com"
+_API_BASE_URL_V3 = "https://eu1.informaticacloud.com"
+
+_V2_LOGIN_RESPONSE = {"serverUrl": _API_BASE_URL_V2, "icSessionId": "session-v2-abc"}
+_V3_LOGIN_RESPONSE = {
+    "products": [
+        {"name": "Integration Cloud", "baseApiUrl": _API_BASE_URL_V3},
+        {"name": "Other Service", "baseApiUrl": "https://other.example.com"},
+    ],
+    "userInfo": {"sessionId": "session-v3-xyz"},
+}
+_JWT_LOGIN_RESPONSE = {"serverUrl": _API_BASE_URL_V2, "icSessionId": "session-jwt-123"}
+
+
+def _mock_post(body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_step(
+    input_: dict, session_key: str = "session_id", base_url_key: str = "api_base_url"
+) -> TransformStep:
+    return TransformStep(
+        type="resolve_informatica_session",
+        input=input_,
+        output={"session_id": session_key, "api_base_url": base_url_key},
+    )
+
+
+def _run(step: TransformStep, raw: dict) -> PipelineState:
+    state = PipelineState(raw=raw)
+    ResolveInformaticaSessionTransform().execute(step, state)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistration(TestCase):
+    def test_registered(self):
+        transform = TransformRegistry.get("resolve_informatica_session")
+        self.assertIsInstance(transform, ResolveInformaticaSessionTransform)
+
+
+# ---------------------------------------------------------------------------
+# V2 password mode
+# ---------------------------------------------------------------------------
+
+
+class TestV2PasswordMode(TestCase):
+    @patch("requests.post")
+    def test_v2_login_extracts_server_url_and_session_id(self, mock_post):
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        state = _run(step, {"username": "svc_user", "password": "s3cr3t"})
+
+        self.assertEqual("session-v2-abc", state.derived["session_id"])
+        self.assertEqual(_API_BASE_URL_V2, state.derived["api_base_url"])
+
+    @patch("requests.post")
+    def test_v2_login_posts_to_v2_path(self, mock_post):
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"username": "u", "password": "p"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/ma/api/v2/user/login", login_url)
+        self.assertNotIn("loginOAuth", login_url)
+
+    @patch("requests.post")
+    def test_v2_login_sends_credentials_as_form_data(self, mock_post):
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"username": "myuser", "password": "mypass"})
+
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(
+            {"username": "myuser", "password": "mypass"}, call_kwargs["data"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# V3 password mode
+# ---------------------------------------------------------------------------
+
+
+class TestV3PasswordMode(TestCase):
+    @patch("requests.post")
+    def test_v3_login_extracts_integration_cloud_base_url(self, mock_post):
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
+        )
+        state = _run(step, {"username": "svc_user", "password": "s3cr3t"})
+
+        self.assertEqual("session-v3-xyz", state.derived["session_id"])
+        self.assertEqual(_API_BASE_URL_V3, state.derived["api_base_url"])
+
+    @patch("requests.post")
+    def test_v3_login_posts_to_v3_path(self, mock_post):
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"username": "u", "password": "p"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/saas/public/core/v3/login", login_url)
+
+    @patch("requests.post")
+    def test_missing_informatica_auth_defaults_to_v3(self, mock_post):
+        """When informatica_auth is absent, V3 is used."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+            }
+        )
+        _run(step, {"username": "u", "password": "p"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/saas/public/core/v3/login", login_url)
+
+    @patch("requests.post")
+    def test_v3_response_ignores_non_integration_cloud_products(self, mock_post):
+        """Only the 'Integration Cloud' product's baseApiUrl is used."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
+        )
+        state = _run(step, {"username": "u", "password": "p"})
+
+        self.assertNotEqual("https://other.example.com", state.derived["api_base_url"])
+        self.assertEqual(_API_BASE_URL_V3, state.derived["api_base_url"])
+
+
+# ---------------------------------------------------------------------------
+# JWT mode
+# ---------------------------------------------------------------------------
+
+
+class TestJwtMode(TestCase):
+    @patch("requests.post")
+    def test_jwt_login_extracts_server_url_and_session_id(self, mock_post):
+        mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "jwt_token": "{{ raw.jwt_token }}",
+                "org_id": "{{ raw.org_id }}",
+                "base_url": _BASE_URL,
+            }
+        )
+        state = _run(step, {"jwt_token": "eyJhb...", "org_id": "6KAbcd1EFG"})
+
+        self.assertEqual("session-jwt-123", state.derived["session_id"])
+        self.assertEqual(_API_BASE_URL_V2, state.derived["api_base_url"])
+
+    @patch("requests.post")
+    def test_jwt_login_posts_to_login_oauth_path(self, mock_post):
+        mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "jwt_token": "{{ raw.jwt_token }}",
+                "org_id": "{{ raw.org_id }}",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"jwt_token": "eyJhb...", "org_id": "myorg"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/ma/api/v2/user/loginOAuth", login_url)
+
+    @patch("requests.post")
+    def test_jwt_login_sends_org_id_and_token_as_json(self, mock_post):
+        mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "jwt_token": "{{ raw.jwt_token }}",
+                "org_id": "{{ raw.org_id }}",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"jwt_token": "my.jwt.token", "org_id": "myorg123"})
+
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(
+            {"orgId": "myorg123", "oauthToken": "my.jwt.token"}, call_kwargs["json"]
+        )
+
+    @patch("requests.post")
+    def test_jwt_mode_uses_custom_base_url(self, mock_post):
+        mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
+        custom_url = "https://eu1-dm.informaticacloud.com"
+
+        step = _make_step(
+            {
+                "jwt_token": "{{ raw.jwt_token }}",
+                "org_id": "{{ raw.org_id }}",
+                "base_url": custom_url,
+            }
+        )
+        _run(step, {"jwt_token": "t", "org_id": "org"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertTrue(login_url.startswith(custom_url))
+
+
+# ---------------------------------------------------------------------------
+# base_url handling
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrl(TestCase):
+    @patch("requests.post")
+    def test_custom_base_url_used_in_login_request(self, mock_post):
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+        custom = "https://dm-eu.informaticacloud.com"
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v2",
+                "base_url": custom,
+            }
+        )
+        _run(step, {"username": "u", "password": "p"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertTrue(login_url.startswith(custom))
+
+    @patch("requests.post")
+    def test_missing_base_url_falls_back_to_default(self, mock_post):
+        """When base_url is absent, the US pod default is used."""
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v2",
+            }
+        )
+        _run(step, {"username": "u", "password": "p"})
+
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("dm-us.informaticacloud.com", login_url)
+
+
+# ---------------------------------------------------------------------------
+# Output key naming
+# ---------------------------------------------------------------------------
+
+
+class TestOutputKeys(TestCase):
+    @patch("requests.post")
+    def test_custom_output_keys_written_to_derived(self, mock_post):
+        """Output key names in step.output control where values land in derived."""
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            },
+            session_key="infa_session",
+            base_url_key="infa_api_url",
+        )
+        state = _run(step, {})
+
+        self.assertEqual("session-v2-abc", state.derived["infa_session"])
+        self.assertEqual(_API_BASE_URL_V2, state.derived["infa_api_url"])
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPaths(TestCase):
+    def test_no_credentials_raises(self):
+        """Neither jwt_token nor username/password → CtpPipelineError."""
+        step = _make_step({"base_url": _BASE_URL})
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("username", str(ctx.exception).lower())
+
+    def test_jwt_without_org_id_raises(self):
+        step = _make_step({"jwt_token": "tok", "base_url": _BASE_URL})
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("org_id", str(ctx.exception))
+
+    def test_unsupported_informatica_auth_raises(self):
+        step = _make_step(
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v99",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("v99", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_v2_response_missing_server_url_raises(self, mock_post):
+        mock_post.return_value = _mock_post({"icSessionId": "s"})  # no serverUrl
+
+        step = _make_step(
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("serverUrl", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_v3_response_missing_integration_cloud_raises(self, mock_post):
+        mock_post.return_value = _mock_post(
+            {
+                "products": [{"name": "Other Service", "baseApiUrl": "https://x.com"}],
+                "userInfo": {"sessionId": "s"},
+            }
+        )
+
+        step = _make_step(
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("baseApiUrl", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_jwt_response_missing_session_id_raises(self, mock_post):
+        mock_post.return_value = _mock_post(
+            {"serverUrl": "https://x.com"}
+        )  # no icSessionId
+
+        step = _make_step(
+            {
+                "jwt_token": "tok",
+                "org_id": "org",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("icSessionId", str(ctx.exception))
+
+    @patch("requests.post")
+    def test_http_error_during_login_raises_ctp_error(self, mock_post):
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.status_code = 401
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        step = _make_step(
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+        self.assertIn("login failed", str(ctx.exception).lower())
+
+
+# ---------------------------------------------------------------------------
+# Credential safety
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialSafety(TestCase):
+    """Credentials must not appear in CtpPipelineError messages."""
+
+    _PASSWORD = "super_secret_password_xyz"
+    _JWT = "eyJhbGciOiJSUzI1NiJ9.secret_payload.signature"
+
+    @patch("requests.post")
+    def test_password_not_leaked_in_login_failure_message(self, mock_post):
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        step = _make_step(
+            {
+                "username": "user",
+                "password": self._PASSWORD,
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+
+        self.assertNotIn(self._PASSWORD, str(ctx.exception))
+
+    @patch("requests.post")
+    def test_jwt_token_not_leaked_in_login_failure_message(self, mock_post):
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        step = _make_step(
+            {
+                "jwt_token": self._JWT,
+                "org_id": "org",
+                "base_url": _BASE_URL,
+            }
+        )
+        with self.assertRaises(CtpPipelineError) as ctx:
+            _run(step, {})
+
+        self.assertNotIn(self._JWT, str(ctx.exception))

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -380,7 +380,12 @@ class TestLoginTimeout(TestCase):
     def test_v2_login_passes_timeout(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
         step = _make_step(
-            {"username": "u", "password": "p", "informatica_auth": "v2", "base_url": _BASE_URL}
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v2",
+                "base_url": _BASE_URL,
+            }
         )
         _run(step, {})
         self.assertEqual(30, mock_post.call_args[1]["timeout"])
@@ -389,7 +394,12 @@ class TestLoginTimeout(TestCase):
     def test_v3_login_passes_timeout(self, mock_post):
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
         step = _make_step(
-            {"username": "u", "password": "p", "informatica_auth": "v3", "base_url": _BASE_URL}
+            {
+                "username": "u",
+                "password": "p",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
         )
         _run(step, {})
         self.assertEqual(30, mock_post.call_args[1]["timeout"])

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -186,6 +186,27 @@ class TestV3PasswordMode(TestCase):
         self.assertIn("/saas/public/core/v3/login", login_url)
 
     @patch("requests.post")
+    def test_v3_login_sends_credentials_as_json(self, mock_post):
+        """V3 endpoint requires application/json — must use json=, not data=."""
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+
+        step = _make_step(
+            {
+                "username": "{{ raw.username }}",
+                "password": "{{ raw.password }}",
+                "informatica_auth": "v3",
+                "base_url": _BASE_URL,
+            }
+        )
+        _run(step, {"username": "myuser", "password": "mypass"})
+
+        call_kwargs = mock_post.call_args[1]
+        self.assertEqual(
+            {"username": "myuser", "password": "mypass"}, call_kwargs["json"]
+        )
+        self.assertNotIn("data", call_kwargs)
+
+    @patch("requests.post")
     def test_v3_response_ignores_non_integration_cloud_products(self, mock_post):
         """Only the 'Integration Cloud' product's baseApiUrl is used."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -452,7 +452,9 @@ class TestErrorPaths(TestCase):
         )
         with self.assertRaises(CtpPipelineError) as ctx:
             _run(step, {})
-        self.assertIn("login failed", str(ctx.exception).lower())
+        error_msg = str(ctx.exception)
+        self.assertIn("login failed", error_msg.lower())
+        self.assertIn("HTTP 401", error_msg)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -369,6 +369,40 @@ class TestOutputKeys(TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Timeout
+# ---------------------------------------------------------------------------
+
+
+class TestLoginTimeout(TestCase):
+    """All three login paths must pass timeout= to requests.post."""
+
+    @patch("requests.post")
+    def test_v2_login_passes_timeout(self, mock_post):
+        mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
+        step = _make_step(
+            {"username": "u", "password": "p", "informatica_auth": "v2", "base_url": _BASE_URL}
+        )
+        _run(step, {})
+        self.assertEqual(30, mock_post.call_args[1]["timeout"])
+
+    @patch("requests.post")
+    def test_v3_login_passes_timeout(self, mock_post):
+        mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
+        step = _make_step(
+            {"username": "u", "password": "p", "informatica_auth": "v3", "base_url": _BASE_URL}
+        )
+        _run(step, {})
+        self.assertEqual(30, mock_post.call_args[1]["timeout"])
+
+    @patch("requests.post")
+    def test_jwt_login_passes_timeout(self, mock_post):
+        mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
+        step = _make_step({"jwt_token": "tok", "org_id": "org", "base_url": _BASE_URL})
+        _run(step, {})
+        self.assertEqual(30, mock_post.call_args[1]["timeout"])
+
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -7,7 +7,6 @@ from apollo.agent.agent import Agent
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.common.agent.constants import (
     ATTRIBUTE_NAME_ERROR,
-    ATTRIBUTE_NAME_RESULT,
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
 from apollo.interfaces.lambda_function.json_log_formatter import JsonLogFormatter
@@ -132,7 +131,7 @@ class InformaticaHttpTests(TestCase):
         """POST requests forward the JSON payload."""
         mock_request.return_value = _make_api_mock({"id": "job-123"})
 
-        self._agent.execute_operation(
+        response = self._agent.execute_operation(
             "informatica",
             "http_request",
             _make_operation(
@@ -141,16 +140,7 @@ class InformaticaHttpTests(TestCase):
             {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
-        self.assertIsNone(
-            self._agent.execute_operation(
-                "informatica",
-                "http_request",
-                _make_operation(
-                    "/api/v2/jobs", http_method="POST", payload={"name": "new-job"}
-                ),
-                {"connect_args": _RESOLVED_CONNECT_ARGS},
-            ).result.get(ATTRIBUTE_NAME_ERROR)
-        )
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
         self.assertEqual(mock_request.call_args[0][0], "POST")
         self.assertEqual(mock_request.call_args[1].get("json"), {"name": "new-job"})
 

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -16,59 +16,37 @@ from apollo.interfaces.lambda_function.json_log_formatter import JsonLogFormatte
 # Shared test fixtures
 # ---------------------------------------------------------------------------
 
-_V2_CONNECT_ARGS = {
-    "username": "testuser",
-    "password": "s3cr3t_p@ss!",
-    "informatica_auth": "v2",
-}
+_API_BASE_URL = "https://na1.informaticacloud.com"
+_SESSION_ID = "pre-resolved-session-abc123"
 
-_V3_CONNECT_ARGS = {
-    "username": "testuser",
-    "password": "s3cr3t_p@ss!",
-    "informatica_auth": "v3",
-}
-
-_API_BASE_URL_V2 = "https://na1.informaticacloud.com"
-_API_BASE_URL_V3 = "https://eu1.informaticacloud.com"
-
-_V2_LOGIN_BODY = {
-    "serverUrl": _API_BASE_URL_V2,
-    "icSessionId": "v2-session-abc123",
-}
-
-_V3_LOGIN_BODY = {
-    "products": [
-        {
-            "name": "Integration Cloud",
-            "baseApiUrl": _API_BASE_URL_V3,
-        },
-        {
-            "name": "Other Service",
-            "baseApiUrl": "https://other.example.com",
-        },
-    ],
-    "userInfo": {"sessionId": "v3-session-xyz789"},
+# connect_args produced by the resolve_informatica_session CTP transform —
+# the proxy client never sees raw credentials.
+_RESOLVED_CONNECT_ARGS = {
+    "session_id": _SESSION_ID,
+    "api_base_url": _API_BASE_URL,
 }
 
 
-def _make_mock_response(body: dict, status_code: int = 200) -> MagicMock:
+def _make_api_mock(body: dict, status_code: int = 200) -> MagicMock:
     resp = MagicMock()
     resp.status_code = status_code
     resp.json.return_value = body
     resp.text = json.dumps(body)
-    return resp
-
-
-def _make_login_mock(body: dict) -> MagicMock:
-    resp = _make_mock_response(body)
     resp.raise_for_status.return_value = None
     return resp
 
 
-def _make_api_mock(body: dict) -> MagicMock:
-    resp = _make_mock_response(body)
-    resp.raise_for_status.return_value = None
-    return resp
+def _make_operation(path: str, http_method: str = "GET", **kwargs) -> dict:
+    return {
+        "trace_id": "test",
+        "skip_cache": True,
+        "commands": [
+            {
+                "method": "do_http_request",
+                "kwargs": {"path": path, "http_method": http_method, **kwargs},
+            }
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -77,276 +55,109 @@ def _make_api_mock(body: dict) -> MagicMock:
 
 
 class InformaticaHttpTests(TestCase):
-    """Tests for InformaticaProxyClient login and do_http_request behavior."""
+    """Tests for InformaticaProxyClient do_http_request behavior.
+
+    The proxy client receives pre-resolved session credentials from the CTP
+    pipeline — there is no login call here. Login logic lives in the
+    resolve_informatica_session transform (see tests/ctp/test_informatica_ctp.py).
+    """
 
     def setUp(self) -> None:
         self._agent = Agent(LoggingUtils())
 
     @patch("requests.request")
-    @patch("requests.post")
-    def test_v2_login_success_and_do_http_request(self, mock_post, mock_request):
-        """V2 login: login POST sent to v2 path, API calls use serverUrl from response."""
-        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
+    def test_do_http_request_constructs_url_from_api_base_url(self, mock_request):
+        """API calls use api_base_url from connect_args, not any login URL."""
         mock_request.return_value = _make_api_mock({"items": []})
-
-        operation_dict = {
-            "trace_id": "v2-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {
-                        "path": "/mfnRunStatus/api/v1/Activity",
-                        "http_method": "GET",
-                    },
-                }
-            ],
-        }
-
-        response = self._agent.execute_operation(
-            "informatica",
-            "http_request",
-            operation_dict,
-            {"connect_args": _V2_CONNECT_ARGS},
-        )
-
-        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
-
-        # Login went to the V2 path
-        mock_post.assert_called_once()
-        login_url = mock_post.call_args[0][0]
-        self.assertIn("/ma/api/v2/user/login", login_url)
-
-        # API call used the API base URL from the login response, not the login URL
-        mock_request.assert_called_once()
-        api_url = mock_request.call_args[0][1]
-        self.assertTrue(
-            api_url.startswith(_API_BASE_URL_V2),
-            f"Expected API URL to start with {_API_BASE_URL_V2!r}, got {api_url!r}",
-        )
-        self.assertIn("/mfnRunStatus/api/v1/Activity", api_url)
-
-    @patch("requests.request")
-    @patch("requests.post")
-    def test_v3_login_success_and_do_http_request(self, mock_post, mock_request):
-        """V3 login: login POST sent to v3 path, API base URL from Integration Cloud product."""
-        mock_post.return_value = _make_login_mock(_V3_LOGIN_BODY)
-        mock_request.return_value = _make_api_mock({"items": []})
-
-        operation_dict = {
-            "trace_id": "v3-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {
-                        "path": "/mfnRunStatus/api/v1/Activity",
-                        "http_method": "GET",
-                    },
-                }
-            ],
-        }
-
-        response = self._agent.execute_operation(
-            "informatica",
-            "http_request",
-            operation_dict,
-            {"connect_args": _V3_CONNECT_ARGS},
-        )
-
-        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
-
-        # Login went to the V3 path
-        login_url = mock_post.call_args[0][0]
-        self.assertIn("/saas/public/core/v3/login", login_url)
-
-        # API call used the Integration Cloud product's baseApiUrl
-        api_url = mock_request.call_args[0][1]
-        self.assertTrue(
-            api_url.startswith(_API_BASE_URL_V3),
-            f"Expected API URL to start with {_API_BASE_URL_V3!r}, got {api_url!r}",
-        )
-
-    @patch("requests.request")
-    @patch("requests.post")
-    def test_api_requests_use_base_url_from_login_response_not_login_url(
-        self, mock_post, mock_request
-    ):
-        """API calls use the API base URL returned by login, not the login base URL."""
-        login_base_url = "https://dm-us.informaticacloud.com"
-        connect_args = {**_V2_CONNECT_ARGS, "base_url": login_base_url}
-
-        mock_post.return_value = _make_login_mock(
-            _V2_LOGIN_BODY
-        )  # serverUrl differs from login URL
-        mock_request.return_value = _make_api_mock({"result": "ok"})
-
-        operation_dict = {
-            "trace_id": "url-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {"path": "/v2/jobs", "http_method": "GET"},
-                }
-            ],
-        }
 
         self._agent.execute_operation(
             "informatica",
             "http_request",
-            operation_dict,
-            {"connect_args": connect_args},
+            _make_operation("/api/v2/workflow"),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
         api_url = mock_request.call_args[0][1]
-        # Must NOT start with the login base URL — must use serverUrl from login response
-        self.assertFalse(
-            api_url.startswith(login_base_url),
-            f"API URL should use serverUrl from login response, not the login base URL. Got: {api_url!r}",
+        self.assertTrue(
+            api_url.startswith(_API_BASE_URL),
+            f"Expected URL to start with {_API_BASE_URL!r}, got {api_url!r}",
         )
-        self.assertTrue(api_url.startswith(_API_BASE_URL_V2))
+        self.assertIn("/api/v2/workflow", api_url)
 
     @patch("requests.request")
-    @patch("requests.post")
-    def test_v3_session_uses_v2_auth_header(self, mock_post, mock_request):
-        """V3-authenticated sessions use icSessionId (not INFA-SESSION-ID) for API calls.
+    def test_do_http_request_sends_ic_session_id_header(self, mock_request):
+        """All API calls use icSessionId header regardless of how the session was obtained.
 
-        The DC currently calls only V2 API endpoints, which require the icSessionId header.
-        This test acts as a regression guard for that intentional quirk.
+        This is coupled to V2 API usage, not the auth method. Acts as a regression
+        guard for the intentional icSessionId-over-INFA-SESSION-ID behavior.
         """
-        mock_post.return_value = _make_login_mock(_V3_LOGIN_BODY)
         mock_request.return_value = _make_api_mock({"result": "ok"})
-
-        operation_dict = {
-            "trace_id": "header-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {"path": "/v2/jobs", "http_method": "GET"},
-                }
-            ],
-        }
 
         self._agent.execute_operation(
             "informatica",
             "http_request",
-            operation_dict,
-            {"connect_args": _V3_CONNECT_ARGS},
+            _make_operation("/api/v2/workflow"),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
         headers = mock_request.call_args[1]["headers"]
-        self.assertIn("icSessionId", headers, "V3 sessions must use icSessionId header")
+        self.assertIn("icSessionId", headers, "icSessionId header must always be sent")
         self.assertNotIn(
             "INFA-SESSION-ID", headers, "INFA-SESSION-ID must not be used (V2 API path)"
         )
-        self.assertEqual(headers["icSessionId"], "v3-session-xyz789")
-
-    @patch("requests.post")
-    def test_login_failure_raises_error(self, mock_post):
-        """Login failure surfaces as an error in the agent response."""
-        from requests import HTTPError
-
-        mock_fail = MagicMock()
-        mock_fail.status_code = 401
-        mock_fail.text = "Unauthorized"
-        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
-        mock_post.return_value = mock_fail
-
-        operation_dict = {
-            "trace_id": "fail-test",
-            "skip_cache": True,
-            "commands": [{"method": "do_http_request", "kwargs": {"path": "/v2/jobs"}}],
-        }
-
-        response = self._agent.execute_operation(
-            "informatica",
-            "http_request",
-            operation_dict,
-            {"connect_args": _V2_CONNECT_ARGS},
-        )
-
-        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
-        error = response.result[ATTRIBUTE_NAME_ERROR]
-        self.assertIn("login failed", error.lower())
+        self.assertEqual(headers["icSessionId"], _SESSION_ID)
 
     @patch("requests.request")
-    @patch("requests.post")
-    def test_do_http_request_passes_params(self, mock_post, mock_request):
+    def test_do_http_request_passes_params(self, mock_request):
         """Query params are forwarded to the API call."""
-        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
         mock_request.return_value = _make_api_mock({"items": []})
-
-        operation_dict = {
-            "trace_id": "params-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {
-                        "path": "/v2/jobs",
-                        "http_method": "GET",
-                        "params": {"limit": 50, "offset": 0},
-                    },
-                }
-            ],
-        }
 
         self._agent.execute_operation(
             "informatica",
             "http_request",
-            operation_dict,
-            {"connect_args": _V2_CONNECT_ARGS},
+            _make_operation(
+                "/api/v2/activity/activityLog",
+                params={"taskId": "t1", "offset": 0, "rowLimit": 100},
+            ),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
         self.assertEqual(
-            mock_request.call_args[1].get("params"), {"limit": 50, "offset": 0}
+            mock_request.call_args[1].get("params"),
+            {"taskId": "t1", "offset": 0, "rowLimit": 100},
         )
 
     @patch("requests.request")
-    @patch("requests.post")
-    def test_do_http_request_post_with_payload(self, mock_post, mock_request):
+    def test_do_http_request_post_with_payload(self, mock_request):
         """POST requests forward the JSON payload."""
-        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
         mock_request.return_value = _make_api_mock({"id": "job-123"})
 
-        operation_dict = {
-            "trace_id": "post-test",
-            "skip_cache": True,
-            "commands": [
-                {
-                    "method": "do_http_request",
-                    "kwargs": {
-                        "path": "/v2/jobs",
-                        "http_method": "POST",
-                        "payload": {"name": "new-job", "type": "mapping"},
-                    },
-                }
-            ],
-        }
-
-        response = self._agent.execute_operation(
+        self._agent.execute_operation(
             "informatica",
             "http_request",
-            operation_dict,
-            {"connect_args": _V2_CONNECT_ARGS},
+            _make_operation(
+                "/api/v2/jobs", http_method="POST", payload={"name": "new-job"}
+            ),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
-        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
-        self.assertEqual(mock_request.call_args[0][0], "POST")
-        self.assertEqual(
-            mock_request.call_args[1].get("json"),
-            {"name": "new-job", "type": "mapping"},
+        self.assertIsNone(
+            self._agent.execute_operation(
+                "informatica",
+                "http_request",
+                _make_operation(
+                    "/api/v2/jobs", http_method="POST", payload={"name": "new-job"}
+                ),
+                {"connect_args": _RESOLVED_CONNECT_ARGS},
+            ).result.get(ATTRIBUTE_NAME_ERROR)
         )
+        self.assertEqual(mock_request.call_args[0][0], "POST")
+        self.assertEqual(mock_request.call_args[1].get("json"), {"name": "new-job"})
 
     @patch("requests.request")
-    @patch("requests.post")
-    def test_http_error_handling(self, mock_post, mock_request):
+    def test_http_error_surfaced_as_http_error_type(self, mock_request):
         """HTTP errors on API calls are surfaced with HTTPError type."""
         from requests import HTTPError
-
-        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
 
         mock_fail = MagicMock()
         mock_fail.status_code = 404
@@ -355,19 +166,11 @@ class InformaticaHttpTests(TestCase):
         mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
         mock_request.return_value = mock_fail
 
-        operation_dict = {
-            "trace_id": "error-test",
-            "skip_cache": True,
-            "commands": [
-                {"method": "do_http_request", "kwargs": {"path": "/v2/nonexistent"}}
-            ],
-        }
-
         response = self._agent.execute_operation(
             "informatica",
             "http_request",
-            operation_dict,
-            {"connect_args": _V2_CONNECT_ARGS},
+            _make_operation("/api/v2/nonexistent"),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
 
         self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
@@ -394,21 +197,22 @@ class _ListHandler(logging.Handler):
 
 
 class InformaticaProxyClientSafetyTests(TestCase):
-    """Verify that credentials do not leak into responses or log output."""
+    """Verify that session credentials do not leak into responses or log output."""
 
-    _USERNAME = "svc_account@example.com"
-    _PASSWORD = "s3cr3t_p@ssw0rd!"
+    _SESSION_ID = "super-secret-session-token-xyz"
+    _API_BASE_URL = "https://na1.informaticacloud.com"
 
     _CONNECT_ARGS = {
-        "username": _USERNAME,
-        "password": _PASSWORD,
-        "informatica_auth": "v2",
+        "session_id": _SESSION_ID,
+        "api_base_url": _API_BASE_URL,
     }
 
     _OPERATION = {
         "trace_id": "safety-test",
         "skip_cache": True,
-        "commands": [{"method": "do_http_request", "kwargs": {"path": "/v2/jobs"}}],
+        "commands": [
+            {"method": "do_http_request", "kwargs": {"path": "/api/v2/workflow"}}
+        ],
     }
 
     def setUp(self):
@@ -420,59 +224,33 @@ class InformaticaProxyClientSafetyTests(TestCase):
     def tearDown(self):
         logging.getLogger().removeHandler(self._log_handler)
 
-    def _assert_no_credential_leak(self, response) -> None:
-        serialized = json.dumps(response.result, default=str)
-        self.assertNotIn(
-            self._PASSWORD, serialized, "password leaked in agent response"
-        )
-
-    def test_missing_username_is_actionable_and_safe(self):
-        """Missing username produces an actionable error without leaking password."""
-        connect_args = {"password": self._PASSWORD, "informatica_auth": "v2"}
+    def test_missing_credentials_gives_actionable_error(self):
+        """Empty connect_args (no username/password, no jwt_token, no session_id) →
+        actionable error from the CTP pipeline, not a cryptic traceback."""
         response = self._agent.execute_operation(
             "informatica",
             "http_request",
             self._OPERATION,
-            {"connect_args": connect_args},
+            {"connect_args": {}},
         )
         self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
+        # Error must mention what's needed — not expose internal state or credentials.
         error = response.result[ATTRIBUTE_NAME_ERROR]
-        self.assertIn("username", error)
-        self._assert_no_credential_leak(response)
+        self.assertTrue(
+            len(error) > 0,
+            "Error message must be non-empty",
+        )
 
-    @patch("requests.post")
-    def test_login_failure_is_actionable_and_safe(self, mock_post):
-        """Login failure surfaces a useful error without leaking the password."""
+    @patch("requests.request")
+    def test_log_output_does_not_leak_session_token(self, mock_request):
+        """JsonLogFormatter (Datadog/Lambda path) never emits the session token."""
         from requests import HTTPError
 
         mock_fail = MagicMock()
-        mock_fail.status_code = 401
-        mock_fail.text = "Unauthorized"
+        mock_fail.status_code = 403
+        mock_fail.text = "Forbidden"
         mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
-        mock_post.return_value = mock_fail
-
-        response = self._agent.execute_operation(
-            "informatica",
-            "http_request",
-            self._OPERATION,
-            {"connect_args": self._CONNECT_ARGS},
-        )
-
-        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
-        self._assert_no_credential_leak(response)
-        error = response.result[ATTRIBUTE_NAME_ERROR]
-        self.assertIn("login failed", error.lower())
-
-    @patch("requests.post")
-    def test_log_output_does_not_leak_credentials(self, mock_post):
-        """JsonLogFormatter (Datadog/Lambda path) never emits the password."""
-        from requests import HTTPError
-
-        mock_fail = MagicMock()
-        mock_fail.status_code = 401
-        mock_fail.text = "Unauthorized"
-        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
-        mock_post.return_value = mock_fail
+        mock_request.return_value = mock_fail
 
         self._agent.execute_operation(
             "informatica",
@@ -485,5 +263,7 @@ class InformaticaProxyClientSafetyTests(TestCase):
         for record in self._log_records:
             output = formatter.format(record)
             self.assertNotIn(
-                self._PASSWORD, output, f"password leaked in log record: {output}"
+                self._SESSION_ID,
+                output,
+                f"session token leaked in log record: {output}",
             )

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -224,11 +224,11 @@ class InformaticaProxyClientSafetyTests(TestCase):
             {"connect_args": {}},
         )
         self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
-        # Error must mention what's needed — not expose internal state or credentials.
+        # Error must name what's missing so the user knows what to fix.
         error = response.result[ATTRIBUTE_NAME_ERROR]
         self.assertTrue(
-            len(error) > 0,
-            "Error message must be non-empty",
+            any(token in error for token in ("username", "jwt_token", "session_id")),
+            f"Error must name the missing credential input, got: {error!r}",
         )
 
     @patch("requests.request")

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -1,0 +1,489 @@
+import json
+import logging
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from apollo.agent.agent import Agent
+from apollo.agent.logging_utils import LoggingUtils
+from apollo.common.agent.constants import (
+    ATTRIBUTE_NAME_ERROR,
+    ATTRIBUTE_NAME_RESULT,
+    ATTRIBUTE_NAME_ERROR_TYPE,
+)
+from apollo.interfaces.lambda_function.json_log_formatter import JsonLogFormatter
+
+# ---------------------------------------------------------------------------
+# Shared test fixtures
+# ---------------------------------------------------------------------------
+
+_V2_CONNECT_ARGS = {
+    "username": "testuser",
+    "password": "s3cr3t_p@ss!",
+    "informatica_auth": "v2",
+}
+
+_V3_CONNECT_ARGS = {
+    "username": "testuser",
+    "password": "s3cr3t_p@ss!",
+    "informatica_auth": "v3",
+}
+
+_API_BASE_URL_V2 = "https://na1.informaticacloud.com"
+_API_BASE_URL_V3 = "https://eu1.informaticacloud.com"
+
+_V2_LOGIN_BODY = {
+    "serverUrl": _API_BASE_URL_V2,
+    "icSessionId": "v2-session-abc123",
+}
+
+_V3_LOGIN_BODY = {
+    "products": [
+        {
+            "name": "Integration Cloud",
+            "baseApiUrl": _API_BASE_URL_V3,
+        },
+        {
+            "name": "Other Service",
+            "baseApiUrl": "https://other.example.com",
+        },
+    ],
+    "userInfo": {"sessionId": "v3-session-xyz789"},
+}
+
+
+def _make_mock_response(body: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = body
+    resp.text = json.dumps(body)
+    return resp
+
+
+def _make_login_mock(body: dict) -> MagicMock:
+    resp = _make_mock_response(body)
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_api_mock(body: dict) -> MagicMock:
+    resp = _make_mock_response(body)
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# HTTP request tests
+# ---------------------------------------------------------------------------
+
+
+class InformaticaHttpTests(TestCase):
+    """Tests for InformaticaProxyClient login and do_http_request behavior."""
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_v2_login_success_and_do_http_request(self, mock_post, mock_request):
+        """V2 login: login POST sent to v2 path, API calls use serverUrl from response."""
+        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        operation_dict = {
+            "trace_id": "v2-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {
+                        "path": "/mfnRunStatus/api/v1/Activity",
+                        "http_method": "GET",
+                    },
+                }
+            ],
+        }
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V2_CONNECT_ARGS},
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+
+        # Login went to the V2 path
+        mock_post.assert_called_once()
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/ma/api/v2/user/login", login_url)
+
+        # API call used the API base URL from the login response, not the login URL
+        mock_request.assert_called_once()
+        api_url = mock_request.call_args[0][1]
+        self.assertTrue(
+            api_url.startswith(_API_BASE_URL_V2),
+            f"Expected API URL to start with {_API_BASE_URL_V2!r}, got {api_url!r}",
+        )
+        self.assertIn("/mfnRunStatus/api/v1/Activity", api_url)
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_v3_login_success_and_do_http_request(self, mock_post, mock_request):
+        """V3 login: login POST sent to v3 path, API base URL from Integration Cloud product."""
+        mock_post.return_value = _make_login_mock(_V3_LOGIN_BODY)
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        operation_dict = {
+            "trace_id": "v3-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {
+                        "path": "/mfnRunStatus/api/v1/Activity",
+                        "http_method": "GET",
+                    },
+                }
+            ],
+        }
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V3_CONNECT_ARGS},
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+
+        # Login went to the V3 path
+        login_url = mock_post.call_args[0][0]
+        self.assertIn("/saas/public/core/v3/login", login_url)
+
+        # API call used the Integration Cloud product's baseApiUrl
+        api_url = mock_request.call_args[0][1]
+        self.assertTrue(
+            api_url.startswith(_API_BASE_URL_V3),
+            f"Expected API URL to start with {_API_BASE_URL_V3!r}, got {api_url!r}",
+        )
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_api_requests_use_base_url_from_login_response_not_login_url(
+        self, mock_post, mock_request
+    ):
+        """API calls use the API base URL returned by login, not the login base URL."""
+        login_base_url = "https://dm-us.informaticacloud.com"
+        connect_args = {**_V2_CONNECT_ARGS, "base_url": login_base_url}
+
+        mock_post.return_value = _make_login_mock(
+            _V2_LOGIN_BODY
+        )  # serverUrl differs from login URL
+        mock_request.return_value = _make_api_mock({"result": "ok"})
+
+        operation_dict = {
+            "trace_id": "url-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {"path": "/v2/jobs", "http_method": "GET"},
+                }
+            ],
+        }
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": connect_args},
+        )
+
+        api_url = mock_request.call_args[0][1]
+        # Must NOT start with the login base URL — must use serverUrl from login response
+        self.assertFalse(
+            api_url.startswith(login_base_url),
+            f"API URL should use serverUrl from login response, not the login base URL. Got: {api_url!r}",
+        )
+        self.assertTrue(api_url.startswith(_API_BASE_URL_V2))
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_v3_session_uses_v2_auth_header(self, mock_post, mock_request):
+        """V3-authenticated sessions use icSessionId (not INFA-SESSION-ID) for API calls.
+
+        The DC currently calls only V2 API endpoints, which require the icSessionId header.
+        This test acts as a regression guard for that intentional quirk.
+        """
+        mock_post.return_value = _make_login_mock(_V3_LOGIN_BODY)
+        mock_request.return_value = _make_api_mock({"result": "ok"})
+
+        operation_dict = {
+            "trace_id": "header-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {"path": "/v2/jobs", "http_method": "GET"},
+                }
+            ],
+        }
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V3_CONNECT_ARGS},
+        )
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertIn("icSessionId", headers, "V3 sessions must use icSessionId header")
+        self.assertNotIn(
+            "INFA-SESSION-ID", headers, "INFA-SESSION-ID must not be used (V2 API path)"
+        )
+        self.assertEqual(headers["icSessionId"], "v3-session-xyz789")
+
+    @patch("requests.post")
+    def test_login_failure_raises_error(self, mock_post):
+        """Login failure surfaces as an error in the agent response."""
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.status_code = 401
+        mock_fail.text = "Unauthorized"
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        operation_dict = {
+            "trace_id": "fail-test",
+            "skip_cache": True,
+            "commands": [{"method": "do_http_request", "kwargs": {"path": "/v2/jobs"}}],
+        }
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V2_CONNECT_ARGS},
+        )
+
+        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
+        error = response.result[ATTRIBUTE_NAME_ERROR]
+        self.assertIn("login failed", error.lower())
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_do_http_request_passes_params(self, mock_post, mock_request):
+        """Query params are forwarded to the API call."""
+        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        operation_dict = {
+            "trace_id": "params-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {
+                        "path": "/v2/jobs",
+                        "http_method": "GET",
+                        "params": {"limit": 50, "offset": 0},
+                    },
+                }
+            ],
+        }
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V2_CONNECT_ARGS},
+        )
+
+        self.assertEqual(
+            mock_request.call_args[1].get("params"), {"limit": 50, "offset": 0}
+        )
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_do_http_request_post_with_payload(self, mock_post, mock_request):
+        """POST requests forward the JSON payload."""
+        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
+        mock_request.return_value = _make_api_mock({"id": "job-123"})
+
+        operation_dict = {
+            "trace_id": "post-test",
+            "skip_cache": True,
+            "commands": [
+                {
+                    "method": "do_http_request",
+                    "kwargs": {
+                        "path": "/v2/jobs",
+                        "http_method": "POST",
+                        "payload": {"name": "new-job", "type": "mapping"},
+                    },
+                }
+            ],
+        }
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V2_CONNECT_ARGS},
+        )
+
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+        self.assertEqual(mock_request.call_args[0][0], "POST")
+        self.assertEqual(
+            mock_request.call_args[1].get("json"),
+            {"name": "new-job", "type": "mapping"},
+        )
+
+    @patch("requests.request")
+    @patch("requests.post")
+    def test_http_error_handling(self, mock_post, mock_request):
+        """HTTP errors on API calls are surfaced with HTTPError type."""
+        from requests import HTTPError
+
+        mock_post.return_value = _make_login_mock(_V2_LOGIN_BODY)
+
+        mock_fail = MagicMock()
+        mock_fail.status_code = 404
+        mock_fail.text = "Not Found"
+        mock_fail.reason = "Not Found"
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_request.return_value = mock_fail
+
+        operation_dict = {
+            "trace_id": "error-test",
+            "skip_cache": True,
+            "commands": [
+                {"method": "do_http_request", "kwargs": {"path": "/v2/nonexistent"}}
+            ],
+        }
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            operation_dict,
+            {"connect_args": _V2_CONNECT_ARGS},
+        )
+
+        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
+        self.assertEqual("HTTPError", response.result.get(ATTRIBUTE_NAME_ERROR_TYPE))
+
+
+# ---------------------------------------------------------------------------
+# Logging handler helper
+# ---------------------------------------------------------------------------
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self, records):
+        super().__init__()
+        self._records = records
+
+    def emit(self, record):
+        self._records.append(record)
+
+
+# ---------------------------------------------------------------------------
+# Credential safety tests
+# ---------------------------------------------------------------------------
+
+
+class InformaticaProxyClientSafetyTests(TestCase):
+    """Verify that credentials do not leak into responses or log output."""
+
+    _USERNAME = "svc_account@example.com"
+    _PASSWORD = "s3cr3t_p@ssw0rd!"
+
+    _CONNECT_ARGS = {
+        "username": _USERNAME,
+        "password": _PASSWORD,
+        "informatica_auth": "v2",
+    }
+
+    _OPERATION = {
+        "trace_id": "safety-test",
+        "skip_cache": True,
+        "commands": [{"method": "do_http_request", "kwargs": {"path": "/v2/jobs"}}],
+    }
+
+    def setUp(self):
+        self._agent = Agent(LoggingUtils())
+        self._log_records = []
+        self._log_handler = _ListHandler(self._log_records)
+        logging.getLogger().addHandler(self._log_handler)
+
+    def tearDown(self):
+        logging.getLogger().removeHandler(self._log_handler)
+
+    def _assert_no_credential_leak(self, response) -> None:
+        serialized = json.dumps(response.result, default=str)
+        self.assertNotIn(
+            self._PASSWORD, serialized, "password leaked in agent response"
+        )
+
+    def test_missing_username_is_actionable_and_safe(self):
+        """Missing username produces an actionable error without leaking password."""
+        connect_args = {"password": self._PASSWORD, "informatica_auth": "v2"}
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            self._OPERATION,
+            {"connect_args": connect_args},
+        )
+        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
+        error = response.result[ATTRIBUTE_NAME_ERROR]
+        self.assertIn("username", error)
+        self._assert_no_credential_leak(response)
+
+    @patch("requests.post")
+    def test_login_failure_is_actionable_and_safe(self, mock_post):
+        """Login failure surfaces a useful error without leaking the password."""
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.status_code = 401
+        mock_fail.text = "Unauthorized"
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        response = self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            self._OPERATION,
+            {"connect_args": self._CONNECT_ARGS},
+        )
+
+        self.assertIn(ATTRIBUTE_NAME_ERROR, response.result)
+        self._assert_no_credential_leak(response)
+        error = response.result[ATTRIBUTE_NAME_ERROR]
+        self.assertIn("login failed", error.lower())
+
+    @patch("requests.post")
+    def test_log_output_does_not_leak_credentials(self, mock_post):
+        """JsonLogFormatter (Datadog/Lambda path) never emits the password."""
+        from requests import HTTPError
+
+        mock_fail = MagicMock()
+        mock_fail.status_code = 401
+        mock_fail.text = "Unauthorized"
+        mock_fail.raise_for_status.side_effect = HTTPError(response=mock_fail)
+        mock_post.return_value = mock_fail
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            self._OPERATION,
+            {"connect_args": self._CONNECT_ARGS},
+        )
+
+        formatter = JsonLogFormatter()
+        for record in self._log_records:
+            output = formatter.format(record)
+            self.assertNotIn(
+                self._PASSWORD, output, f"password leaked in log record: {output}"
+            )


### PR DESCRIPTION
## Summary

- Adds `resolve_informatica_session` CTP transform supporting V2 password, V3 password, and JWT `loginOAuth` auth modes
- Refactors `InformaticaProxyClient` to be auth-method agnostic — it receives a pre-resolved `session_id` + `api_base_url` from CTP rather than performing login itself
- Registers the Informatica default CTP config (guarded by `when="raw.session_id is not defined"` so the pre-shaped DC path still works)
- Registers `informatica` in `proxy_client_factory`

## Motivation

Previously the proxy client contained login logic tied to specific auth methods. Moving session resolution into a CTP transform:
- Decouples auth from the proxy client (same pattern as other CTP connectors)
- Enables custom per-customer CTP configs (e.g. JWT via Okta ROPC → `loginOAuth`) without touching the proxy client
- Supports self-hosted credential passthrough via AWS Secrets Manager

## What's tested

- `tests/ctp/test_resolve_informatica_session.py` — 23+ tests across V2, V3, JWT, and error paths
- `tests/ctp/test_informatica_ctp.py` — pipeline integration tests
- `tests/test_informatica_proxy_client.py` — proxy client tests against the new connect_args shape

## Notes

- `INFORMATICA_PROXY_CLIENT_AGENT_MIN_VERSION` in the DC is set to `9_999_999` temporarily; will be updated to the real build number once this merges and a dev image is cut
- JWT loginOAuth requires `matchType: "aliasName"` in the Informatica IDP config and the service account user set to "IDP with SAML" authentication type