### PR TITLE
Agent endpoint for returning custom connector types in the agent

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -387,25 +387,35 @@ class Agent:
                     "get_infra_details failed:"
                 )
 
-    def get_custom_connector_types(self, trace_id: Optional[str]) -> AgentResponse:
+    def get_supported_connector_types(
+        self, trace_id: Optional[str]
+    ) -> AgentResponse:
         """
-        Returns a lightweight list of supported custom connector types
-        (type ID and display name only — no full manifest).
+        Returns the connector types this agent supports, split into
+        native (built-in) and custom categories.
         """
-        with self._inject_log_context("get_custom_connector_types", trace_id):
+        with self._inject_log_context("get_supported_connector_types", trace_id):
             try:
-                logger.info("get_custom_connector_types requested")
+                logger.info("get_supported_connector_types requested")
+                from apollo.agent.proxy_client_factory import (
+                    get_native_connection_types,
+                )
                 from apollo.integrations.custom.custom_proxy_client import (
                     CustomProxyClient,
                 )
 
-                connector_types = CustomProxyClient.get_custom_connector_types()
                 return AgentUtils.agent_ok_response(
-                    {"connector_types": connector_types}, trace_id
+                    {
+                        "connector_types": {
+                            "native": get_native_connection_types(),
+                            "custom": CustomProxyClient.get_custom_connector_types(),
+                        }
+                    },
+                    trace_id,
                 )
             except Exception:  # noqa
                 return AgentUtils.agent_response_for_last_exception(
-                    "get_custom_connector_types failed:"
+                    "get_supported_connector_types failed:"
                 )
 
     def get_connection_manifests(self, trace_id: Optional[str]) -> AgentResponse:

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -387,9 +387,7 @@ class Agent:
                     "get_infra_details failed:"
                 )
 
-    def get_supported_connector_types(
-        self, trace_id: Optional[str]
-    ) -> AgentResponse:
+    def get_supported_connector_types(self, trace_id: Optional[str]) -> AgentResponse:
         """
         Returns the connector types this agent supports, split into
         native (built-in) and custom categories.

--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -387,6 +387,27 @@ class Agent:
                     "get_infra_details failed:"
                 )
 
+    def get_custom_connector_types(self, trace_id: Optional[str]) -> AgentResponse:
+        """
+        Returns a lightweight list of supported custom connector types
+        (type ID and display name only — no full manifest).
+        """
+        with self._inject_log_context("get_custom_connector_types", trace_id):
+            try:
+                logger.info("get_custom_connector_types requested")
+                from apollo.integrations.custom.custom_proxy_client import (
+                    CustomProxyClient,
+                )
+
+                connector_types = CustomProxyClient.get_custom_connector_types()
+                return AgentUtils.agent_ok_response(
+                    {"connector_types": connector_types}, trace_id
+                )
+            except Exception:  # noqa
+                return AgentUtils.agent_response_for_last_exception(
+                    "get_custom_connector_types failed:"
+                )
+
     def get_connection_manifests(self, trace_id: Optional[str]) -> AgentResponse:
         """
         Returns manifests, capabilities, and templates for all custom

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -422,6 +422,11 @@ _CLIENT_FACTORY_MAPPING = {
 }
 
 
+def get_native_connection_types() -> list[str]:
+    """Return a sorted list of all native (built-in) connection type identifiers."""
+    return sorted(_CLIENT_FACTORY_MAPPING.keys())
+
+
 class ProxyClientFactory:
     """
     Factory class used to create the proxy clients for a given connection type.

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from jinja2 import Template
 from jinja2.sandbox import ImmutableSandboxedEnvironment
@@ -144,6 +144,29 @@ class CustomProxyClient(BaseProxyClient):
     def get_capabilities(self) -> Dict:
         """Return the capabilities from the manifest."""
         return self._capabilities
+
+    @staticmethod
+    def get_custom_connector_types() -> List[Dict[str, str]]:
+        """
+        Return a lightweight list of supported custom connector types.
+
+        Each entry contains:
+          - type: the connection_type identifier from the manifest
+          - name: the human-readable connection_name (falls back to type)
+
+        Returns an empty list when no custom connectors are installed.
+        """
+        registry = get_custom_connector_registry()
+        result: List[Dict[str, str]] = []
+        for connection_type, connector_dir in registry.items():
+            manifest = load_manifest(connector_dir)
+            result.append(
+                {
+                    "type": connection_type,
+                    "name": manifest.get("connection_name", connection_type),
+                }
+            )
+        return result
 
     @staticmethod
     def get_connection_manifests() -> Dict[str, Dict[str, Any]]:

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -1220,12 +1220,12 @@ def _get_infra_details() -> Tuple[Dict, int]:
 
 
 @app.route("/api/v1/agent/custom-connectors/types", methods=["POST"])
-def get_custom_connector_types() -> Tuple[Dict, int]:
+def get_supported_connector_types() -> Tuple[Dict, int]:
     """
-    Get Supported Custom Connector Types
-    Returns a lightweight list of custom connector types installed on this
-    agent (type ID and display name only).  Used during agent registration
-    to validate supported connectors without a full manifest extraction.
+    Get Supported Connector Types
+    Returns all connector types this agent supports, split into native
+    (built-in) and custom categories.  Used during agent registration to
+    validate supported connectors without a full manifest extraction.
     ---
     tags:
         - Agent Operations
@@ -1235,7 +1235,7 @@ def get_custom_connector_types() -> Tuple[Dict, int]:
         - in: body
           name: body
           schema:
-            id: CustomConnectorTypesRequest
+            id: SupportedConnectorTypesRequest
             properties:
                 trace_id:
                   type: string
@@ -1243,28 +1243,38 @@ def get_custom_connector_types() -> Tuple[Dict, int]:
                   example: 324986b4-b185-4187-b4af-b0c2cd60f7a0
     responses:
         200:
-            description: Returns the list of supported custom connector types.
+            description: Returns native and custom connector types supported by this agent.
             schema:
                 properties:
                     __mcd_result__:
                         type: object
                         properties:
                             connector_types:
-                                type: array
-                                items:
-                                    type: object
-                                    properties:
-                                        type:
+                                type: object
+                                properties:
+                                    native:
+                                        type: array
+                                        items:
                                             type: string
-                                        name:
-                                            type: string
-                                example:
-                                    - type: acme-crm
-                                      name: Acme CRM
+                                        example:
+                                            - bigquery
+                                            - snowflake
+                                    custom:
+                                        type: array
+                                        items:
+                                            type: object
+                                            properties:
+                                                type:
+                                                    type: string
+                                                name:
+                                                    type: string
+                                        example:
+                                            - type: acme-crm
+                                              name: Acme CRM
     """
     request_dict: Dict = request.json or {}
     trace_id: Optional[str] = request_dict.get("trace_id")
-    response = agent.get_custom_connector_types(trace_id=trace_id)
+    response = agent.get_supported_connector_types(trace_id=trace_id)
     return response.result, response.status_code
 
 

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -1219,6 +1219,55 @@ def _get_infra_details() -> Tuple[Dict, int]:
     return response.result, response.status_code
 
 
+@app.route("/api/v1/agent/custom-connectors/types", methods=["POST"])
+def get_custom_connector_types() -> Tuple[Dict, int]:
+    """
+    Get Supported Custom Connector Types
+    Returns a lightweight list of custom connector types installed on this
+    agent (type ID and display name only).  Used during agent registration
+    to validate supported connectors without a full manifest extraction.
+    ---
+    tags:
+        - Agent Operations
+    produces:
+        - application/json
+    parameters:
+        - in: body
+          name: body
+          schema:
+            id: CustomConnectorTypesRequest
+            properties:
+                trace_id:
+                  type: string
+                  description: An optional trace_id
+                  example: 324986b4-b185-4187-b4af-b0c2cd60f7a0
+    responses:
+        200:
+            description: Returns the list of supported custom connector types.
+            schema:
+                properties:
+                    __mcd_result__:
+                        type: object
+                        properties:
+                            connector_types:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        type:
+                                            type: string
+                                        name:
+                                            type: string
+                                example:
+                                    - type: acme-crm
+                                      name: Acme CRM
+    """
+    request_dict: Dict = request.json or {}
+    trace_id: Optional[str] = request_dict.get("trace_id")
+    response = agent.get_custom_connector_types(trace_id=trace_id)
+    return response.result, response.status_code
+
+
 @app.route("/api/v1/agent/custom-connectors/manifests", methods=["POST"])
 def get_connection_manifests() -> Tuple[Dict, int]:
     """

--- a/apollo/interfaces/generic/main.py
+++ b/apollo/interfaces/generic/main.py
@@ -1219,7 +1219,7 @@ def _get_infra_details() -> Tuple[Dict, int]:
     return response.result, response.status_code
 
 
-@app.route("/api/v1/agent/custom-connectors/types", methods=["POST"])
+@app.route("/api/v1/agent/connectors/types", methods=["POST"])
 def get_supported_connector_types() -> Tuple[Dict, int]:
     """
     Get Supported Connector Types

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -688,18 +688,30 @@ class TestGetCustomConnectorTypes(TestCase):
             self.assertEqual(result[0]["name"], "no-name-connector")
 
 
-class TestAgentGetCustomConnectorTypes(TestCase):
+class TestAgentGetSupportedConnectorTypes(TestCase):
     @patch(
         "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
         return_value={},
     )
-    def test_returns_ok_response(self, _mock_registry):
+    def test_returns_native_and_custom(self, _mock_registry):
         agent = Agent(None)
-        response = agent.get_custom_connector_types(trace_id="test-trace")
+        response = agent.get_supported_connector_types(trace_id="test-trace")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("__mcd_result__", response.result)
-        self.assertEqual(response.result["__mcd_result__"], {"connector_types": []})
+        result = response.result["__mcd_result__"]
+        self.assertIn("connector_types", result)
+        self.assertIn("native", result["connector_types"])
+        self.assertIn("custom", result["connector_types"])
+        # native should contain known built-in types
+        native = result["connector_types"]["native"]
+        self.assertIn("bigquery", native)
+        self.assertIn("snowflake", native)
+        self.assertIn("postgres", native)
+        # native list should be sorted
+        self.assertEqual(native, sorted(native))
+        # custom is empty because registry is mocked empty
+        self.assertEqual(result["connector_types"]["custom"], [])
         self.assertEqual(response.trace_id, "test-trace")
 
     @patch(
@@ -708,7 +720,7 @@ class TestAgentGetCustomConnectorTypes(TestCase):
     )
     def test_returns_error_on_failure(self, _mock_registry):
         agent = Agent(None)
-        response = agent.get_custom_connector_types(trace_id="test-trace")
+        response = agent.get_supported_connector_types(trace_id="test-trace")
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("__mcd_error__", response.result)

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -631,3 +631,84 @@ class TestAgentGetConnectionManifests(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("__mcd_error__", response.result)
+
+
+class TestGetCustomConnectorTypes(TestCase):
+    def test_returns_all_types(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_connector_dir(tmp_dir, "Acme CRM", "acme-crm")
+            _create_mock_connector_dir(tmp_dir, "Internal API", "internal-api")
+
+            with patch(
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_custom_connector_types()
+
+            self.assertEqual(len(result), 2)
+            types_by_id = {entry["type"]: entry["name"] for entry in result}
+            self.assertEqual(types_by_id["acme-crm"], "Acme CRM")
+            self.assertEqual(types_by_id["internal-api"], "Internal API")
+
+    def test_returns_empty_list_when_no_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch(
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_custom_connector_types()
+
+            self.assertEqual(result, [])
+
+    def test_falls_back_to_type_when_no_connection_name(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Create a connector dir with a manifest that has no connection_name
+            connector_dir = os.path.join(tmp_dir, "noname")
+            os.makedirs(connector_dir)
+            with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
+                json.dump({"connection_type": "no-name-connector"}, f)
+
+            with patch(
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_custom_connector_types()
+
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["type"], "no-name-connector")
+            self.assertEqual(result[0]["name"], "no-name-connector")
+
+
+class TestAgentGetCustomConnectorTypes(TestCase):
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        return_value={},
+    )
+    def test_returns_ok_response(self, _mock_registry):
+        agent = Agent(None)
+        response = agent.get_custom_connector_types(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_result__", response.result)
+        self.assertEqual(response.result["__mcd_result__"], {"connector_types": []})
+        self.assertEqual(response.trace_id, "test-trace")
+
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        side_effect=RuntimeError("boom"),
+    )
+    def test_returns_error_on_failure(self, _mock_registry):
+        agent = Agent(None)
+        response = agent.get_custom_connector_types(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_error__", response.result)

--- a/tests/test_proxy_client_factory.py
+++ b/tests/test_proxy_client_factory.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call
 from apollo.agent.agent import Agent
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.common.agent.models import AgentCommands
-from apollo.agent.proxy_client_factory import ProxyClientFactory
+from apollo.agent.proxy_client_factory import ProxyClientFactory, get_native_connection_types
 from apollo.common.interfaces.agent_response import AgentResponse
 from apollo.interfaces.azure.azure_platform import AzurePlatformProvider
 from apollo.interfaces.lambda_function.platform import AwsPlatformProvider
@@ -75,3 +75,18 @@ class ProxyClientFactoryTests(TestCase):
                 call("test_type", None, agent.platform, ctp_config=None),
             ]
         )
+
+
+class TestGetNativeConnectionTypes(TestCase):
+    def test_returns_sorted_list(self):
+        result = get_native_connection_types()
+        self.assertEqual(result, sorted(result))
+
+    def test_contains_known_types(self):
+        result = get_native_connection_types()
+        for expected in ["bigquery", "snowflake", "postgres", "redshift", "mysql"]:
+            self.assertIn(expected, result)
+
+    def test_returns_strings(self):
+        result = get_native_connection_types()
+        self.assertTrue(all(isinstance(t, str) for t in result))

--- a/tests/test_proxy_client_factory.py
+++ b/tests/test_proxy_client_factory.py
@@ -4,7 +4,10 @@ from unittest.mock import patch, call
 from apollo.agent.agent import Agent
 from apollo.agent.logging_utils import LoggingUtils
 from apollo.common.agent.models import AgentCommands
-from apollo.agent.proxy_client_factory import ProxyClientFactory, get_native_connection_types
+from apollo.agent.proxy_client_factory import (
+    ProxyClientFactory,
+    get_native_connection_types,
+)
 from apollo.common.interfaces.agent_response import AgentResponse
 from apollo.interfaces.azure.azure_platform import AzurePlatformProvider
 from apollo.interfaces.lambda_function.platform import AwsPlatformProvider


### PR DESCRIPTION
Add lightweight `POST /api/v1/agent/custom-connectors/types` endpoint that returns supported custom
connector type IDs and display names without full manifest extraction. Used by the DC validator during
egress agent registration to show users what connectors were discovered.

#### Related issues and PRs

- [YET-1020](https://linear.app/montecarlodata/issue/YET-1020/connection-manifest-job-schedule)
- [monolith-django#13312](https://github.com/monte-carlo-data/monolith-django/pull/13312), [data-collector#2302](https://github.com/monte-carlo-data/data-collector/pull/2302)