### PR TITLE
add Informatica v2 CTP pipeline (OAuth + password auth modes)

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -419,6 +419,7 @@ _CLIENT_FACTORY_MAPPING = {
     "starburst-galaxy": _get_proxy_client_starburst_galaxy,
     "starburst-enterprise": _get_proxy_client_starburst_enterprise,
     "informatica": _get_proxy_client_informatica,
+    "informatica-v2": _get_proxy_client_informatica,
 }
 
 

--- a/apollo/integrations/ctp/defaults/informatica_v2.py
+++ b/apollo/integrations/ctp/defaults/informatica_v2.py
@@ -10,31 +10,35 @@ class InformaticaV2ClientArgs(TypedDict):
     api_base_url: Required[str]
 
 
-# Informatica v2 authenticates via OAuth → JWT → /loginOAuth, using the same
-# `OAuthConfiguration` shape monolith stores for Snowflake. v1 (username/password)
-# keeps using INFORMATICA_DEFAULT_CTP.
+# v2 supports two auth modes, discriminated by `raw.auth_mode`:
+#   - "oauth"    → OAuth grant against the customer's IDP → JWT → /loginOAuth
+#   - "password" → V2 or V3 password login (same as v1's INFORMATICA_DEFAULT_CTP)
+# `resolve_informatica_session` picks the right Informatica login path from
+# whichever fields are present. We only need a leading OAuth step in oauth mode.
 INFORMATICA_V2_DEFAULT_CTP = CtpConfig(
     name="informatica-v2-default",
     steps=[
-        # Step 1: OAuth grant against the customer's IDP. Whatever grant_type
-        # `raw.oauth` declares (client_credentials, password, etc.) is what the
-        # shared `oauth` transform performs. Skipped when the session is already
-        # pre-resolved.
+        # Step 1 (OAuth mode only): OAuth grant against the customer's IDP using
+        # the shared `oauth` transform. Whatever grant_type `raw.oauth` declares
+        # (client_credentials, password, etc.) is what the transform performs.
         TransformStep(
             type="oauth",
-            when="raw.session_id is not defined",
+            when="raw.session_id is not defined and raw.auth_mode == 'oauth'",
             input={"oauth": "{{ raw.oauth }}"},
             output={"token": "informatica_jwt"},
         ),
-        # Step 2: Exchange the JWT at /ma/api/v2/user/loginOAuth for an
-        # icSessionId + API base URL. Skipped when pre-resolved.
+        # Step 2: Resolve the Informatica session. In oauth mode, exchange the
+        # JWT from step 1 at /loginOAuth. In password mode, do a V2 or V3 login.
         TransformStep(
             type="resolve_informatica_session",
             when="raw.session_id is not defined",
             input={
-                "jwt_token": "{{ derived.informatica_jwt }}",
-                "org_id": "{{ raw.org_id }}",
+                "username": "{{ raw.username | default(none) }}",
+                "password": "{{ raw.password | default(none) }}",
+                "informatica_auth": "{{ raw.informatica_auth | default(none) }}",
                 "base_url": "{{ raw.base_url | default(none) }}",
+                "jwt_token": "{{ derived.informatica_jwt | default(none) }}",
+                "org_id": "{{ raw.org_id | default(none) }}",
             },
             output={
                 "session_id": "informatica_session_id",

--- a/apollo/integrations/ctp/defaults/informatica_v2.py
+++ b/apollo/integrations/ctp/defaults/informatica_v2.py
@@ -10,36 +10,24 @@ class InformaticaV2ClientArgs(TypedDict):
     api_base_url: Required[str]
 
 
-# Informatica v2 authenticates via OAuth client_credentials → JWT → /loginOAuth.
-# v1 (username/password) keeps using INFORMATICA_DEFAULT_CTP; this pipeline is
-# separate so the two auth flows don't share validation surface area.
+# Informatica v2 authenticates via OAuth → JWT → /loginOAuth, using the same
+# `OAuthConfiguration` shape monolith stores for Snowflake. v1 (username/password)
+# keeps using INFORMATICA_DEFAULT_CTP.
 INFORMATICA_V2_DEFAULT_CTP = CtpConfig(
     name="informatica-v2-default",
     steps=[
-        # Step 1: OAuth client_credentials grant against the customer's IDP token
-        # endpoint. The shared `oauth` transform expects an `oauth` config dict;
-        # build it inline from the flat raw credential fields. Skipped when the
-        # session is already pre-resolved (DC pre-shaped path or custom CTP
-        # config that resolved upstream).
+        # Step 1: OAuth grant against the customer's IDP. Whatever grant_type
+        # `raw.oauth` declares (client_credentials, password, etc.) is what the
+        # shared `oauth` transform performs. Skipped when the session is already
+        # pre-resolved.
         TransformStep(
             type="oauth",
             when="raw.session_id is not defined",
-            input={
-                "oauth": (
-                    "{{ {"
-                    "'client_id': raw.client_id, "
-                    "'client_secret': raw.client_secret, "
-                    "'access_token_endpoint': raw.token_url, "
-                    "'grant_type': 'client_credentials'"
-                    "} }}"
-                ),
-            },
+            input={"oauth": "{{ raw.oauth }}"},
             output={"token": "informatica_jwt"},
         ),
-        # Step 2: Exchange the JWT at Informatica's /ma/api/v2/user/loginOAuth
-        # endpoint for an icSessionId + API base URL. Reuses the v1 transform's
-        # JWT mode (requires SAML federation configured org-wide). Skipped when
-        # the session is already pre-resolved.
+        # Step 2: Exchange the JWT at /ma/api/v2/user/loginOAuth for an
+        # icSessionId + API base URL. Skipped when pre-resolved.
         TransformStep(
             type="resolve_informatica_session",
             when="raw.session_id is not defined",

--- a/apollo/integrations/ctp/defaults/informatica_v2.py
+++ b/apollo/integrations/ctp/defaults/informatica_v2.py
@@ -1,0 +1,72 @@
+from typing import Required, TypedDict
+
+from apollo.integrations.ctp.models import CtpConfig, MapperConfig, TransformStep
+
+
+class InformaticaV2ClientArgs(TypedDict):
+    # Pre-resolved Informatica session, identical to v1's shape — the proxy client
+    # is auth-method agnostic and only needs these two values.
+    session_id: Required[str]
+    api_base_url: Required[str]
+
+
+# Informatica v2 authenticates via OAuth client_credentials → JWT → /loginOAuth.
+# v1 (username/password) keeps using INFORMATICA_DEFAULT_CTP; this pipeline is
+# separate so the two auth flows don't share validation surface area.
+INFORMATICA_V2_DEFAULT_CTP = CtpConfig(
+    name="informatica-v2-default",
+    steps=[
+        # Step 1: OAuth client_credentials grant against the customer's IDP token
+        # endpoint. The shared `oauth` transform expects an `oauth` config dict;
+        # build it inline from the flat raw credential fields. Skipped when the
+        # session is already pre-resolved (DC pre-shaped path or custom CTP
+        # config that resolved upstream).
+        TransformStep(
+            type="oauth",
+            when="raw.session_id is not defined",
+            input={
+                "oauth": (
+                    "{{ {"
+                    "'client_id': raw.client_id, "
+                    "'client_secret': raw.client_secret, "
+                    "'access_token_endpoint': raw.token_url, "
+                    "'grant_type': 'client_credentials'"
+                    "} }}"
+                ),
+            },
+            output={"token": "informatica_jwt"},
+        ),
+        # Step 2: Exchange the JWT at Informatica's /ma/api/v2/user/loginOAuth
+        # endpoint for an icSessionId + API base URL. Reuses the v1 transform's
+        # JWT mode (requires SAML federation configured org-wide). Skipped when
+        # the session is already pre-resolved.
+        TransformStep(
+            type="resolve_informatica_session",
+            when="raw.session_id is not defined",
+            input={
+                "jwt_token": "{{ derived.informatica_jwt }}",
+                "org_id": "{{ raw.org_id }}",
+                "base_url": "{{ raw.base_url | default(none) }}",
+            },
+            output={
+                "session_id": "informatica_session_id",
+                "api_base_url": "informatica_api_base_url",
+            },
+        ),
+    ],
+    mapper=MapperConfig(
+        name="informatica_v2_client_args",
+        schema=InformaticaV2ClientArgs,
+        field_map={
+            # When the steps ran: read from derived. When pre-resolved: fall
+            # back to raw (the DC pre-shaped path).
+            "session_id": "{{ derived.informatica_session_id | default(raw.session_id) }}",
+            "api_base_url": "{{ derived.informatica_api_base_url | default(raw.api_base_url) }}",
+        },
+    ),
+)
+
+
+from apollo.integrations.ctp.registry import CtpRegistry  # noqa: E402
+
+CtpRegistry.register("informatica-v2", INFORMATICA_V2_DEFAULT_CTP)

--- a/apollo/integrations/ctp/defaults/informatica_v2.py
+++ b/apollo/integrations/ctp/defaults/informatica_v2.py
@@ -20,7 +20,8 @@ INFORMATICA_V2_DEFAULT_CTP = CtpConfig(
     steps=[
         # Step 1 (OAuth mode only): OAuth grant against the customer's IDP using
         # the shared `oauth` transform. Whatever grant_type `raw.oauth` declares
-        # (client_credentials, password, etc.) is what the transform performs.
+        # (client_credentials or password — the only types the shared transform
+        # supports) is what the transform performs.
         TransformStep(
             type="oauth",
             when="raw.session_id is not defined and raw.auth_mode == 'oauth'",

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -24,6 +24,7 @@ def _discover() -> None:
     import apollo.integrations.ctp.defaults.hive  # noqa: F401
     import apollo.integrations.ctp.defaults.http  # noqa: F401
     import apollo.integrations.ctp.defaults.informatica  # noqa: F401
+    import apollo.integrations.ctp.defaults.informatica_v2  # noqa: F401
     import apollo.integrations.ctp.defaults.motherduck  # noqa: F401
     import apollo.integrations.ctp.defaults.presto  # noqa: F401
     import apollo.integrations.ctp.defaults.snowflake  # noqa: F401

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -18,10 +18,18 @@ _INFORMATICA_LOGIN_OAUTH_RESPONSE = {
     "icSessionId": "session-v2-abc",
 }
 
-_FLAT_CREDENTIALS = {
+# Mirrors monolith's `OAuthConfiguration` GraphQL input — the same shape stored
+# for Snowflake OAuth credentials.
+_OAUTH_CONFIG_CLIENT_CREDENTIALS = {
     "client_id": "idp-client-id",
     "client_secret": "idp-client-secret",
-    "token_url": "https://idp.example.com/oauth2/token",
+    "access_token_endpoint": "https://idp.example.com/oauth2/token",
+    "grant_type": "client_credentials",
+    "scope": "informatica",
+}
+
+_FLAT_CREDENTIALS = {
+    "oauth": _OAUTH_CONFIG_CLIENT_CREDENTIALS,
     "org_id": "ORG-12345",
     "base_url": "https://dm-us.informaticacloud.com",
 }
@@ -59,14 +67,12 @@ class TestInformaticaV2CtpPipeline(TestCase):
         self.assertEqual("session-v2-abc", result["session_id"])
         self.assertEqual("https://na1.informaticacloud.com", result["api_base_url"])
         # Raw credentials must not appear in connect_args
-        self.assertNotIn("client_id", result)
-        self.assertNotIn("client_secret", result)
-        self.assertNotIn("token_url", result)
+        self.assertNotIn("oauth", result)
         self.assertNotIn("org_id", result)
 
     @patch("requests.post")
     def test_first_call_is_idp_token_endpoint(self, mock_post):
-        """Step 1 hits the IDP token URL with client_credentials grant."""
+        """Step 1 hits the IDP token URL with the grant_type and scope from raw.oauth."""
         mock_post.side_effect = [
             _mock_post(_IDP_TOKEN_RESPONSE),
             _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
@@ -78,6 +84,34 @@ class TestInformaticaV2CtpPipeline(TestCase):
         first_call_data = mock_post.call_args_list[0][1]["data"]
         self.assertEqual("https://idp.example.com/oauth2/token", first_call_url)
         self.assertEqual("client_credentials", first_call_data["grant_type"])
+        # `scope` from the raw.oauth blob is forwarded to the IDP request body.
+        self.assertEqual("informatica", first_call_data["scope"])
+
+    @patch("requests.post")
+    def test_password_grant_carries_username_and_password(self, mock_post):
+        """raw.oauth with grant_type=password forwards username/password to the IDP."""
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        creds = {
+            **_FLAT_CREDENTIALS,
+            "oauth": {
+                "client_id": "cid",
+                "client_secret": "csec",
+                "access_token_endpoint": "https://idp.example.com/oauth2/token",
+                "grant_type": "password",
+                "username": "svc-user",
+                "password": "svc-pass",
+            },
+        }
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, creds)
+
+        first_call_data = mock_post.call_args_list[0][1]["data"]
+        self.assertEqual("password", first_call_data["grant_type"])
+        self.assertEqual("svc-user", first_call_data["username"])
+        self.assertEqual("svc-pass", first_call_data["password"])
 
     @patch("requests.post")
     def test_second_call_is_informatica_login_oauth_with_jwt(self, mock_post):

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -28,11 +28,23 @@ _OAUTH_CONFIG_CLIENT_CREDENTIALS = {
     "scope": "informatica",
 }
 
-_FLAT_CREDENTIALS = {
+_OAUTH_MODE_CREDENTIALS = {
+    "auth_mode": "oauth",
     "oauth": _OAUTH_CONFIG_CLIENT_CREDENTIALS,
     "org_id": "ORG-12345",
     "base_url": "https://dm-us.informaticacloud.com",
 }
+
+_PASSWORD_MODE_CREDENTIALS = {
+    "auth_mode": "password",
+    "username": "svc-user",
+    "password": "svc-pass",
+    "informatica_auth": "v3",
+    "base_url": "https://dm-us.informaticacloud.com",
+}
+
+# Backwards-compat alias for tests written before the auth_mode discriminator.
+_FLAT_CREDENTIALS = _OAUTH_MODE_CREDENTIALS
 
 
 def _mock_post(body: dict) -> MagicMock:
@@ -143,6 +155,35 @@ class TestInformaticaV2CtpPipeline(TestCase):
         # Second call must still go to a default Informatica login URL
         second_call_url = mock_post.call_args_list[1][0][0]
         self.assertIn("informaticacloud.com/ma/api/v2/user/loginOAuth", second_call_url)
+
+
+class TestInformaticaV2CtpPasswordMode(TestCase):
+    """Verify password mode skips the OAuth step and goes straight to Informatica login."""
+
+    _V3_LOGIN_RESPONSE = {
+        "products": [
+            {
+                "name": "Integration Cloud",
+                "baseApiUrl": "https://eu1.informaticacloud.com",
+            },
+        ],
+        "userInfo": {"sessionId": "session-v3-xyz"},
+    }
+
+    @patch("requests.post")
+    def test_password_mode_skips_oauth_step_and_does_v3_login(self, mock_post):
+        mock_post.return_value = _mock_post(self._V3_LOGIN_RESPONSE)
+
+        result = CtpPipeline().execute(
+            INFORMATICA_V2_DEFAULT_CTP, _PASSWORD_MODE_CREDENTIALS
+        )
+
+        # Only one HTTP call — straight to Informatica's V3 login (no OAuth step).
+        self.assertEqual(1, mock_post.call_count)
+        login_url = mock_post.call_args_list[0][0][0]
+        self.assertIn("/saas/public/core/v3/login", login_url)
+        self.assertEqual("session-v3-xyz", result["session_id"])
+        self.assertEqual("https://eu1.informaticacloud.com", result["api_base_url"])
 
 
 class TestInformaticaV2CtpFailureSurfaces(TestCase):

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -1,0 +1,180 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from apollo.agent.proxy_client_factory import ProxyClientFactory
+from apollo.integrations.ctp.defaults.informatica_v2 import INFORMATICA_V2_DEFAULT_CTP
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.pipeline import CtpPipeline
+from apollo.integrations.ctp.registry import CtpRegistry
+
+# Canned IDP token-endpoint and Informatica /loginOAuth responses
+_IDP_TOKEN_RESPONSE = {
+    "access_token": "jwt-issued-by-customer-idp",
+    "expires_in": 3600,
+    "token_type": "Bearer",
+}
+_INFORMATICA_LOGIN_OAUTH_RESPONSE = {
+    "serverUrl": "https://na1.informaticacloud.com",
+    "icSessionId": "session-v2-abc",
+}
+
+_FLAT_CREDENTIALS = {
+    "client_id": "idp-client-id",
+    "client_secret": "idp-client-secret",
+    "token_url": "https://idp.example.com/oauth2/token",
+    "org_id": "ORG-12345",
+    "base_url": "https://dm-us.informaticacloud.com",
+}
+
+
+def _mock_post(body: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = body
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestInformaticaV2CtpRegistered(TestCase):
+    def test_registered(self):
+        """CtpRegistry.get('informatica-v2') must return a config — not None."""
+        self.assertIsNotNone(CtpRegistry.get("informatica-v2"))
+
+
+class TestInformaticaV2CtpPipeline(TestCase):
+    """Verify the v2 pipeline chains oauth → resolve_informatica_session correctly."""
+
+    @patch("requests.post")
+    def test_oauth_credentials_produce_session_and_base_url(self, mock_post):
+        """Flat OAuth credentials flow through both steps and produce connect_args."""
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        result = CtpPipeline().execute(
+            INFORMATICA_V2_DEFAULT_CTP,
+            _FLAT_CREDENTIALS,
+        )
+
+        self.assertEqual("session-v2-abc", result["session_id"])
+        self.assertEqual("https://na1.informaticacloud.com", result["api_base_url"])
+        # Raw credentials must not appear in connect_args
+        self.assertNotIn("client_id", result)
+        self.assertNotIn("client_secret", result)
+        self.assertNotIn("token_url", result)
+        self.assertNotIn("org_id", result)
+
+    @patch("requests.post")
+    def test_first_call_is_idp_token_endpoint(self, mock_post):
+        """Step 1 hits the IDP token URL with client_credentials grant."""
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+
+        first_call_url = mock_post.call_args_list[0][0][0]
+        first_call_data = mock_post.call_args_list[0][1]["data"]
+        self.assertEqual("https://idp.example.com/oauth2/token", first_call_url)
+        self.assertEqual("client_credentials", first_call_data["grant_type"])
+
+    @patch("requests.post")
+    def test_second_call_is_informatica_login_oauth_with_jwt(self, mock_post):
+        """Step 2 hits Informatica /loginOAuth with the JWT obtained in step 1."""
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+
+        second_call_url = mock_post.call_args_list[1][0][0]
+        # /ma/api/v2/user/loginOAuth path is exercised when jwt_token is provided
+        self.assertIn("/ma/api/v2/user/loginOAuth", second_call_url)
+
+    @patch("requests.post")
+    def test_default_base_url_when_omitted(self, mock_post):
+        """Omitting base_url falls back to the default Informatica POD URL."""
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        creds_without_base_url = {
+            k: v for k, v in _FLAT_CREDENTIALS.items() if k != "base_url"
+        }
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, creds_without_base_url)
+
+        # Second call must still go to a default Informatica login URL
+        second_call_url = mock_post.call_args_list[1][0][0]
+        self.assertIn("informaticacloud.com/ma/api/v2/user/loginOAuth", second_call_url)
+
+
+class TestInformaticaV2CtpFailureSurfaces(TestCase):
+    """Each external failure surface must raise CtpPipelineError without leaking creds."""
+
+    @patch("requests.post")
+    def test_idp_token_failure_raises(self, mock_post):
+        """A 4xx from the IDP token endpoint surfaces as CtpPipelineError."""
+        idp_failure = MagicMock()
+        idp_failure.raise_for_status.side_effect = __import__("requests").HTTPError(
+            response=MagicMock(status_code=401, text="invalid_client")
+        )
+        mock_post.return_value = idp_failure
+
+        with self.assertRaises(CtpPipelineError):
+            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+
+    @patch("requests.post")
+    def test_informatica_login_oauth_failure_raises(self, mock_post):
+        """A 4xx from /loginOAuth (after IDP succeeded) surfaces as CtpPipelineError."""
+        informatica_failure = MagicMock()
+        informatica_failure.raise_for_status.side_effect = __import__(
+            "requests"
+        ).HTTPError(response=MagicMock(status_code=403, text="JWT not trusted"))
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            informatica_failure,
+        ]
+
+        with self.assertRaises(CtpPipelineError):
+            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+
+
+class TestInformaticaV2CtpFactoryResolution(TestCase):
+    """Verify CTP runs before InformaticaProxyClient is instantiated for v2."""
+
+    @patch("requests.post")
+    def test_flat_credentials_resolved_to_connect_args_before_client_creation(
+        self, mock_post
+    ):
+        mock_post.side_effect = [
+            _mock_post(_IDP_TOKEN_RESPONSE),
+            _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
+        ]
+
+        captured = {}
+
+        def fake_factory(credentials, **kwargs):
+            captured["credentials"] = credentials
+            raise StopIteration  # bail before any further work
+
+        with patch(
+            "apollo.agent.proxy_client_factory._CLIENT_FACTORY_MAPPING",
+            {"informatica-v2": fake_factory},
+        ):
+            with self.assertRaises(StopIteration):
+                ProxyClientFactory._create_proxy_client(
+                    "informatica-v2", _FLAT_CREDENTIALS, "local"
+                )
+
+        self.assertIn("connect_args", captured["credentials"])
+        connect_args = captured["credentials"]["connect_args"]
+        self.assertEqual("session-v2-abc", connect_args["session_id"])
+        self.assertEqual(
+            "https://na1.informaticacloud.com", connect_args["api_base_url"]
+        )
+        # Raw credentials must not reach the proxy client
+        self.assertNotIn("client_id", connect_args)
+        self.assertNotIn("client_secret", connect_args)

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -43,9 +43,6 @@ _PASSWORD_MODE_CREDENTIALS = {
     "base_url": "https://dm-us.informaticacloud.com",
 }
 
-# Backwards-compat alias for tests written before the auth_mode discriminator.
-_FLAT_CREDENTIALS = _OAUTH_MODE_CREDENTIALS
-
 
 def _mock_post(body: dict) -> MagicMock:
     resp = MagicMock()
@@ -73,7 +70,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
 
         result = CtpPipeline().execute(
             INFORMATICA_V2_DEFAULT_CTP,
-            _FLAT_CREDENTIALS,
+            _OAUTH_MODE_CREDENTIALS,
         )
 
         self.assertEqual("session-v2-abc", result["session_id"])
@@ -90,7 +87,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
             _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
         ]
 
-        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
         first_call_url = mock_post.call_args_list[0][0][0]
         first_call_data = mock_post.call_args_list[0][1]["data"]
@@ -108,7 +105,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
         ]
 
         creds = {
-            **_FLAT_CREDENTIALS,
+            **_OAUTH_MODE_CREDENTIALS,
             "oauth": {
                 "client_id": "cid",
                 "client_secret": "csec",
@@ -133,7 +130,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
             _mock_post(_INFORMATICA_LOGIN_OAUTH_RESPONSE),
         ]
 
-        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+        CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
         second_call_url = mock_post.call_args_list[1][0][0]
         # /ma/api/v2/user/loginOAuth path is exercised when jwt_token is provided
@@ -148,7 +145,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
         ]
 
         creds_without_base_url = {
-            k: v for k, v in _FLAT_CREDENTIALS.items() if k != "base_url"
+            k: v for k, v in _OAUTH_MODE_CREDENTIALS.items() if k != "base_url"
         }
         CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, creds_without_base_url)
 
@@ -199,7 +196,7 @@ class TestInformaticaV2CtpFailureSurfaces(TestCase):
         mock_post.return_value = idp_failure
 
         with self.assertRaises(CtpPipelineError):
-            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
     @patch("requests.post")
     def test_informatica_login_oauth_failure_raises(self, mock_post):
@@ -214,7 +211,7 @@ class TestInformaticaV2CtpFailureSurfaces(TestCase):
         ]
 
         with self.assertRaises(CtpPipelineError):
-            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _FLAT_CREDENTIALS)
+            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
 
 class TestInformaticaV2CtpFactoryResolution(TestCase):
@@ -241,7 +238,7 @@ class TestInformaticaV2CtpFactoryResolution(TestCase):
         ):
             with self.assertRaises(StopIteration):
                 ProxyClientFactory._create_proxy_client(
-                    "informatica-v2", _FLAT_CREDENTIALS, "local"
+                    "informatica-v2", _OAUTH_MODE_CREDENTIALS, "local"
                 )
 
         self.assertIn("connect_args", captured["credentials"])

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -258,3 +258,25 @@ class TestInformaticaV2CtpFactoryResolution(TestCase):
         # Raw credentials must not reach the proxy client
         self.assertNotIn("client_id", connect_args)
         self.assertNotIn("client_secret", connect_args)
+
+
+class TestInformaticaV2CtpPreResolvedPath(TestCase):
+    """Verify the `when=raw.session_id is not defined` guards skip both steps when
+    the DC has already pre-resolved the session upstream. Mirrors v1's
+    TestInformaticaCtpPreResolvedPath so a future change to either guard surfaces
+    here in tests rather than at runtime.
+    """
+
+    @patch("requests.post")
+    def test_pre_resolved_session_skips_both_steps(self, mock_post):
+        result = CtpPipeline().execute(
+            INFORMATICA_V2_DEFAULT_CTP,
+            {
+                "session_id": "pre-existing-session",
+                "api_base_url": "https://na1.informaticacloud.com",
+            },
+        )
+
+        mock_post.assert_not_called()
+        self.assertEqual("pre-existing-session", result["session_id"])
+        self.assertEqual("https://na1.informaticacloud.com", result["api_base_url"])

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -6,6 +6,9 @@ from apollo.integrations.ctp.defaults.informatica_v2 import INFORMATICA_V2_DEFAU
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.pipeline import CtpPipeline
 from apollo.integrations.ctp.registry import CtpRegistry
+from apollo.integrations.ctp.transforms.resolve_informatica_session import (
+    _DEFAULT_BASE_URL as _INFORMATICA_DEFAULT_BASE_URL,
+)
 
 # Canned IDP token-endpoint and Informatica /loginOAuth responses
 _IDP_TOKEN_RESPONSE = {
@@ -149,9 +152,14 @@ class TestInformaticaV2CtpPipeline(TestCase):
         }
         CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, creds_without_base_url)
 
-        # Second call must still go to a default Informatica login URL
+        # Second call goes to the exact default URL — pin it so silent drift in
+        # `_DEFAULT_BASE_URL` (e.g., dm-us → dm-eu, or to a staging URL) breaks
+        # this test instead of slipping by a substring match.
         second_call_url = mock_post.call_args_list[1][0][0]
-        self.assertIn("informaticacloud.com/ma/api/v2/user/loginOAuth", second_call_url)
+        self.assertEqual(
+            f"{_INFORMATICA_DEFAULT_BASE_URL}/ma/api/v2/user/loginOAuth",
+            second_call_url,
+        )
 
 
 class TestInformaticaV2CtpPasswordMode(TestCase):

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -260,6 +260,33 @@ class TestInformaticaV2CtpFactoryResolution(TestCase):
         self.assertNotIn("client_secret", connect_args)
 
 
+class TestInformaticaV2CtpAuthModeDiscriminator(TestCase):
+    """Pin behavior of the `auth_mode` discriminator at the boundary cases.
+
+    The OAuth step's `when` evaluates `raw.auth_mode == 'oauth'` strictly, so any
+    value other than the exact literal `"oauth"` (case mismatch, missing, None,
+    arbitrary string) falls through to the password path. That's the intended
+    behavior — but it's worth pinning so a future refactor doesn't accidentally
+    make the discriminator case-insensitive (or coerce missing values).
+    """
+
+    @patch("requests.post")
+    def test_case_mismatch_auth_mode_falls_through_to_password_path(self, mock_post):
+        """`auth_mode: "OAuth"` (uppercase) falls through to password mode and
+        therefore fails when required password fields are missing — surfacing
+        clearly rather than silently routing through the OAuth step."""
+        creds = {
+            **_OAUTH_MODE_CREDENTIALS,
+            "auth_mode": "OAuth",  # case-mismatch — strict equality fails
+        }
+
+        with self.assertRaises(CtpPipelineError):
+            CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, creds)
+
+        # Step 1 (OAuth) was skipped — no IDP token call made
+        mock_post.assert_not_called()
+
+
 class TestInformaticaV2CtpPreResolvedPath(TestCase):
     """Verify the `when=raw.session_id is not defined` guards skip both steps when
     the DC has already pre-resolved the session upstream. Mirrors v1's

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -257,3 +257,40 @@ class InformaticaProxyClientSafetyTests(TestCase):
                 output,
                 f"session token leaked in log record: {output}",
             )
+
+
+# ---------------------------------------------------------------------------
+# v2 connection type — proxy client reuse
+# ---------------------------------------------------------------------------
+
+
+class InformaticaV2ProxyClientReuseTests(TestCase):
+    """Lock in that 'informatica-v2' resolves to the same proxy client as 'informatica'.
+
+    v2 differs from v1 in how its session is *obtained* (OAuth client_credentials
+    → JWT → /loginOAuth, vs v1's username/password). Once the session is resolved
+    by the CTP pipeline, the proxy client behavior is identical — so v2 routes
+    through the same _get_proxy_client_informatica factory function. This test
+    guards against accidental divergence (e.g., someone adding a separate v2
+    proxy client without need).
+    """
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    @patch("requests.request")
+    def test_v2_connection_type_uses_same_proxy_client(self, mock_request):
+        """v2 connection type drives the same do_http_request path as v1."""
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        self._agent.execute_operation(
+            "informatica-v2",
+            "http_request",
+            _make_operation("/api/v2/mttask"),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
+        )
+
+        api_url = mock_request.call_args[0][1]
+        self.assertTrue(api_url.startswith(_API_BASE_URL))
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["icSessionId"], _SESSION_ID)


### PR DESCRIPTION
## Changes

Adds the agent-side credential transform pipeline for the upcoming `informatica-v2` connection type. v2 supports **two auth modes**, discriminated by an `auth_mode` field in the credentials:

- **`auth_mode="oauth"`** — OAuth grant against the customer's IDP → JWT → Informatica `/loginOAuth`. Any grant type the shared `oauth` transform handles works (we've exercised both `client_credentials` and `password` grants against Okta in dev). Requires SAML federation configured org-wide on the customer's Informatica org.
- **`auth_mode="password"`** — direct V2 or V3 password login at Informatica (same shape v1 uses). For customers without an IDP.

The existing `InformaticaProxyClient` and `resolve_informatica_session` transform are reused as-is — both are auth-method agnostic; they only need a `session_id` + `api_base_url` at the end of the pipeline.

What this PR adds:

- **`apollo/integrations/ctp/defaults/informatica_v2.py`** — new `INFORMATICA_V2_DEFAULT_CTP` pipeline. Two transform steps, both gated on `raw.session_id is not defined` so the DC pre-shaped path bypasses them:
  1. **`oauth`** transform — runs only when `auth_mode == 'oauth'`. Performs the configured OAuth grant against the customer's IDP token endpoint and outputs a JWT. The OAuth config blob is passed through from `raw.oauth`, matching the shape monolith already stores for Snowflake.
  2. **`resolve_informatica_session`** — picks the right Informatica login path from whichever fields are present. In OAuth mode, exchanges the JWT from step 1 at `/ma/api/v2/user/loginOAuth`. In password mode, does a V2 or V3 login with `username`/`password`.
- **`apollo/integrations/ctp/registry.py`** — register the new defaults module in `_discover()`.
- **`apollo/agent/proxy_client_factory.py`** — map `"informatica-v2"` to the existing `_get_proxy_client_informatica` factory function. Same proxy client class for both v1 and v2; the only difference is which CTP pipeline resolved the session.

v1's `INFORMATICA_DEFAULT_CTP` is intentionally left untouched.

## Testing

Local unit tests:

- `tests/ctp/test_informatica_v2_ctp.py` covers pipeline registration, end-to-end OAuth happy path, password-mode happy path, IDP error surfacing as `CtpPipelineError`, Informatica `/loginOAuth` error surfacing, default base-url fallback, and absence of raw credentials in the resolved output.
- `tests/test_informatica_proxy_client.py::InformaticaV2ProxyClientReuseTests` confirms `"informatica-v2"` drives the same `do_http_request` path as v1.
- v1 informatica suites unchanged: `tests/ctp/test_informatica_ctp.py`, `tests/ctp/test_resolve_informatica_session.py`, and the rest of `tests/test_informatica_proxy_client.py` all pass without modification.

```
$ pytest tests/ctp/test_informatica_v2_ctp.py tests/ctp/test_informatica_ctp.py \
         tests/ctp/test_resolve_informatica_session.py tests/test_informatica_proxy_client.py
======================== 52 passed in 1.68s ========================
```

`black` and `pyright` are clean on changed files.

End-to-end verification in dev:

- **OAuth mode (password grant against Okta IDP)** — verified successful authentication and full extractor walk against the Informatica sandbox via the **data-collector** direct path, the **apollo-agent** path, and the **hermes-agent** path (file-mounted self-hosted credentials).
- **Password mode (direct V3 login at Informatica)** — verified successful authentication and full extractor walk against the same sandbox via the **data-collector** direct path, the **apollo-agent** path, and the **hermes-agent** path.

In each case the validator's `validate_informatica_v2_api_calls` check returned `success: true` with the expected per-call `additionalData.queriesWithResults` entries.

## Context

Part of the broader Informatica v2 (mapping-task-first) integration. v1's discovery model (taskflow-first) misses mapping tasks customers run outside any taskflow; v2 pivots to mapping-task-first discovery via the V2 `/mttask` listing endpoint.

Authentication is the other big change. v1 is username/password only. v2 supports both OAuth (for customers with an IDP and SAML-federated Informatica orgs) and password (for customers without an IDP). The CTP pipeline branches on `auth_mode` rather than committing to a single auth flow — keeps v2 usable for customers across the spectrum without forcing a separate v3 down the road.

Coordinated with monolith-django#13339 (Phase 2: monolith connection enablement) and the upcoming data-collector PR (Phase 3: collection-side validator + extractor + OAuth/password auth classes). Once this PR merges, an apollo-agent release should be tagged so the data-collector can pin its `INFORMATICA_V2_AGENT_MIN_VERSION` to a known-good version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)