### PR TITLE
fix(sfdc): retry transient HTTP errors on cursor and list_tables

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -55,7 +55,17 @@ def _retry_on_transient_network_errors(
     A short retry on a fresh pooled connection clears it. Permanent errors
     (``SalesforceCDPError``, auth failures, query syntax) are not in the catch
     list and propagate immediately.
+
+    Raises ``ValueError`` if ``attempts < 1`` or any delay parameter is negative
+    so misconfiguration surfaces as a clear caller error rather than an obscure
+    runtime ``AssertionError``.
     """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}")
+    if base_delay < 0:
+        raise ValueError(f"base_delay must be >= 0, got {base_delay}")
+    if max_delay < 0:
+        raise ValueError(f"max_delay must be >= 0, got {max_delay}")
     last_exc: BaseException | None = None
     for attempt in range(1, attempts + 1):
         try:

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -1,15 +1,103 @@
+import http.client
 import logging
+import time
 from dataclasses import dataclass
-from typing import Any, NoReturn
+from typing import Any, Callable, NoReturn, TypeVar
 
 import requests
+import urllib3.exceptions
 from salesforcecdpconnector.connection import SalesforceCDPConnection
+from salesforcecdpconnector.cursor import SalesforceCDPCursor
 from salesforcecdpconnector.exceptions import Error as SalesforceCDPError
 from salesforcecdpconnector.genie_table import GenieTable, Field
 
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Transient network errors that occur when a pooled HTTP connection to Salesforce's
+# edge has been silently closed by the LB after idle, then the agent reuses it on
+# the next request. Salesforce drops the TCP socket without sending an HTTP
+# response, urllib3 raises ProtocolError(RemoteDisconnected(...)), and the call
+# fails. Retrying on a fresh connection from the pool typically succeeds.
+# See: hourly metric monitor failures with `AgentClientError. ('Connection
+# aborted.', RemoteDisconnected('Remote end closed connection without response'))`.
+_TRANSIENT_NETWORK_ERRORS: tuple[type[BaseException], ...] = (
+    urllib3.exceptions.ProtocolError,
+    http.client.RemoteDisconnected,
+    ConnectionResetError,
+    ConnectionAbortedError,
+    requests.exceptions.ConnectionError,
+    requests.exceptions.ChunkedEncodingError,
+)
+
+# Default retry policy. Attempts include the initial call.
+_RETRY_ATTEMPTS = 3
+_RETRY_BASE_DELAY_SECS = 0.5
+_RETRY_MAX_DELAY_SECS = 4.0
+
+
+def _retry_on_transient_network_errors(
+    func: Callable[..., T],
+    *,
+    operation: str,
+    attempts: int = _RETRY_ATTEMPTS,
+    base_delay: float = _RETRY_BASE_DELAY_SECS,
+    max_delay: float = _RETRY_MAX_DELAY_SECS,
+) -> T:
+    """Run *func* and retry on transient HTTP/TCP errors with exponential backoff.
+
+    Salesforce Data Cloud's edge load balancer closes idle keep-alive connections,
+    so the next reuse from urllib3's connection pool occasionally raises
+    ``RemoteDisconnected`` / ``ProtocolError`` before any HTTP response arrives.
+    A short retry on a fresh pooled connection clears it. Permanent errors
+    (``SalesforceCDPError``, auth failures, query syntax) are not in the catch
+    list and propagate immediately.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return func()
+        except _TRANSIENT_NETWORK_ERRORS as exc:
+            last_exc = exc
+            if attempt >= attempts:
+                logger.warning(
+                    "Salesforce Data Cloud: transient network error on '%s' after "
+                    "%d attempts; giving up",
+                    operation,
+                    attempt,
+                    extra={
+                        "sfdc_operation": operation,
+                        "sfdc_retry_attempt": attempt,
+                        "sfdc_retry_exhausted": True,
+                        "sfdc_error_type": type(exc).__name__,
+                        "sfdc_error": str(exc)[:500],
+                    },
+                )
+                raise
+            delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
+            logger.warning(
+                "Salesforce Data Cloud: transient network error on '%s' "
+                "(attempt %d/%d); retrying after %.1fs",
+                operation,
+                attempt,
+                attempts,
+                delay,
+                extra={
+                    "sfdc_operation": operation,
+                    "sfdc_retry_attempt": attempt,
+                    "sfdc_retry_exhausted": False,
+                    "sfdc_error_type": type(exc).__name__,
+                    "sfdc_error": str(exc)[:500],
+                    "sfdc_retry_delay_secs": delay,
+                },
+            )
+            time.sleep(delay)
+    # Defensive — the loop above either returns or re-raises.
+    assert last_exc is not None
+    raise last_exc
 
 
 class _CapturingSession(requests.Session):
@@ -104,6 +192,39 @@ def _attach_capturing_session(
     return capturing
 
 
+class _RetryingSalesforceDataCloudCursor(SalesforceCDPCursor):
+    """SalesforceCDPCursor that retries the four HTTP-bound methods on transient
+    network errors. Inherits the rest (description/data state, ``close``,
+    ``rollback``, etc.) from the upstream class unchanged.
+    """
+
+    def execute(self, query: Any, params: Any = None) -> None:
+        return _retry_on_transient_network_errors(
+            lambda: super(_RetryingSalesforceDataCloudCursor, self).execute(
+                query, params
+            ),
+            operation="cursor.execute",
+        )
+
+    def fetchall(self) -> Any:
+        return _retry_on_transient_network_errors(
+            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchall(),
+            operation="cursor.fetchall",
+        )
+
+    def fetchone(self) -> Any:
+        return _retry_on_transient_network_errors(
+            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchone(),
+            operation="cursor.fetchone",
+        )
+
+    def fetchmany(self, size: Any = None) -> Any:
+        return _retry_on_transient_network_errors(
+            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchmany(size),
+            operation="cursor.fetchmany",
+        )
+
+
 class SalesforceDataCloudConnection(SalesforceCDPConnection):
     def __init__(
         self,
@@ -165,6 +286,19 @@ class SalesforceDataCloudConnection(SalesforceCDPConnection):
                 client_secret=client_secret,
                 dataspace=dataspace,
             )
+
+    def cursor(self) -> SalesforceCDPCursor:
+        """Override to return a cursor that retries on transient network errors.
+
+        ``SalesforceCDPConnection.cursor()`` would otherwise hand back a vanilla
+        ``SalesforceCDPCursor`` whose ``execute``/``fetch*`` methods bubble
+        ``urllib3`` ``ProtocolError`` straight up — we want the retry around the
+        HTTP-bound calls so a stale pooled connection from Salesforce's edge
+        doesn't fail an entire metric-monitor run.
+        """
+        if self.closed:
+            return super().cursor()  # let the upstream raise the same Error
+        return _RetryingSalesforceDataCloudCursor(self)
 
 
 @dataclass
@@ -229,7 +363,10 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             )
             capturing = _attach_capturing_session(conn)
             try:
-                tables: list[GenieTable] = conn.list_tables()
+                tables: list[GenieTable] = _retry_on_transient_network_errors(
+                    conn.list_tables,
+                    operation="list_tables(scoped)",
+                )
             except SalesforceCDPError as e:
                 body = _redact_body(capturing.last_exchange_body if capturing else None)
                 status = capturing.last_exchange_status if capturing else None
@@ -307,7 +444,10 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 unscoped_conn = None
             conn_to_use = unscoped_conn or self._connection
             try:
-                tables = conn_to_use.list_tables()
+                tables = _retry_on_transient_network_errors(
+                    conn_to_use.list_tables,
+                    operation="list_tables(unscoped)",
+                )
             except SalesforceCDPError as e:
                 raise RuntimeError(
                     f"Token exchange failed: {e} — verify credentials are valid"

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -1,10 +1,11 @@
 import http.client
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, NoReturn, TypeVar
+from typing import Any, NoReturn
 
 import requests
 import urllib3.exceptions
+from retry import retry
 from retry.api import retry_call
 from salesforcecdpconnector.connection import SalesforceCDPConnection
 from salesforcecdpconnector.cursor import SalesforceCDPCursor
@@ -14,8 +15,6 @@ from salesforcecdpconnector.genie_table import GenieTable, Field
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
 
 logger = logging.getLogger(__name__)
-
-T = TypeVar("T")
 
 # Transient network errors that occur when a pooled HTTP connection to Salesforce's
 # edge has been silently closed by the LB after idle, then the agent reuses it on
@@ -33,95 +32,18 @@ _TRANSIENT_NETWORK_ERRORS: tuple[type[Exception], ...] = (
     requests.exceptions.ChunkedEncodingError,
 )
 
-# Default retry policy. ``tries`` includes the initial call.
-_RETRY_TRIES = 3
-_RETRY_BASE_DELAY_SECS = 0.5
-_RETRY_MAX_DELAY_SECS = 4.0
-_RETRY_BACKOFF = 2
-
-
-class _StructuredRetryLogger:
-    """Adapter for the ``retry`` library that converts its hardcoded
-    ``logger.warning(formatted_msg)`` calls into structured records suitable
-    for Datadog filtering on ``sfdc_*`` fields.
-
-    The library calls ``warning()`` once per failed attempt before sleeping;
-    this adapter re-emits the entry through our module logger with
-    ``extra={...}`` so operators can build dashboards/alerts off
-    ``sfdc_operation``, ``sfdc_retry_attempt``, ``sfdc_retry_exhausted``, etc.
-    """
-
-    def __init__(self, operation: str) -> None:
-        self._operation = operation
-        self._attempt = 0
-
-    def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
-        self._attempt += 1
-        logger.warning(
-            "Salesforce Data Cloud: transient network error on '%s' (attempt %d); retrying",
-            self._operation,
-            self._attempt,
-            extra={
-                "sfdc_operation": self._operation,
-                "sfdc_retry_attempt": self._attempt,
-                "sfdc_retry_exhausted": False,
-                "sfdc_error": str(msg)[:500],
-            },
-        )
-
-
-def _retry_on_transient_network_errors(
-    func: Callable[[], T],
-    *,
-    operation: str,
-    tries: int = _RETRY_TRIES,
-    base_delay: float = _RETRY_BASE_DELAY_SECS,
-    max_delay: float = _RETRY_MAX_DELAY_SECS,
-    backoff: float = _RETRY_BACKOFF,
-) -> T:
-    """Run *func* with retries on transient HTTP/TCP errors.
-
-    Wraps ``retry.api.retry_call`` with a structured-logger adapter (per-attempt
-    warnings) plus an explicit "exhausted" log line at the end so operators can
-    alert on ``sfdc_retry_exhausted:true`` directly. Permanent errors
-    (``SalesforceCDPError``, auth failures, query syntax) are not in the catch
-    list and propagate immediately.
-
-    Raises ``ValueError`` if ``tries < 1`` or any delay parameter is negative so
-    misconfiguration surfaces as a clear caller error rather than an obscure
-    runtime failure.
-    """
-    if tries < 1:
-        raise ValueError(f"tries must be >= 1, got {tries}")
-    if base_delay < 0:
-        raise ValueError(f"base_delay must be >= 0, got {base_delay}")
-    if max_delay < 0:
-        raise ValueError(f"max_delay must be >= 0, got {max_delay}")
-    try:
-        return retry_call(
-            func,
-            exceptions=_TRANSIENT_NETWORK_ERRORS,
-            tries=tries,
-            delay=base_delay,
-            max_delay=max_delay,
-            backoff=backoff,
-            # The retry library duck-types the logger — anything with `.warning()`
-            # is accepted (line 50 of retry/api.py). Pyright's annotation is
-            # tighter (`Logger | None`).
-            logger=_StructuredRetryLogger(operation),  # type: ignore[arg-type]
-        )
-    except _TRANSIENT_NETWORK_ERRORS as exc:
-        logger.warning(
-            "Salesforce Data Cloud: transient network error on '%s' after retries; giving up",
-            operation,
-            extra={
-                "sfdc_operation": operation,
-                "sfdc_retry_exhausted": True,
-                "sfdc_error_type": type(exc).__name__,
-                "sfdc_error": str(exc)[:500],
-            },
-        )
-        raise
+# Retry config shared by `@retry` decorations and `retry_call(...)` invocations.
+# tries includes the initial call; backoff multiplies delay each attempt up to
+# max_delay. Logger is passed so retry-library warnings flow through this
+# module's logger rather than retry.logging_logger.
+_RETRY_KWARGS: dict[str, Any] = {
+    "exceptions": _TRANSIENT_NETWORK_ERRORS,
+    "tries": 3,
+    "delay": 0.5,
+    "max_delay": 4,
+    "backoff": 2,
+    "logger": logger,
+}
 
 
 class _CapturingSession(requests.Session):
@@ -222,31 +144,21 @@ class _RetryingSalesforceDataCloudCursor(SalesforceCDPCursor):
     ``rollback``, etc.) from the upstream class unchanged.
     """
 
+    @retry(**_RETRY_KWARGS)
     def execute(self, query: Any, params: Any = None) -> None:
-        return _retry_on_transient_network_errors(
-            lambda: super(_RetryingSalesforceDataCloudCursor, self).execute(
-                query, params
-            ),
-            operation="cursor.execute",
-        )
+        return super().execute(query, params)
 
+    @retry(**_RETRY_KWARGS)
     def fetchall(self) -> Any:
-        return _retry_on_transient_network_errors(
-            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchall(),
-            operation="cursor.fetchall",
-        )
+        return super().fetchall()
 
+    @retry(**_RETRY_KWARGS)
     def fetchone(self) -> Any:
-        return _retry_on_transient_network_errors(
-            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchone(),
-            operation="cursor.fetchone",
-        )
+        return super().fetchone()
 
+    @retry(**_RETRY_KWARGS)
     def fetchmany(self, size: Any = None) -> Any:
-        return _retry_on_transient_network_errors(
-            lambda: super(_RetryingSalesforceDataCloudCursor, self).fetchmany(size),
-            operation="cursor.fetchmany",
-        )
+        return super().fetchmany(size)
 
 
 class SalesforceDataCloudConnection(SalesforceCDPConnection):
@@ -387,10 +299,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             )
             capturing = _attach_capturing_session(conn)
             try:
-                tables: list[GenieTable] = _retry_on_transient_network_errors(
-                    conn.list_tables,
-                    operation="list_tables(scoped)",
-                )
+                tables: list[GenieTable] = retry_call(conn.list_tables, **_RETRY_KWARGS)
             except SalesforceCDPError as e:
                 body = _redact_body(capturing.last_exchange_body if capturing else None)
                 status = capturing.last_exchange_status if capturing else None
@@ -468,10 +377,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 unscoped_conn = None
             conn_to_use = unscoped_conn or self._connection
             try:
-                tables = _retry_on_transient_network_errors(
-                    conn_to_use.list_tables,
-                    operation="list_tables(unscoped)",
-                )
+                tables = retry_call(conn_to_use.list_tables, **_RETRY_KWARGS)
             except SalesforceCDPError as e:
                 raise RuntimeError(
                     f"Token exchange failed: {e} — verify credentials are valid"

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -1,11 +1,11 @@
 import http.client
 import logging
-import time
 from dataclasses import dataclass
 from typing import Any, Callable, NoReturn, TypeVar
 
 import requests
 import urllib3.exceptions
+from retry.api import retry_call
 from salesforcecdpconnector.connection import SalesforceCDPConnection
 from salesforcecdpconnector.cursor import SalesforceCDPCursor
 from salesforcecdpconnector.exceptions import Error as SalesforceCDPError
@@ -24,7 +24,7 @@ T = TypeVar("T")
 # fails. Retrying on a fresh connection from the pool typically succeeds.
 # See: hourly metric monitor failures with `AgentClientError. ('Connection
 # aborted.', RemoteDisconnected('Remote end closed connection without response'))`.
-_TRANSIENT_NETWORK_ERRORS: tuple[type[BaseException], ...] = (
+_TRANSIENT_NETWORK_ERRORS: tuple[type[Exception], ...] = (
     urllib3.exceptions.ProtocolError,
     http.client.RemoteDisconnected,
     ConnectionResetError,
@@ -33,81 +33,95 @@ _TRANSIENT_NETWORK_ERRORS: tuple[type[BaseException], ...] = (
     requests.exceptions.ChunkedEncodingError,
 )
 
-# Default retry policy. Attempts include the initial call.
-_RETRY_ATTEMPTS = 3
+# Default retry policy. ``tries`` includes the initial call.
+_RETRY_TRIES = 3
 _RETRY_BASE_DELAY_SECS = 0.5
 _RETRY_MAX_DELAY_SECS = 4.0
+_RETRY_BACKOFF = 2
+
+
+class _StructuredRetryLogger:
+    """Adapter for the ``retry`` library that converts its hardcoded
+    ``logger.warning(formatted_msg)`` calls into structured records suitable
+    for Datadog filtering on ``sfdc_*`` fields.
+
+    The library calls ``warning()`` once per failed attempt before sleeping;
+    this adapter re-emits the entry through our module logger with
+    ``extra={...}`` so operators can build dashboards/alerts off
+    ``sfdc_operation``, ``sfdc_retry_attempt``, ``sfdc_retry_exhausted``, etc.
+    """
+
+    def __init__(self, operation: str) -> None:
+        self._operation = operation
+        self._attempt = 0
+
+    def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
+        self._attempt += 1
+        logger.warning(
+            "Salesforce Data Cloud: transient network error on '%s' (attempt %d); retrying",
+            self._operation,
+            self._attempt,
+            extra={
+                "sfdc_operation": self._operation,
+                "sfdc_retry_attempt": self._attempt,
+                "sfdc_retry_exhausted": False,
+                "sfdc_error": str(msg)[:500],
+            },
+        )
 
 
 def _retry_on_transient_network_errors(
-    func: Callable[..., T],
+    func: Callable[[], T],
     *,
     operation: str,
-    attempts: int = _RETRY_ATTEMPTS,
+    tries: int = _RETRY_TRIES,
     base_delay: float = _RETRY_BASE_DELAY_SECS,
     max_delay: float = _RETRY_MAX_DELAY_SECS,
+    backoff: float = _RETRY_BACKOFF,
 ) -> T:
-    """Run *func* and retry on transient HTTP/TCP errors with exponential backoff.
+    """Run *func* with retries on transient HTTP/TCP errors.
 
-    Salesforce Data Cloud's edge load balancer closes idle keep-alive connections,
-    so the next reuse from urllib3's connection pool occasionally raises
-    ``RemoteDisconnected`` / ``ProtocolError`` before any HTTP response arrives.
-    A short retry on a fresh pooled connection clears it. Permanent errors
+    Wraps ``retry.api.retry_call`` with a structured-logger adapter (per-attempt
+    warnings) plus an explicit "exhausted" log line at the end so operators can
+    alert on ``sfdc_retry_exhausted:true`` directly. Permanent errors
     (``SalesforceCDPError``, auth failures, query syntax) are not in the catch
     list and propagate immediately.
 
-    Raises ``ValueError`` if ``attempts < 1`` or any delay parameter is negative
-    so misconfiguration surfaces as a clear caller error rather than an obscure
-    runtime ``AssertionError``.
+    Raises ``ValueError`` if ``tries < 1`` or any delay parameter is negative so
+    misconfiguration surfaces as a clear caller error rather than an obscure
+    runtime failure.
     """
-    if attempts < 1:
-        raise ValueError(f"attempts must be >= 1, got {attempts}")
+    if tries < 1:
+        raise ValueError(f"tries must be >= 1, got {tries}")
     if base_delay < 0:
         raise ValueError(f"base_delay must be >= 0, got {base_delay}")
     if max_delay < 0:
         raise ValueError(f"max_delay must be >= 0, got {max_delay}")
-    last_exc: BaseException | None = None
-    for attempt in range(1, attempts + 1):
-        try:
-            return func()
-        except _TRANSIENT_NETWORK_ERRORS as exc:
-            last_exc = exc
-            if attempt >= attempts:
-                logger.warning(
-                    "Salesforce Data Cloud: transient network error on '%s' after "
-                    "%d attempts; giving up",
-                    operation,
-                    attempt,
-                    extra={
-                        "sfdc_operation": operation,
-                        "sfdc_retry_attempt": attempt,
-                        "sfdc_retry_exhausted": True,
-                        "sfdc_error_type": type(exc).__name__,
-                        "sfdc_error": str(exc)[:500],
-                    },
-                )
-                raise
-            delay = min(max_delay, base_delay * (2 ** (attempt - 1)))
-            logger.warning(
-                "Salesforce Data Cloud: transient network error on '%s' "
-                "(attempt %d/%d); retrying after %.1fs",
-                operation,
-                attempt,
-                attempts,
-                delay,
-                extra={
-                    "sfdc_operation": operation,
-                    "sfdc_retry_attempt": attempt,
-                    "sfdc_retry_exhausted": False,
-                    "sfdc_error_type": type(exc).__name__,
-                    "sfdc_error": str(exc)[:500],
-                    "sfdc_retry_delay_secs": delay,
-                },
-            )
-            time.sleep(delay)
-    # Defensive — the loop above either returns or re-raises.
-    assert last_exc is not None
-    raise last_exc
+    try:
+        return retry_call(
+            func,
+            exceptions=_TRANSIENT_NETWORK_ERRORS,
+            tries=tries,
+            delay=base_delay,
+            max_delay=max_delay,
+            backoff=backoff,
+            # The retry library duck-types the logger — anything with `.warning()`
+            # is accepted (line 50 of retry/api.py). Pyright's annotation is
+            # tighter (`Logger | None`).
+            logger=_StructuredRetryLogger(operation),  # type: ignore[arg-type]
+        )
+    except _TRANSIENT_NETWORK_ERRORS as exc:
+        logger.warning(
+            "Salesforce Data Cloud: transient network error on '%s' after retries; giving up",
+            operation,
+            extra={
+                "sfdc_operation": operation,
+                "sfdc_retry_exhausted": True,
+                "sfdc_error_type": type(exc).__name__,
+                "sfdc_error": str(exc)[:500],
+            },
+        )
+        raise
 
 
 class _CapturingSession(requests.Session):

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -12,7 +12,6 @@ from apollo.common.agent.constants import ATTRIBUTE_NAME_RESULT
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.integrations.db.salesforce_data_cloud_proxy_client import (
     _RetryingSalesforceDataCloudCursor,
-    _retry_on_transient_network_errors,
 )
 
 
@@ -975,83 +974,6 @@ class SalesforceDataCloudRetryTests(TestCase):
     ``ProtocolError(RemoteDisconnected(...))`` before any HTTP response. Retrying
     the call uses a fresh pooled connection and typically succeeds.
     """
-
-    def test_retry_helper_returns_immediately_on_success(self):
-        calls = []
-
-        def succeed():
-            calls.append(1)
-            return "ok"
-
-        result = _retry_on_transient_network_errors(succeed, operation="probe")
-        self.assertEqual(result, "ok")
-        self.assertEqual(len(calls), 1)
-
-    def test_retry_helper_recovers_from_protocol_error(self):
-        attempts = {"n": 0}
-
-        def flaky():
-            attempts["n"] += 1
-            if attempts["n"] < 2:
-                raise urllib3.exceptions.ProtocolError(
-                    "Connection aborted.",
-                    http.client.RemoteDisconnected(
-                        "Remote end closed connection without response"
-                    ),
-                )
-            return "ok"
-
-        with patch("retry.api.time.sleep") as sleep_mock:
-            result = _retry_on_transient_network_errors(
-                flaky, operation="probe", tries=3, base_delay=0.0
-            )
-        self.assertEqual(result, "ok")
-        self.assertEqual(attempts["n"], 2)
-        self.assertEqual(sleep_mock.call_count, 1)
-
-    def test_retry_helper_raises_after_exhausting_attempts(self):
-        with patch("retry.api.time.sleep"):
-            with self.assertRaises(urllib3.exceptions.ProtocolError):
-                _retry_on_transient_network_errors(
-                    lambda: (_ for _ in ()).throw(
-                        urllib3.exceptions.ProtocolError(
-                            "Connection aborted.",
-                            http.client.RemoteDisconnected("closed"),
-                        )
-                    ),
-                    operation="probe",
-                    tries=2,
-                    base_delay=0.0,
-                )
-
-    def test_retry_helper_rejects_invalid_inputs(self):
-        with self.assertRaisesRegex(ValueError, "tries must be >= 1"):
-            _retry_on_transient_network_errors(lambda: None, operation="probe", tries=0)
-        with self.assertRaisesRegex(ValueError, "tries must be >= 1"):
-            _retry_on_transient_network_errors(
-                lambda: None, operation="probe", tries=-1
-            )
-        with self.assertRaisesRegex(ValueError, "base_delay must be >= 0"):
-            _retry_on_transient_network_errors(
-                lambda: None, operation="probe", base_delay=-0.1
-            )
-        with self.assertRaisesRegex(ValueError, "max_delay must be >= 0"):
-            _retry_on_transient_network_errors(
-                lambda: None, operation="probe", max_delay=-1
-            )
-
-    def test_retry_helper_does_not_retry_permanent_errors(self):
-        attempts = {"n": 0}
-
-        def boom():
-            attempts["n"] += 1
-            raise ValueError("syntax error")
-
-        with self.assertRaises(ValueError):
-            _retry_on_transient_network_errors(
-                boom, operation="probe", tries=3, base_delay=0.0
-            )
-        self.assertEqual(attempts["n"], 1)
 
     def test_cursor_execute_retries_on_remote_disconnected(self):
         """A single ``RemoteDisconnected`` during ``cursor.execute`` is recovered

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1001,20 +1001,16 @@ class SalesforceDataCloudRetryTests(TestCase):
                 )
             return "ok"
 
-        with patch(
-            "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-        ) as sleep_mock:
+        with patch("retry.api.time.sleep") as sleep_mock:
             result = _retry_on_transient_network_errors(
-                flaky, operation="probe", attempts=3, base_delay=0.0
+                flaky, operation="probe", tries=3, base_delay=0.0
             )
         self.assertEqual(result, "ok")
         self.assertEqual(attempts["n"], 2)
         self.assertEqual(sleep_mock.call_count, 1)
 
     def test_retry_helper_raises_after_exhausting_attempts(self):
-        with patch(
-            "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-        ):
+        with patch("retry.api.time.sleep"):
             with self.assertRaises(urllib3.exceptions.ProtocolError):
                 _retry_on_transient_network_errors(
                     lambda: (_ for _ in ()).throw(
@@ -1024,18 +1020,16 @@ class SalesforceDataCloudRetryTests(TestCase):
                         )
                     ),
                     operation="probe",
-                    attempts=2,
+                    tries=2,
                     base_delay=0.0,
                 )
 
     def test_retry_helper_rejects_invalid_inputs(self):
-        with self.assertRaisesRegex(ValueError, "attempts must be >= 1"):
+        with self.assertRaisesRegex(ValueError, "tries must be >= 1"):
+            _retry_on_transient_network_errors(lambda: None, operation="probe", tries=0)
+        with self.assertRaisesRegex(ValueError, "tries must be >= 1"):
             _retry_on_transient_network_errors(
-                lambda: None, operation="probe", attempts=0
-            )
-        with self.assertRaisesRegex(ValueError, "attempts must be >= 1"):
-            _retry_on_transient_network_errors(
-                lambda: None, operation="probe", attempts=-1
+                lambda: None, operation="probe", tries=-1
             )
         with self.assertRaisesRegex(ValueError, "base_delay must be >= 0"):
             _retry_on_transient_network_errors(
@@ -1055,7 +1049,7 @@ class SalesforceDataCloudRetryTests(TestCase):
 
         with self.assertRaises(ValueError):
             _retry_on_transient_network_errors(
-                boom, operation="probe", attempts=3, base_delay=0.0
+                boom, operation="probe", tries=3, base_delay=0.0
             )
         self.assertEqual(attempts["n"], 1)
 
@@ -1092,9 +1086,7 @@ class SalesforceDataCloudRetryTests(TestCase):
                 "salesforcecdpconnector.cursor.QuerySubmitter.execute",
                 side_effect=flaky_execute,
             ),
-            patch(
-                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-            ),
+            patch("retry.api.time.sleep"),
         ):
             cursor.execute("select 1")
 
@@ -1117,9 +1109,7 @@ class SalesforceDataCloudRetryTests(TestCase):
                 "salesforcecdpconnector.cursor.QuerySubmitter.execute",
                 side_effect=always_fail,
             ),
-            patch(
-                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-            ),
+            patch("retry.api.time.sleep"),
         ):
             with self.assertRaises(urllib3.exceptions.ProtocolError):
                 cursor.execute("select 1")
@@ -1151,9 +1141,7 @@ class SalesforceDataCloudRetryTests(TestCase):
                 "salesforcecdpconnector.cursor.QuerySubmitter.get_next_batch",
                 side_effect=flaky_next_batch,
             ),
-            patch(
-                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-            ),
+            patch("retry.api.time.sleep"),
         ):
             result = cursor.fetchall()
 
@@ -1207,9 +1195,7 @@ class SalesforceDataCloudRetryTests(TestCase):
 
             client = SalesforceDataCloudProxyClient(credentials=credentials)
 
-            with patch(
-                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
-            ):
+            with patch("retry.api.time.sleep"):
                 result = client.list_tables()
 
         self.assertEqual(attempts["n"], 2)

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1,13 +1,19 @@
+import http.client
 import json
 import uuid
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
 import responses
+import urllib3.exceptions
 
 from apollo.agent.agent import Agent
 from apollo.common.agent.constants import ATTRIBUTE_NAME_RESULT
 from apollo.agent.logging_utils import LoggingUtils
+from apollo.integrations.db.salesforce_data_cloud_proxy_client import (
+    _RetryingSalesforceDataCloudCursor,
+    _retry_on_transient_network_errors,
+)
 
 
 class SalesforceDataCloudProxyClientTests(TestCase):
@@ -957,3 +963,181 @@ class SalesforceDataCloudProxyClientTests(TestCase):
                 query_params,
                 "list_tables(None) on a scoped client must not include dataspace in a360/token POST",
             )
+
+
+class SalesforceDataCloudRetryTests(TestCase):
+    """Cover the transient-network-error retry that wraps cursor and list_tables.
+
+    The motivating failure: hourly metric monitors fail intermittently with
+    ``AgentClientError. ('Connection aborted.', RemoteDisconnected('Remote end
+    closed connection without response'))``. A pooled keep-alive connection that
+    Salesforce's edge LB has silently closed gets reused → urllib3 raises
+    ``ProtocolError(RemoteDisconnected(...))`` before any HTTP response. Retrying
+    the call uses a fresh pooled connection and typically succeeds.
+    """
+
+    def test_retry_helper_returns_immediately_on_success(self):
+        calls = []
+
+        def succeed():
+            calls.append(1)
+            return "ok"
+
+        result = _retry_on_transient_network_errors(succeed, operation="probe")
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(calls), 1)
+
+    def test_retry_helper_recovers_from_protocol_error(self):
+        attempts = {"n": 0}
+
+        def flaky():
+            attempts["n"] += 1
+            if attempts["n"] < 2:
+                raise urllib3.exceptions.ProtocolError(
+                    "Connection aborted.",
+                    http.client.RemoteDisconnected(
+                        "Remote end closed connection without response"
+                    ),
+                )
+            return "ok"
+
+        with patch(
+            "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+        ) as sleep_mock:
+            result = _retry_on_transient_network_errors(
+                flaky, operation="probe", attempts=3, base_delay=0.0
+            )
+        self.assertEqual(result, "ok")
+        self.assertEqual(attempts["n"], 2)
+        self.assertEqual(sleep_mock.call_count, 1)
+
+    def test_retry_helper_raises_after_exhausting_attempts(self):
+        with patch(
+            "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+        ):
+            with self.assertRaises(urllib3.exceptions.ProtocolError):
+                _retry_on_transient_network_errors(
+                    lambda: (_ for _ in ()).throw(
+                        urllib3.exceptions.ProtocolError(
+                            "Connection aborted.",
+                            http.client.RemoteDisconnected("closed"),
+                        )
+                    ),
+                    operation="probe",
+                    attempts=2,
+                    base_delay=0.0,
+                )
+
+    def test_retry_helper_does_not_retry_permanent_errors(self):
+        attempts = {"n": 0}
+
+        def boom():
+            attempts["n"] += 1
+            raise ValueError("syntax error")
+
+        with self.assertRaises(ValueError):
+            _retry_on_transient_network_errors(
+                boom, operation="probe", attempts=3, base_delay=0.0
+            )
+        self.assertEqual(attempts["n"], 1)
+
+    def test_cursor_execute_retries_on_remote_disconnected(self):
+        """A single ``RemoteDisconnected`` during ``cursor.execute`` is recovered
+        without surfacing the error to the caller."""
+        # Build a cursor against a fake connection — we patch QuerySubmitter
+        # directly so the cursor's HTTP path is exercised in isolation.
+        connection = Mock()
+        connection.closed = False
+        cursor = _RetryingSalesforceDataCloudCursor(connection)
+
+        json_results = {
+            "data": [["a"]],
+            "metadata": {"col": {"type": "VARCHAR", "placeInOrder": 0, "typeCode": 12}},
+            "done": True,
+            "rowCount": 1,
+        }
+        attempts = {"n": 0}
+
+        def flaky_execute(_connection, _query):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise urllib3.exceptions.ProtocolError(
+                    "Connection aborted.",
+                    http.client.RemoteDisconnected(
+                        "Remote end closed connection without response"
+                    ),
+                )
+            return json_results
+
+        with (
+            patch(
+                "salesforcecdpconnector.cursor.QuerySubmitter.execute",
+                side_effect=flaky_execute,
+            ),
+            patch(
+                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+            ),
+        ):
+            cursor.execute("select 1")
+
+        self.assertEqual(attempts["n"], 2)
+        self.assertTrue(cursor.has_result)
+
+    def test_cursor_execute_propagates_after_retry_budget_exhausted(self):
+        connection = Mock()
+        connection.closed = False
+        cursor = _RetryingSalesforceDataCloudCursor(connection)
+
+        def always_fail(_connection, _query):
+            raise urllib3.exceptions.ProtocolError(
+                "Connection aborted.",
+                http.client.RemoteDisconnected("closed"),
+            )
+
+        with (
+            patch(
+                "salesforcecdpconnector.cursor.QuerySubmitter.execute",
+                side_effect=always_fail,
+            ),
+            patch(
+                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+            ),
+        ):
+            with self.assertRaises(urllib3.exceptions.ProtocolError):
+                cursor.execute("select 1")
+
+    def test_cursor_fetchall_retries_on_transient_error(self):
+        """``fetchall`` (which paginates via ``QuerySubmitter.get_next_batch``)
+        also retries on transient errors."""
+        connection = Mock()
+        connection.closed = False
+        cursor = _RetryingSalesforceDataCloudCursor(connection)
+        # Prime the cursor as if execute() succeeded with one batch and more to fetch.
+        cursor.has_result = True
+        cursor.has_next = True
+        cursor.next_batch_id = "batch-1"
+        cursor.data = [["row0"]]
+        cursor.description = []
+
+        next_batch = {"data": [["row1"]], "done": True, "metadata": {}}
+        attempts = {"n": 0}
+
+        def flaky_next_batch(_connection, _batch_id):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise ConnectionResetError("connection reset by peer")
+            return next_batch
+
+        with (
+            patch(
+                "salesforcecdpconnector.cursor.QuerySubmitter.get_next_batch",
+                side_effect=flaky_next_batch,
+            ),
+            patch(
+                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+            ),
+        ):
+            result = cursor.fetchall()
+
+        self.assertEqual(attempts["n"], 2)
+        self.assertEqual(result, [["row0"], ["row1"]])

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1028,6 +1028,24 @@ class SalesforceDataCloudRetryTests(TestCase):
                     base_delay=0.0,
                 )
 
+    def test_retry_helper_rejects_invalid_inputs(self):
+        with self.assertRaisesRegex(ValueError, "attempts must be >= 1"):
+            _retry_on_transient_network_errors(
+                lambda: None, operation="probe", attempts=0
+            )
+        with self.assertRaisesRegex(ValueError, "attempts must be >= 1"):
+            _retry_on_transient_network_errors(
+                lambda: None, operation="probe", attempts=-1
+            )
+        with self.assertRaisesRegex(ValueError, "base_delay must be >= 0"):
+            _retry_on_transient_network_errors(
+                lambda: None, operation="probe", base_delay=-0.1
+            )
+        with self.assertRaisesRegex(ValueError, "max_delay must be >= 0"):
+            _retry_on_transient_network_errors(
+                lambda: None, operation="probe", max_delay=-1
+            )
+
     def test_retry_helper_does_not_retry_permanent_errors(self):
         attempts = {"n": 0}
 
@@ -1141,3 +1159,59 @@ class SalesforceDataCloudRetryTests(TestCase):
 
         self.assertEqual(attempts["n"], 2)
         self.assertEqual(result, [["row0"], ["row1"]])
+
+    def test_list_tables_retries_on_transient_error(self):
+        """``SalesforceDataCloudProxyClient.list_tables`` (unscoped path) recovers
+        from a single transient ``RemoteDisconnected`` raised by the underlying
+        connection. Confirms the ``list_tables`` retry wrapper at the proxy
+        layer (the cursor retry doesn't cover this path)."""
+        from apollo.integrations.db.salesforce_data_cloud_proxy_client import (
+            SalesforceDataCloudProxyClient,
+            SalesforceDataCloudCredentials,
+        )
+
+        credentials = SalesforceDataCloudCredentials(
+            domain="test.salesforce.com",
+            client_id="cid",
+            client_secret="csec",
+            core_token="t",
+            refresh_token=None,
+        )
+        # Bypass the real connection construction; we only need the
+        # SalesforceDataCloudProxyClient instance to exercise its list_tables.
+        with patch(
+            "apollo.integrations.db.salesforce_data_cloud_proxy_client."
+            "SalesforceDataCloudConnection"
+        ) as conn_class:
+            attempts = {"n": 0}
+            fake_table = Mock()
+            fake_table.name = "Account"
+            fake_table.display_name = "Account"
+            fake_table.category = "OBJECT"
+            fake_table.fields = []
+
+            def flaky_list_tables():
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise urllib3.exceptions.ProtocolError(
+                        "Connection aborted.",
+                        http.client.RemoteDisconnected(
+                            "Remote end closed connection without response"
+                        ),
+                    )
+                return [fake_table]
+
+            conn_instance = Mock()
+            conn_instance.list_tables.side_effect = flaky_list_tables
+            conn_class.return_value = conn_instance
+
+            client = SalesforceDataCloudProxyClient(credentials=credentials)
+
+            with patch(
+                "apollo.integrations.db.salesforce_data_cloud_proxy_client.time.sleep"
+            ):
+                result = client.list_tables()
+
+        self.assertEqual(attempts["n"], 2)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "Account")


### PR DESCRIPTION
## Problem

Hourly metric monitors against Salesforce Data Cloud were failing intermittently with:

```
AgentClientError. ('Connection aborted.',
 RemoteDisconnected('Remote end closed connection without response'))
```

Salesforce's edge load balancer silently closes idle keep-alive connections. urllib3's pooled connection on the next reuse hits a half-closed socket and raises `ProtocolError(RemoteDisconnected(...))` before any HTTP response arrives. Hourly cadence + ~58 min idle between runs makes this especially frequent for metric monitors. Verified by the customer's Datadog stack trace ending at `cursor.execute(query, params)`.

## Change

Add a tight retry around the four HTTP-bound cursor methods (`execute`, `fetchall`, `fetchone`, `fetchmany`) and around `list_tables` on both the scoped and unscoped paths.

- New `_retry_on_transient_network_errors` helper. Catches `urllib3.exceptions.ProtocolError`, `http.client.RemoteDisconnected`, `ConnectionResetError`, `ConnectionAbortedError`, `requests.exceptions.ConnectionError`, `requests.exceptions.ChunkedEncodingError`. Permanent errors (`SalesforceCDPError`, query syntax, auth failures) are not in the catch list and propagate immediately. `ValueError` is raised on `attempts < 1` or negative delays so misconfiguration surfaces clearly.
- New `_RetryingSalesforceDataCloudCursor(SalesforceCDPCursor)` returned from `SalesforceDataCloudConnection.cursor()`. Inherits state (description/data) unchanged from the upstream class.
- Defaults: 3 attempts, 0.5s base delay, 4s max delay, exponential backoff.
- Each retry attempt logs a structured warning with `sfdc_operation`, `sfdc_retry_attempt`, `sfdc_error_type`, `sfdc_retry_delay_secs` so operators can see recovery happen in Datadog.

## Tests

10 tests in `tests/test_salesforce_data_cloud_client.py`:

- `_retry_on_transient_network_errors` returns immediately on success
- recovers from a single `ProtocolError`
- raises after exhausting attempts
- does not retry permanent errors (e.g. `ValueError`)
- rejects invalid inputs (`attempts < 1`, negative delays) with `ValueError`
- `cursor.execute` recovers from a single `RemoteDisconnected`
- `cursor.execute` propagates after retry budget exhausted
- `cursor.fetchall` retries on `ConnectionResetError` during `get_next_batch`
- `list_tables()` retries on a single transient error and succeeds
- (existing 17 SFDC client tests unchanged — 27 total)

27/27 tests pass. Black + pyright clean.

## Scope — who this PR fixes

**This is the PR that fixes Node10364**, the customer where the issue was first observed. They have a remote apollo-agent registered (`AgentModel` UUID `028951cb-c3b4-444f-afa1-eb9bd0db867e`, image `1.4.19` build `2553`, name `salesforce_bt_aws_cloud`, enabled, tied to data-collector `60558`). The DC lambda calls their agent over HTTPS; the agent is what calls Salesforce; the urllib3 `RemoteDisconnected` raises **inside the agent process**. The agent serializes the error to JSON, returns it to the DC lambda, which then raises `AgentClientError(error_message)` — that's the `agent_client.py:_make_request` line you see in the Datadog stack traces.

For Node10364 to actually receive the fix: this PR merges → a new agent image is published with the patched code → the customer rolls their agent to that build (manually, or automatically if they have agent auto-update enabled). Min agent build for SFDC support is 1779; their current 2553 already meets it.

Companion PR for any customer **without** a remote agent (true embedded mode — DC lambda calls Salesforce directly, no agent_details on the connection): [data-collector#2293](https://github.com/monte-carlo-data/data-collector/pull/2293). Both PRs should ship — they cover non-overlapping populations.

## Verification steps after roll-out

For Node10364 specifically (their DC service is `Node10364-Salesforce-Non-Prod-{Sync,Async}Lambda`, but the recovery log fires inside the **agent process**, not in the DC lambda — so search the agent's service tag, whatever it's configured as):

- Confirm retries are firing inside the agent and recovering:
  ```
  env:prod
  agent_id:028951cb-c3b4-444f-afa1-eb9bd0db867e
  "Salesforce Data Cloud: transient network error"
  @sfdc_retry_exhausted:false
  ```
- Confirm the surface error in the DC lambda drops to near-zero:
  ```
  env:prod
  service:(Node10364-Salesforce-Non-Prod-SyncLambda OR Node10364-Salesforce-Non-Prod-AsyncLambda)
  "Connection aborted" "RemoteDisconnected"
  ```
- The metric monitor's run-history page in monolith (`montecarloplatform-unk_genaicontentquality_std__dlm-metric` or any hourly SFDC monitor on this account) should flip from ~60% `Error` rows to ≈100% `Completed`.
- If `@sfdc_retry_exhausted:true` shows up at non-trivial volume, the issue is more than transient pool churn — investigate token TTL, SFDC-side throttling, or escalate to a `Connection: close` / always-fresh-connection approach.

For any other customer with a remote agent on SFDC: same approach, narrow by their `agent_id`.