### PR TITLE
ci: split system-base from venv-included base, publish system-base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,15 +94,18 @@ jobs:
       - checkout
       - docker/check:
           use-docker-credentials-store: true
-      # Publish the `base` stage as `<version>-generic-base` so downstream
-      # repos (e.g. hermes-agent) can pin to a specific apollo version that
-      # matches their pip-installed apollo dependency.
+      # Publish the `system-base` stage (apt-only, no venv, no apollo source) as
+      # `<version>-system-base`. Downstream consumers (e.g. hermes-agent) build
+      # their own venv on top against the same native libs without inheriting
+      # apollo's pip-installed Python deps. Replaces the previous `generic-base`
+      # tag, which bundled the venv and caused image bloat for downstream repos
+      # whose pinned versions diverged from apollo's resolved set.
       - docker/build:
-          step-name: Build generic base image
+          step-name: Build system base image
           use-buildkit: true # to build only the required stages
-          extra_build_args: --target base --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
+          extra_build_args: --target system-base --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
           image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-generic-base,<< parameters.code_version >>-generic-base
+          tag: latest-system-base,<< parameters.code_version >>-system-base
       - docker/build:
           step-name: Build AWS generic image
           use-buildkit: true  # to build only the required stages
@@ -121,9 +124,8 @@ jobs:
           extra_build_args: --target azure --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-azure,<< parameters.code_version >>-azure
-      - verify-version-in-docker-image:
-          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-generic-base
-          version: << parameters.code_version >>,<< pipeline.number >>
+      # system-base has no apollo source, so there is no /app/apollo/agent/version
+      # file to verify — skip the version check for it.
       - verify-version-in-docker-image:
           image: montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun
           version: << parameters.code_version >>,<< pipeline.number >>
@@ -135,7 +137,7 @@ jobs:
           version: << parameters.code_version >>,<< pipeline.number >>
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-generic-base,<< parameters.code_version >>-generic-base,latest-cloudrun,<< parameters.code_version >>-cloudrun,latest-azure,<< parameters.code_version >>-azure,latest-aws-generic,<< parameters.code_version >>-aws-generic,latest-aws-proxied,<< parameters.code_version >>-aws-proxied
+          tag: latest-system-base,<< parameters.code_version >>-system-base,latest-cloudrun,<< parameters.code_version >>-cloudrun,latest-azure,<< parameters.code_version >>-azure,latest-aws-generic,<< parameters.code_version >>-aws-generic,latest-aws-proxied,<< parameters.code_version >>-aws-proxied
 
   build-and-push-lambda:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,8 +124,6 @@ jobs:
           extra_build_args: --target azure --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-azure,<< parameters.code_version >>-azure
-      # system-base has no apollo source, so there is no /app/apollo/agent/version
-      # file to verify — skip the version check for it.
       - verify-version-in-docker-image:
           image: montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun
           version: << parameters.code_version >>,<< pipeline.number >>

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@
 FROM python:3.12-slim AS system-base
 
 ENV APP_HOME=/app
-ENV VENV_DIR=.venv
 WORKDIR $APP_HOME
 
 RUN apt-get update
@@ -43,6 +42,8 @@ ENV GUNICORN_TIMEOUT=0
 
 # Allow statements and log messages to immediately appear in the logs
 ENV PYTHONUNBUFFERED=True
+
+ENV VENV_DIR=.venv
 
 COPY requirements.txt ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,12 @@
-FROM python:3.12-slim AS base
-
-# Web server env var configuration
-ENV GUNICORN_WORKERS=5
-ENV GUNICORN_THREADS=8
-ENV GUNICORN_TIMEOUT=0
-
-# Allow statements and log messages to immediately appear in the logs
-ENV PYTHONUNBUFFERED=True
+# system-base — system-level dependencies only (apt packages, no venv).
+# Published as `<version>-system-base` so downstream consumers (e.g. hermes-agent)
+# can build their own venv against the same native libs without inheriting
+# apollo's pip-installed dependencies.
+FROM python:3.12-slim AS system-base
 
 ENV APP_HOME=/app
 ENV VENV_DIR=.venv
 WORKDIR $APP_HOME
-COPY requirements.txt ./
 
 RUN apt-get update
 # install git as we need it for the direct oscrypto dependency
@@ -23,15 +18,9 @@ RUN apt-get install -y --no-install-recommends libcrypt1
 # openssh-client required by git client
 RUN apt-get install -y openssh-client
 
-RUN python -m venv $VENV_DIR
-RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
-# VULN-423
-RUN . $VENV_DIR/bin/activate && pip install -U pip setuptools
-
 # Azure database clients uses pyodbc which requires unixODBC and 'ODBC Driver 17 for SQL Server'
 # ODBC Driver 17's latest release was April, 2024. To patch vulnerabilities raised since then,
 # we have to apt-get those specific versions:
-RUN apt-get update
 RUN apt-get install -y --no-install-recommends gnupg gnupg2 gnupg1 curl apt-transport-https
 RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
@@ -42,6 +31,25 @@ RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc unixodbc-dev
 
 # clean up all unused libraries
 RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# base — apollo runtime: venv + apollo's Python deps + apollo source.
+# All apollo target stages (aws_proxied, cloudrun, generic, tests) extend this.
+FROM system-base AS base
+
+# Web server env var configuration
+ENV GUNICORN_WORKERS=5
+ENV GUNICORN_THREADS=8
+ENV GUNICORN_TIMEOUT=0
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED=True
+
+COPY requirements.txt ./
+
+RUN python -m venv $VENV_DIR
+RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements.txt
+# VULN-423
+RUN . $VENV_DIR/bin/activate && pip install -U pip setuptools
 
 # copy sources in the last step so we don't install python libraries due to a change in source code
 COPY apollo/ ./apollo


### PR DESCRIPTION
## Summary
- Split the Dockerfile's monolithic `base` stage into a new `system-base` (apt-only) plus the existing `base` (venv + pip install + apollo source) that now extends it.
- Replace the `generic-base` publish target with `system-base` (`latest-system-base` + `<version>-system-base`).
- Apollo's own targets (`cloudrun`, `azure`, `aws_proxied`, `aws_generic`, `tests`, `lambda`) are functionally unchanged — they still `FROM base` and produce identical images.

## Why
The previous `generic-base` image bundled apollo's full venv on top of the apt layer. Downstream consumers (hermes-agent specifically) inherited that venv, then ran their own `pip install` with their own pinned versions. Where pins diverged (~50 transitive deps in hermes' case), pip reinstalled — adding ~340 MB of duplicate package files on top of an already-installed copy in the lower layer. Net: hermes images were ~1 GB compressed when they should have been ~600 MB.

The fix is structural: stop trying to share the venv. `system-base` shares only the apt/native lib layer (where sharing actually works because there's no version drift), and downstream consumers build a clean venv on top with exactly the deps they want.

## Backwards compatibility
- `latest-generic-base` and `<version>-generic-base` (introduced in #281, present in the v1.5.3 release) stop being published from this PR forward. The existing v1.5.3 tags remain on Docker Hub for any consumer pinned to them.
- Hermes-agent currently consumes `1.5.3-generic-base`. A follow-up hermes PR will switch to `<next-version>-system-base` once this lands and a release is cut.
- No other known consumers of `generic-base`.

## Test plan
- [x] `docker build --target system-base` builds cleanly; `/app/` is empty (no apollo source, no venv); image size ~300 MB uncompressed
- [x] `docker build --target base` builds cleanly with identical end-state to today (apt + venv + apollo source)
- [x] `docker build --progress=plain --target base` shows 5 wheel-build entries (\`agent-base\`, \`oscrypto\`, \`pure-sasl\`, \`thrift\`, \`google-crc32c\`) — all pure-Python; no \`gcc\`/\`cc1\`/header-error lines, confirming no C compilation needs apt-installed headers and the new ordering (all apt before venv/pip) is safe
- [ ] CircleCI: build pipeline succeeds end-to-end including version-verify on the four apollo targets and the docker push of all tags including the new \`*-system-base\` ones
- [ ] After merge + release: confirm \`montecarlodata/agent:latest-system-base\` and \`montecarlodata/agent:<version>-system-base\` exist on Docker Hub
- [ ] Hermes follow-up PR consumes the new tag and reports a smaller image

## Follow-up
Hermes-agent PR #37 will be updated to:
- Swap \`FROM montecarlodata/agent:1.5.3-generic-base\` → \`FROM montecarlodata/agent:<next-version>-system-base\`
- Add \`python -m venv\` (no longer inherited)
- Drop the \`rm -rf ./apollo\` workaround (no apollo source in system-base)