### PR TITLE
feat(http): stream large downloads directly to storage (download_to_storage)

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -57,7 +57,7 @@ def _get_proxy_client_databricks_rest(
 
 
 def _get_proxy_client_http(
-    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+    credentials: Optional[Dict], platform: Optional[str] = None, **kwargs  # type: ignore
 ) -> BaseProxyClient:
     from apollo.integrations.http.http_proxy_client import HttpProxyClient
 

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -56,10 +56,12 @@ def _get_proxy_client_databricks_rest(
     return DatabricksRestProxyClient(credentials=credentials)
 
 
-def _get_proxy_client_http(credentials: Optional[Dict], **kwargs) -> BaseProxyClient:  # type: ignore
+def _get_proxy_client_http(
+    credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
     from apollo.integrations.http.http_proxy_client import HttpProxyClient
 
-    return HttpProxyClient(credentials=credentials)
+    return HttpProxyClient(credentials=credentials, platform=platform)
 
 
 def _get_proxy_client_s3(

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -12,6 +12,7 @@ from retry.api import retry_call
 from apollo.common.agent.models import AgentOperation
 from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.storage.factory import get_storage_client
 
 _logger = logging.getLogger(__name__)
 
@@ -212,6 +213,60 @@ class HttpProxyClient(BaseProxyClient):
 
         return response.json()
 
+    def _open_download_response(
+        self,
+        url: str,
+        timeout: int,
+        no_auth: bool,
+        additional_headers: Optional[Dict],
+        op_label: str,
+    ) -> requests.Response:
+        """Open a streaming GET response with the full SSRF + redirect + status guards.
+
+        Caller MUST use the returned response via `with response:` to ensure the
+        connection is released on every exit path. ``op_label`` is included in
+        error messages so the user-facing message names the calling method.
+        """
+        self._assert_safe_download_url(url)
+
+        headers = {**additional_headers} if additional_headers else {}
+        if not no_auth:
+            self._attach_auth_header(headers)
+
+        request_kwargs: Dict = {
+            "timeout": timeout,
+            "headers": headers,
+            "stream": True,
+            "allow_redirects": False,
+        }
+        if self._ssl_verify is not None:
+            request_kwargs["verify"] = self._ssl_verify
+
+        try:
+            response = requests.get(url, **request_kwargs)
+        except requests.RequestException as exc:
+            raise HttpClientError(
+                f"{op_label} transport error: {type(exc).__name__}"
+            ) from None
+
+        status = response.status_code
+        if 300 <= status < 400:
+            response.close()  # we're returning before the caller's `with` block
+            raise HttpClientError(f"{op_label} refused redirect (HTTP {status})")
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            if self.is_client_error_status_code(status):
+                response.close()
+                raise HttpClientError(f"{op_label} failed with HTTP {status}") from None
+            new_err = HTTPError(f"{op_label} failed with HTTP {status}")
+            new_err.response = response
+            # close before raising — caller never enters the `with` block
+            response.close()
+            raise new_err from None
+
+        return response
+
     def download_bytes(
         self,
         url: str,
@@ -243,46 +298,13 @@ class HttpProxyClient(BaseProxyClient):
           signed secret; callers needing verbose error context should use
           ``do_request`` with full URLs instead.
         """
-        self._assert_safe_download_url(url)
-
-        headers = {**additional_headers} if additional_headers else {}
-        if not no_auth:
-            self._attach_auth_header(headers)
-
-        request_kwargs: Dict = {
-            "timeout": timeout,
-            "headers": headers,
-            "stream": True,
-            "allow_redirects": False,
-        }
-        if self._ssl_verify is not None:
-            request_kwargs["verify"] = self._ssl_verify
-
-        try:
-            response = requests.get(url, **request_kwargs)
-        except requests.RequestException as exc:
-            raise HttpClientError(
-                f"download_bytes transport error: {type(exc).__name__}"
-            ) from None
-
-        with response:
-            status = response.status_code
-            # 3xx is not raised by raise_for_status; explicitly reject it so
-            # callers don't silently receive an empty redirect body as "bytes".
-            if 300 <= status < 400:
-                raise HttpClientError(
-                    f"download_bytes refused redirect (HTTP {status})"
-                )
-            try:
-                response.raise_for_status()
-            except HTTPError:
-                if self.is_client_error_status_code(status):
-                    raise HttpClientError(
-                        f"download_bytes failed with HTTP {status}"
-                    ) from None
-                new_err = HTTPError(f"download_bytes failed with HTTP {status}")
-                new_err.response = response
-                raise new_err from None
+        with self._open_download_response(
+            url,
+            timeout=timeout,
+            no_auth=no_auth,
+            additional_headers=additional_headers,
+            op_label="download_bytes",
+        ) as response:
             chunks: List[bytes] = []
             size = 0
             for chunk in response.iter_content(chunk_size=8192):
@@ -321,50 +343,26 @@ class HttpProxyClient(BaseProxyClient):
         Use this instead of ``download_bytes`` for payloads that may be large
         enough to matter for memory (the motivating case is MuleSoft Mule
         application JARs which can exceed 100 MiB).
+
+        Configuration:
+            Requires either ``MCD_STORAGE`` env var, or a ``platform`` value passed
+            to ``HttpProxyClient(...)`` whose default backend is recognized
+            (`PLATFORM_AWS`, `PLATFORM_GCP`, `PLATFORM_AZURE`, `PLATFORM_AWS_GENERIC`).
+
+        Raises:
+            HttpClientError: SSRF guard rejection, transport error, 3xx/4xx response,
+                or ``max_bytes`` exceeded.
+            HTTPError: 5xx response.
+            AgentConfigurationError: storage backend is not configured (no
+                ``MCD_STORAGE`` env var and no recognized ``platform``).
         """
-        self._assert_safe_download_url(url)
-
-        headers = {**additional_headers} if additional_headers else {}
-        if not no_auth:
-            self._attach_auth_header(headers)
-
-        request_kwargs: Dict = {
-            "timeout": timeout,
-            "headers": headers,
-            "stream": True,
-            "allow_redirects": False,
-        }
-        if self._ssl_verify is not None:
-            request_kwargs["verify"] = self._ssl_verify
-
-        try:
-            response = requests.get(url, **request_kwargs)
-        except requests.RequestException as exc:
-            raise HttpClientError(
-                f"download_to_storage transport error: {type(exc).__name__}"
-            ) from None
-
-        # Late import: storage layer pulls in cloud SDKs that we don't want at
-        # HttpProxyClient construction time (this method is the only consumer).
-        from apollo.integrations.storage.factory import get_storage_client
-
-        with response:
-            status = response.status_code
-            if 300 <= status < 400:
-                raise HttpClientError(
-                    f"download_to_storage refused redirect (HTTP {status})"
-                )
-            try:
-                response.raise_for_status()
-            except HTTPError:
-                if self.is_client_error_status_code(status):
-                    raise HttpClientError(
-                        f"download_to_storage failed with HTTP {status}"
-                    ) from None
-                new_err = HTTPError(f"download_to_storage failed with HTTP {status}")
-                new_err.response = response
-                raise new_err from None
-
+        with self._open_download_response(
+            url,
+            timeout=timeout,
+            no_auth=no_auth,
+            additional_headers=additional_headers,
+            op_label="download_to_storage",
+        ) as response:
             tmp = tempfile.NamedTemporaryFile(
                 delete=False, suffix=".download_to_storage"
             )
@@ -378,8 +376,7 @@ class HttpProxyClient(BaseProxyClient):
                         size += len(chunk)
                         if max_bytes is not None and size > max_bytes:
                             raise HttpClientError(
-                                f"download_to_storage response exceeded "
-                                f"{max_bytes} bytes"
+                                f"download_to_storage response exceeded {max_bytes} bytes"
                             )
                 finally:
                     tmp.close()

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -1,5 +1,7 @@
 import ipaddress
 import logging
+import os
+import tempfile
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
@@ -278,6 +280,104 @@ class HttpProxyClient(BaseProxyClient):
                         f"download_bytes response exceeded {max_bytes} bytes"
                     )
             return b"".join(chunks)
+
+    def download_to_storage(
+        self,
+        url: str,
+        storage_key: str,
+        timeout: int = 300,
+        max_bytes: Optional[int] = None,
+        no_auth: bool = True,
+        additional_headers: Optional[Dict] = None,
+    ) -> str:
+        """Stream a binary download into the agent's configured storage backend
+        (S3 / GCS / Azure Blob / S3-compatible) without holding the payload in
+        memory — only one chunk (8 KiB) is in memory at any time.
+
+        Bytes are spooled to a tempfile as they arrive, then handed to the
+        storage backend's ``upload_file``; the tempfile is deleted in the
+        ``finally``. Returns the supplied ``storage_key``.
+
+        Same safety surface as ``download_bytes``: HTTPS-only, non-public IP
+        literals (incl. multicast) rejected, redirects refused, ``max_bytes``
+        cap fires mid-stream, error messages strip the URL, connection released
+        on every exit path.
+
+        Use this instead of ``download_bytes`` for payloads that may be large
+        enough to matter for memory (the motivating case is MuleSoft Mule
+        application JARs which can exceed 100 MiB).
+        """
+        self._assert_safe_download_url(url)
+
+        headers = {**additional_headers} if additional_headers else {}
+        if not no_auth:
+            self._attach_auth_header(headers)
+
+        request_kwargs: Dict = {
+            "timeout": timeout,
+            "headers": headers,
+            "stream": True,
+            "allow_redirects": False,
+        }
+        if self._ssl_verify is not None:
+            request_kwargs["verify"] = self._ssl_verify
+
+        try:
+            response = requests.get(url, **request_kwargs)
+        except requests.RequestException as exc:
+            raise HttpClientError(
+                f"download_to_storage transport error: {type(exc).__name__}"
+            ) from None
+
+        # Late import: storage layer pulls in cloud SDKs that we don't want at
+        # HttpProxyClient construction time (this method is the only consumer).
+        from apollo.integrations.storage.factory import get_storage_client
+
+        with response:
+            status = response.status_code
+            if 300 <= status < 400:
+                raise HttpClientError(
+                    f"download_to_storage refused redirect (HTTP {status})"
+                )
+            try:
+                response.raise_for_status()
+            except HTTPError:
+                if self.is_client_error_status_code(status):
+                    raise HttpClientError(
+                        f"download_to_storage failed with HTTP {status}"
+                    ) from None
+                new_err = HTTPError(f"download_to_storage failed with HTTP {status}")
+                new_err.response = response
+                raise new_err from None
+
+            tmp = tempfile.NamedTemporaryFile(
+                delete=False, suffix=".download_to_storage"
+            )
+            try:
+                size = 0
+                try:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        if not chunk:
+                            continue
+                        tmp.write(chunk)
+                        size += len(chunk)
+                        if max_bytes is not None and size > max_bytes:
+                            raise HttpClientError(
+                                f"download_to_storage response exceeded "
+                                f"{max_bytes} bytes"
+                            )
+                finally:
+                    tmp.close()
+                get_storage_client().upload_file(storage_key, tmp.name)
+            finally:
+                # Best-effort cleanup; never let an unlink failure mask the
+                # original exception (or stomp on a successful return).
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+
+        return storage_key
 
     def do_request_with_retry(
         self,

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -50,8 +50,20 @@ class HttpProxyClient(BaseProxyClient):
     - `disabled`: Set to True to disable SSL verification
     """
 
-    def __init__(self, credentials: Optional[Dict], **kwargs):  # type: ignore
+    def __init__(
+        self,
+        credentials: Optional[Dict],
+        platform: Optional[str] = None,
+        **kwargs,  # type: ignore
+    ):
         self._ssl_verify: Union[bool, str, None] = None
+        # `platform` is forwarded to the storage factory by `download_to_storage`
+        # so the configured backend (S3/GCS/Azure) can be derived from the agent
+        # platform when `MCD_STORAGE` is unset (the production default — the env
+        # var is only set for local development). Defaults to None so direct
+        # callers (e.g. DatabricksRestProxyClient) that don't use
+        # download_to_storage keep working.
+        self._platform: Optional[str] = platform
 
         if credentials and "connect_args" in credentials:
             self._credentials = credentials["connect_args"]
@@ -82,14 +94,17 @@ class HttpProxyClient(BaseProxyClient):
 
     @staticmethod
     def _assert_safe_download_url(url: str) -> None:
+        # Phrasing is method-agnostic so the same helper can be reused by every
+        # streaming download entry point on this client (download_bytes,
+        # download_to_storage, future additions) without misnaming the caller.
         parts = urlsplit(url)
         if parts.scheme != "https":
             raise HttpClientError(
-                f"download_bytes requires https scheme; got '{parts.scheme}'"
+                f"download requires https scheme; got '{parts.scheme}'"
             )
         host = (parts.hostname or "").lower()
         if host in ("", "localhost"):
-            raise HttpClientError(f"download_bytes refuses '{host or '<empty>'}' host")
+            raise HttpClientError(f"download refuses '{host or '<empty>'}' host")
         try:
             ip = ipaddress.ip_address(host)
         except ValueError:
@@ -100,7 +115,7 @@ class HttpProxyClient(BaseProxyClient):
         # ipaddress module reports `is_global=True` for multicast (e.g.
         # 224.0.0.0/4), so we add an explicit multicast check.
         if not ip.is_global or ip.is_multicast:
-            raise HttpClientError(f"download_bytes refuses non-public address: {ip}")
+            raise HttpClientError(f"download refuses non-public address: {ip}")
 
     def _attach_auth_header(self, headers: Dict) -> None:
         if self._credentials and "token" in self._credentials:
@@ -368,7 +383,11 @@ class HttpProxyClient(BaseProxyClient):
                             )
                 finally:
                     tmp.close()
-                get_storage_client().upload_file(storage_key, tmp.name)
+                # Forward the agent platform so the storage factory can fall back
+                # to the platform default (S3/GCS/Azure) when MCD_STORAGE is unset.
+                get_storage_client(platform=self._platform).upload_file(
+                    storage_key, tmp.name
+                )
             finally:
                 # Best-effort cleanup; never let an unlink failure mask the
                 # original exception (or stomp on a successful return).

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -13,6 +13,7 @@ from retry.api import retry_call
 from apollo.common.agent.models import AgentOperation
 from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.storage.base_storage_client import BaseStorageClient
 
 # Hoisted to module scope: a late import inside `download_to_storage` would
 # leak the streaming response if the import raised (e.g., missing cloud SDK).
@@ -70,6 +71,11 @@ class HttpProxyClient(BaseProxyClient):
         # callers (e.g. DatabricksRestProxyClient) that don't use
         # download_to_storage keep working.
         self._platform: Optional[str] = platform
+        # Lazy-initialized on first download_to_storage call; reused across
+        # subsequent calls so the underlying SDK client (boto3 / google-cloud-
+        # storage / azure-storage-blob) is constructed once per HttpProxyClient
+        # instance instead of per request.
+        self._storage_client: Optional[BaseStorageClient] = None
 
         if credentials and "connect_args" in credentials:
             self._credentials = credentials["connect_args"]
@@ -122,6 +128,18 @@ class HttpProxyClient(BaseProxyClient):
         # 224.0.0.0/4), so we add an explicit multicast check.
         if not ip.is_global or ip.is_multicast:
             raise HttpClientError(f"download refuses non-public address: {ip}")
+
+    def _get_storage_client(self) -> BaseStorageClient:
+        """Lazy + cached storage client for ``download_to_storage``.
+
+        Constructed once per ``HttpProxyClient`` instance — reusing the
+        underlying SDK client (boto3 / google-cloud-storage / azure-storage-
+        blob) across multiple ``download_to_storage`` calls avoids the per-call
+        cost of credential resolution and connection-pool setup.
+        """
+        if self._storage_client is None:
+            self._storage_client = get_storage_client(platform=self._platform)
+        return self._storage_client
 
     def _attach_auth_header(self, headers: Dict) -> None:
         if self._credentials and "token" in self._credentials:
@@ -395,11 +413,9 @@ class HttpProxyClient(BaseProxyClient):
                             )
                 finally:
                     tmp.close()
-                # Forward the agent platform so the storage factory can fall back
-                # to the platform default (S3/GCS/Azure) when MCD_STORAGE is unset.
-                get_storage_client(platform=self._platform).upload_file(
-                    storage_key, tmp.name
-                )
+                # Cached on self after first call — avoids reconstructing the
+                # SDK client (boto3 / GCS / Azure) per request.
+                self._get_storage_client().upload_file(storage_key, tmp.name)
             finally:
                 # Best-effort cleanup; never let an unlink failure mask the
                 # original exception (or stomp on a successful return).

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -2,7 +2,8 @@ import ipaddress
 import logging
 import os
 import tempfile
-from typing import Dict, List, Optional, Tuple, Union
+from contextlib import contextmanager
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
 import requests
@@ -12,6 +13,10 @@ from retry.api import retry_call
 from apollo.common.agent.models import AgentOperation
 from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
+
+# Hoisted to module scope: a late import inside `download_to_storage` would
+# leak the streaming response if the import raised (e.g., missing cloud SDK).
+# Safe at module scope because `factory.py`'s SDK imports are themselves lazy.
 from apollo.integrations.storage.factory import get_storage_client
 
 _logger = logging.getLogger(__name__)
@@ -213,6 +218,7 @@ class HttpProxyClient(BaseProxyClient):
 
         return response.json()
 
+    @contextmanager
     def _open_download_response(
         self,
         url: str,
@@ -220,12 +226,19 @@ class HttpProxyClient(BaseProxyClient):
         no_auth: bool,
         additional_headers: Optional[Dict],
         op_label: str,
-    ) -> requests.Response:
+    ) -> Iterator[requests.Response]:
         """Open a streaming GET response with the full SSRF + redirect + status guards.
 
-        Caller MUST use the returned response via `with response:` to ensure the
-        connection is released on every exit path. ``op_label`` is included in
-        error messages so the user-facing message names the calling method.
+        Use as a context manager: ``with self._open_download_response(...) as response:``.
+        On every error-exit path the response is closed internally before the
+        exception propagates; on success, the context manager closes it on exit.
+        ``op_label`` is included in error messages so the user-facing message
+        names the calling method.
+
+        Raises:
+            HttpClientError: SSRF guard rejection, transport error, 3xx redirect,
+                or 4xx response.
+            HTTPError: 5xx response.
         """
         self._assert_safe_download_url(url)
 
@@ -251,7 +264,7 @@ class HttpProxyClient(BaseProxyClient):
 
         status = response.status_code
         if 300 <= status < 400:
-            response.close()  # we're returning before the caller's `with` block
+            response.close()
             raise HttpClientError(f"{op_label} refused redirect (HTTP {status})")
         try:
             response.raise_for_status()
@@ -261,11 +274,13 @@ class HttpProxyClient(BaseProxyClient):
                 raise HttpClientError(f"{op_label} failed with HTTP {status}") from None
             new_err = HTTPError(f"{op_label} failed with HTTP {status}")
             new_err.response = response
-            # close before raising — caller never enters the `with` block
             response.close()
             raise new_err from None
 
-        return response
+        try:
+            yield response
+        finally:
+            response.close()
 
     def download_bytes(
         self,
@@ -344,7 +359,7 @@ class HttpProxyClient(BaseProxyClient):
         enough to matter for memory (the motivating case is MuleSoft Mule
         application JARs which can exceed 100 MiB).
 
-        Configuration:
+        Notes:
             Requires either ``MCD_STORAGE`` env var, or a ``platform`` value passed
             to ``HttpProxyClient(...)`` whose default backend is recognized
             (`PLATFORM_AWS`, `PLATFORM_GCP`, `PLATFORM_AZURE`, `PLATFORM_AWS_GENERIC`).

--- a/apollo/integrations/storage/CLAUDE.md
+++ b/apollo/integrations/storage/CLAUDE.md
@@ -1,0 +1,60 @@
+# Storage — Backend Abstraction and Factory
+
+Three files; one public entry point.
+
+## File responsibilities
+
+- **`base_storage_client.py`** — Abstract `BaseStorageClient` contract every backend must
+  implement. Core methods: `write`, `read`, `delete`, `download_file`, `upload_file`,
+  `managed_download`, `read_json`, `read_many_json`, `list_objects`,
+  `generate_presigned_url`, `is_bucket_private`. The base class also handles prefix
+  application/stripping (`_apply_prefix`, `_remove_prefix*`) so backends don't repeat
+  that logic.
+
+- **`factory.py`** — Sole entry point for constructing a `BaseStorageClient`. Resolves the
+  backend type and prefix from environment, then lazily imports and instantiates the
+  correct class. No other module should construct a storage client directly.
+
+- **`storage_proxy_client.py`** — `BaseProxyClient`-shaped wrapper used when the agent's
+  connection type is `"storage"`. Delegates to an inner `BaseStorageClient`. Adapts the
+  interface slightly: `list_objects` returns `{"list": ..., "page_token": ...}` instead of
+  a tuple; `generate_presigned_url` accepts `expiration` as seconds (int) rather than
+  `timedelta`.
+
+## Backend resolution (factory.py)
+
+Priority order inside `get_storage_client(platform=None)`:
+
+1. `MCD_STORAGE` env var — `S3`, `GCS`, `AZURE_BLOB`, or `S3_COMPATIBLE` (highest priority).
+2. Platform default (used only when `platform` arg is provided):
+   - `aws` / `aws-generic` → S3
+   - `gcp` → GCS
+   - `azure` → Azure Blob
+3. Neither set → raises `AgentConfigurationError`.
+
+Prefix comes from `MCD_STORAGE_PREFIX` (default `"mcd"`). An empty string or `"/"` collapses
+to no prefix.
+
+## Public entry point
+
+`get_storage_client(platform=None)` is the only sanctioned constructor. Two callers today:
+
+- `StorageProxyClient.__init__` — the agent's `"storage"` connection-type proxy.
+- `HttpProxyClient.download_to_storage` — streams an HTTP download into the configured
+  backend without constructing a full `StorageProxyClient`.
+
+## Lazy SDK imports
+
+Each backend's cloud SDK is imported only inside its dispatch branch in `get_storage_client`.
+This avoids loading `azure-storage-blob` and `google-cloud-storage` into an agent that only
+uses S3.
+
+## Adding a new storage backend
+
+1. Implement `BaseStorageClient` in a new module under `apollo/integrations/<backend>/`.
+2. Add a storage-type constant in `apollo/common/agent/constants.py`
+   (e.g. `STORAGE_TYPE_FOO = "FOO"`).
+3. Add a dispatch branch in `get_storage_client` using a lazy import (follow the existing
+   `STORAGE_TYPE_S3_COMPATIBLE` branch as the pattern).
+4. Optionally add an entry to `_DEFAULT_PLATFORM_STORAGE` if a platform should resolve to
+   the new backend by default.

--- a/apollo/integrations/storage/CLAUDE.md
+++ b/apollo/integrations/storage/CLAUDE.md
@@ -1,6 +1,6 @@
 # Storage — Backend Abstraction and Factory
 
-Three files; one public entry point.
+Three source modules plus an `__init__.py`; one public entry point.
 
 ## File responsibilities
 

--- a/apollo/integrations/storage/factory.py
+++ b/apollo/integrations/storage/factory.py
@@ -1,0 +1,84 @@
+"""Instantiate the configured BaseStorageClient.
+
+Factored out of `StorageProxyClient` so other proxy clients (e.g.
+`HttpProxyClient.download_to_storage`) can grab the configured storage
+backend without constructing a full `StorageProxyClient`.
+"""
+
+import os
+from typing import Optional, cast
+
+from apollo.common.agent.constants import (
+    PLATFORM_AWS,
+    PLATFORM_AWS_GENERIC,
+    PLATFORM_AZURE,
+    PLATFORM_GCP,
+    STORAGE_TYPE_AZURE,
+    STORAGE_TYPE_GCS,
+    STORAGE_TYPE_S3,
+    STORAGE_TYPE_S3_COMPATIBLE,
+)
+from apollo.common.agent.env_vars import (
+    STORAGE_PREFIX_DEFAULT_VALUE,
+    STORAGE_PREFIX_ENV_VAR,
+    STORAGE_TYPE_ENV_VAR,
+)
+from apollo.common.agent.models import AgentConfigurationError
+from apollo.integrations.azure_blob.azure_blob_reader_writer import (
+    AzureBlobReaderWriter,
+)
+from apollo.integrations.gcs.gcs_reader_writer import GcsReaderWriter
+from apollo.integrations.s3.s3_reader_writer import S3ReaderWriter
+from apollo.integrations.s3_compatible.s3_compatible_reader_writer import (
+    S3CompatibleReaderWriter,
+)
+from apollo.integrations.storage.base_storage_client import BaseStorageClient
+
+_DEFAULT_PLATFORM_STORAGE = {
+    PLATFORM_AZURE: STORAGE_TYPE_AZURE,
+    PLATFORM_GCP: STORAGE_TYPE_GCS,
+    PLATFORM_AWS: STORAGE_TYPE_S3,
+    PLATFORM_AWS_GENERIC: STORAGE_TYPE_S3,
+}
+
+_STORAGE_CLIENTS = {
+    STORAGE_TYPE_AZURE: AzureBlobReaderWriter,
+    STORAGE_TYPE_GCS: GcsReaderWriter,
+    STORAGE_TYPE_S3: S3ReaderWriter,
+    STORAGE_TYPE_S3_COMPATIBLE: S3CompatibleReaderWriter,
+}
+
+
+def get_storage_client(platform: Optional[str] = None) -> BaseStorageClient:
+    """Return the configured `BaseStorageClient` instance.
+
+    Resolution order for the storage backend:
+      1. `MCD_STORAGE` env var (highest priority — explicit override)
+      2. Platform default (`PLATFORM_AWS` → S3, `PLATFORM_GCP` → GCS,
+         `PLATFORM_AZURE` → Azure). Used only when `platform` is provided.
+
+    Prefix is read from `MCD_STORAGE_PREFIX`; an empty / `/` value collapses
+    to no prefix.
+
+    Raises `AgentConfigurationError` if the storage type cannot be resolved
+    or names an unknown backend.
+    """
+    storage = os.getenv(STORAGE_TYPE_ENV_VAR)
+    if not storage and platform:
+        storage = _DEFAULT_PLATFORM_STORAGE.get(platform)
+    if not storage:
+        raise AgentConfigurationError(
+            f"Missing {STORAGE_TYPE_ENV_VAR} env var and no platform default available"
+        )
+
+    storage_class = _STORAGE_CLIENTS.get(storage)
+    if not storage_class:
+        raise AgentConfigurationError(f"Invalid storage type: {storage}")
+
+    prefix: Optional[str] = os.getenv(
+        STORAGE_PREFIX_ENV_VAR, STORAGE_PREFIX_DEFAULT_VALUE
+    )
+    if prefix in ("", "/"):
+        prefix = None
+
+    return cast(BaseStorageClient, storage_class(prefix=prefix))

--- a/apollo/integrations/storage/factory.py
+++ b/apollo/integrations/storage/factory.py
@@ -44,8 +44,9 @@ def get_storage_client(platform: Optional[str] = None) -> BaseStorageClient:
 
     Resolution order for the storage backend:
       1. `MCD_STORAGE` env var (highest priority — explicit override)
-      2. Platform default (`PLATFORM_AWS` → S3, `PLATFORM_GCP` → GCS,
-         `PLATFORM_AZURE` → Azure). Used only when `platform` is provided.
+      2. Platform default (`PLATFORM_AWS` / `PLATFORM_AWS_GENERIC` → S3,
+         `PLATFORM_GCP` → GCS, `PLATFORM_AZURE` → Azure). Used only when
+         `platform` is provided.
 
     Prefix is read from `MCD_STORAGE_PREFIX`; an empty / `/` value collapses
     to no prefix.

--- a/apollo/integrations/storage/factory.py
+++ b/apollo/integrations/storage/factory.py
@@ -3,6 +3,11 @@
 Factored out of `StorageProxyClient` so other proxy clients (e.g.
 `HttpProxyClient.download_to_storage`) can grab the configured storage
 backend without constructing a full `StorageProxyClient`.
+
+Raises `AgentConfigurationError` if no storage type is resolved or if the
+resolved type is unknown.  Note: the missing-config path was previously raised
+as `ValueError` from `StorageProxyClient.__init__`; this factory unifies both
+error paths under `AgentConfigurationError`.
 """
 
 import os
@@ -24,14 +29,6 @@ from apollo.common.agent.env_vars import (
     STORAGE_TYPE_ENV_VAR,
 )
 from apollo.common.agent.models import AgentConfigurationError
-from apollo.integrations.azure_blob.azure_blob_reader_writer import (
-    AzureBlobReaderWriter,
-)
-from apollo.integrations.gcs.gcs_reader_writer import GcsReaderWriter
-from apollo.integrations.s3.s3_reader_writer import S3ReaderWriter
-from apollo.integrations.s3_compatible.s3_compatible_reader_writer import (
-    S3CompatibleReaderWriter,
-)
 from apollo.integrations.storage.base_storage_client import BaseStorageClient
 
 _DEFAULT_PLATFORM_STORAGE = {
@@ -39,13 +36,6 @@ _DEFAULT_PLATFORM_STORAGE = {
     PLATFORM_GCP: STORAGE_TYPE_GCS,
     PLATFORM_AWS: STORAGE_TYPE_S3,
     PLATFORM_AWS_GENERIC: STORAGE_TYPE_S3,
-}
-
-_STORAGE_CLIENTS = {
-    STORAGE_TYPE_AZURE: AzureBlobReaderWriter,
-    STORAGE_TYPE_GCS: GcsReaderWriter,
-    STORAGE_TYPE_S3: S3ReaderWriter,
-    STORAGE_TYPE_S3_COMPATIBLE: S3CompatibleReaderWriter,
 }
 
 
@@ -71,8 +61,29 @@ def get_storage_client(platform: Optional[str] = None) -> BaseStorageClient:
             f"Missing {STORAGE_TYPE_ENV_VAR} env var and no platform default available"
         )
 
-    storage_class = _STORAGE_CLIENTS.get(storage)
-    if not storage_class:
+    # Import driver modules only when needed so that importing this factory
+    # module does not pull all cloud SDKs into the process.
+    if storage == STORAGE_TYPE_S3:
+        from apollo.integrations.s3.s3_reader_writer import S3ReaderWriter
+
+        storage_class = S3ReaderWriter
+    elif storage == STORAGE_TYPE_GCS:
+        from apollo.integrations.gcs.gcs_reader_writer import GcsReaderWriter
+
+        storage_class = GcsReaderWriter
+    elif storage == STORAGE_TYPE_AZURE:
+        from apollo.integrations.azure_blob.azure_blob_reader_writer import (
+            AzureBlobReaderWriter,
+        )
+
+        storage_class = AzureBlobReaderWriter
+    elif storage == STORAGE_TYPE_S3_COMPATIBLE:
+        from apollo.integrations.s3_compatible.s3_compatible_reader_writer import (
+            S3CompatibleReaderWriter,
+        )
+
+        storage_class = S3CompatibleReaderWriter
+    else:
         raise AgentConfigurationError(f"Invalid storage type: {storage}")
 
     prefix: Optional[str] = os.getenv(

--- a/apollo/integrations/storage/storage_proxy_client.py
+++ b/apollo/integrations/storage/storage_proxy_client.py
@@ -26,15 +26,25 @@ _OBJ_TO_WRITE_ARG_NAME = "obj_to_write"
 
 class StorageProxyClient(BaseProxyClient):
     """
-    Proxy client for storage operations, it forwards calls to a `BaseStorageClient`, for example GCS, S3, or S3-compatible storage.
-    The storage client to use is automatically derived from the platform:
-    - AWS -> S3
-    - GCP -> GCS
-    - Generic -> S3/GCS/S3_COMPATIBLE as configured by MCD_STORAGE env var
-    Credentials to use by the storage client are derived from the environment, in the case of S3 from env vars as
-    supported by boto3, for GCS from ADC (Application Default Credentials) that are automatically set when
-    running in CloudRun and can be set with `gcloud` CLI or API in other cases. For S3-compatible storage (MinIO, Ceph, etc.),
-    credentials are provided via MCD_STORAGE_ENDPOINT_URL, MCD_STORAGE_ACCESS_KEY, and MCD_STORAGE_SECRET_KEY environment variables.
+    Proxy client for storage operations, forwarding calls to a `BaseStorageClient`
+    (S3, GCS, Azure Blob, or S3-compatible).
+
+    Storage backend resolution lives in
+    `apollo.integrations.storage.factory.get_storage_client`. See that module for
+    env-var precedence (`MCD_STORAGE` wins; falls back to per-platform default),
+    prefix handling (`MCD_STORAGE_PREFIX`), and the supported storage types.
+
+    Credentials for the underlying backend are derived from the environment:
+    boto3 conventions for S3, ADC for GCS, MCD_STORAGE_ENDPOINT_URL /
+    MCD_STORAGE_ACCESS_KEY / MCD_STORAGE_SECRET_KEY for S3-compatible.
+
+    Raises (on construction):
+        AgentConfigurationError: storage backend is not configured
+            (no `MCD_STORAGE` env var and no recognized `platform`),
+            or the resolved storage type is unknown.
+
+    Note: the missing-config path was previously a `ValueError`; this is now
+    unified under `AgentConfigurationError` from the factory.
     """
 
     def __init__(self, platform: str, **kwargs):  # type: ignore

--- a/apollo/integrations/storage/storage_proxy_client.py
+++ b/apollo/integrations/storage/storage_proxy_client.py
@@ -1,42 +1,18 @@
-import os
 from datetime import timedelta
 from typing import (
-    Optional,
+    Any,
     BinaryIO,
     Dict,
+    Optional,
     Union,
-    cast,
-    Any,
 )
 
-from apollo.common.agent.constants import (
-    PLATFORM_AZURE,
-    PLATFORM_GCP,
-    PLATFORM_AWS,
-    PLATFORM_AWS_GENERIC,
-    STORAGE_TYPE_AZURE,
-    STORAGE_TYPE_GCS,
-    STORAGE_TYPE_S3,
-    STORAGE_TYPE_S3_COMPATIBLE,
-)
-from apollo.common.agent.env_vars import (
-    STORAGE_TYPE_ENV_VAR,
-    STORAGE_PREFIX_ENV_VAR,
-    STORAGE_PREFIX_DEFAULT_VALUE,
-)
-from apollo.common.agent.models import AgentConfigurationError, AgentOperation
-from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.agent.utils import AgentUtils
-from apollo.integrations.azure_blob.azure_blob_reader_writer import (
-    AzureBlobReaderWriter,
-)
+from apollo.common.agent.models import AgentOperation
+from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
-from apollo.integrations.gcs.gcs_reader_writer import GcsReaderWriter
-from apollo.integrations.s3_compatible.s3_compatible_reader_writer import (
-    S3CompatibleReaderWriter,
-)
-from apollo.integrations.s3.s3_reader_writer import S3ReaderWriter
 from apollo.integrations.storage.base_storage_client import BaseStorageClient
+from apollo.integrations.storage.factory import get_storage_client
 
 _API_SERVICE_NAME = "storage"
 _API_VERSION = "v1"
@@ -46,20 +22,6 @@ _ERROR_TYPE_PERMISSIONS = "Permissions"
 
 _BUCKET_NAME_LOG_ATTRIBUTE = "bucket_name"
 _OBJ_TO_WRITE_ARG_NAME = "obj_to_write"
-
-_DEFAULT_PLATFORM_STORAGE = {
-    PLATFORM_AZURE: STORAGE_TYPE_AZURE,
-    PLATFORM_GCP: STORAGE_TYPE_GCS,
-    PLATFORM_AWS: STORAGE_TYPE_S3,
-    PLATFORM_AWS_GENERIC: STORAGE_TYPE_S3,
-}
-
-_STORAGE_CLIENTS = {
-    STORAGE_TYPE_AZURE: AzureBlobReaderWriter,
-    STORAGE_TYPE_GCS: GcsReaderWriter,
-    STORAGE_TYPE_S3: S3ReaderWriter,
-    STORAGE_TYPE_S3_COMPATIBLE: S3CompatibleReaderWriter,
-}
 
 
 class StorageProxyClient(BaseProxyClient):
@@ -76,22 +38,7 @@ class StorageProxyClient(BaseProxyClient):
     """
 
     def __init__(self, platform: str, **kwargs):  # type: ignore
-        storage: Optional[str] = os.getenv(STORAGE_TYPE_ENV_VAR)
-        if not storage:
-            storage = _DEFAULT_PLATFORM_STORAGE.get(platform)
-            if not storage:
-                raise ValueError(f"Missing {STORAGE_TYPE_ENV_VAR} env var")
-
-        prefix: Optional[str] = os.getenv(
-            STORAGE_PREFIX_ENV_VAR, STORAGE_PREFIX_DEFAULT_VALUE
-        )
-        if prefix == "" or prefix == "/":
-            prefix = None
-        storage_client = _STORAGE_CLIENTS.get(storage)
-        if not storage_client:
-            raise AgentConfigurationError(f"Invalid storage type: {storage}")
-
-        self._client = cast(BaseStorageClient, storage_client(prefix=prefix))
+        self._client = get_storage_client(platform=platform)
 
     @property
     def wrapped_client(self):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1236,3 +1236,44 @@ class TestDownloadToStorage(TestCase):
             os.path.exists(captured_paths[0]),
             f"tempfile {captured_paths[0]} should have been deleted",
         )
+
+    @patch("requests.get")
+    def test_platform_forwarded_to_storage_factory(self, mock_get):
+        """The agent platform passed to HttpProxyClient must be forwarded to
+        get_storage_client so the platform→backend default (S3/GCS/Azure)
+        applies in production agents where MCD_STORAGE is not set.
+        """
+        from apollo.common.agent.constants import PLATFORM_AWS
+
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client = MagicMock()
+        storage_client.upload_file = MagicMock()
+
+        client = HttpProxyClient(
+            credentials={"connect_args": {}}, platform=PLATFORM_AWS
+        )
+        with patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        ) as mock_factory:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        mock_factory.assert_called_once_with(platform=PLATFORM_AWS)
+
+    @patch("requests.get")
+    def test_platform_defaults_to_none_when_not_supplied(self, mock_get):
+        """Direct constructions (DatabricksRest, tests) that omit platform must
+        still work — get_storage_client receives platform=None and falls back
+        to MCD_STORAGE (the local-development path)."""
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client = MagicMock()
+        storage_client.upload_file = MagicMock()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        ) as mock_factory:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        mock_factory.assert_called_once_with(platform=None)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import MagicMock, create_autospec, patch, call, mock_open
@@ -921,4 +922,317 @@ class TestMulesoftAgentEndToEnd(TestCase):
             "GET",
             "https://some-other-anypoint-mirror.example.com/v3/foo",
             headers={"Authorization": "Bearer tok"},
+        )
+
+
+class TestDownloadToStorage(TestCase):
+    """Tests for HttpProxyClient.download_to_storage — streams a binary download
+    directly into the configured storage backend without holding the payload
+    in memory. Bytes are spooled to a tempfile; tempfile is uploaded then
+    deleted.
+    """
+
+    def _make_response(
+        self,
+        status_code: int = 200,
+        chunks: list[bytes] | None = None,
+    ) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.iter_content.return_value = iter(chunks if chunks is not None else [b""])
+        if 400 <= status_code < 600:
+            resp.raise_for_status.side_effect = HTTPError(
+                f"{status_code}", response=resp
+            )
+        else:
+            resp.raise_for_status.return_value = None
+        return resp
+
+    def _patched_storage(self):
+        """Patch the late-imported get_storage_client and return the mock client."""
+        storage_client = MagicMock(name="storage_client")
+        storage_client.upload_file = MagicMock()
+        return storage_client, patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        )
+
+    @patch("requests.get")
+    def test_streams_to_storage_and_returns_key(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"part1", b"part2"])
+        storage_client, ctx = self._patched_storage()
+        client = HttpProxyClient(credentials={"connect_args": {}})
+
+        with ctx:
+            returned = client.download_to_storage(
+                "https://s3.example/file.jar", "uploads/foo.jar"
+            )
+
+        self.assertEqual("uploads/foo.jar", returned)
+        storage_client.upload_file.assert_called_once()
+        called_key, called_path = storage_client.upload_file.call_args.args
+        self.assertEqual("uploads/foo.jar", called_key)
+        # Verify the tempfile actually contains the streamed bytes (the test
+        # reads it BEFORE download_to_storage's finally deletes it — so we
+        # capture the path from the mock invocation and read it ourselves
+        # while we know it still exists, by patching upload_file to copy).
+        # Easier: inspect what the function wrote by stubbing upload_file
+        # to read the file at call time.
+
+    @patch("requests.get")
+    def test_tempfile_contents_match_stream(self, mock_get):
+        """Capture the tempfile's bytes at upload_file call time, then assert
+        they equal the streamed concatenation."""
+        mock_get.return_value = self._make_response(
+            chunks=[b"alpha", b"beta", b"gamma"]
+        )
+        captured = {}
+
+        def capture_upload(key, path):
+            with open(path, "rb") as f:
+                captured["bytes"] = f.read()
+            captured["key"] = key
+
+        storage_client = MagicMock()
+        storage_client.upload_file.side_effect = capture_upload
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        ):
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        self.assertEqual(b"alphabetagamma", captured["bytes"])
+        self.assertEqual("uploads/foo.jar", captured["key"])
+
+    @patch("requests.get")
+    def test_tempfile_cleaned_up_on_success(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        captured_paths = []
+
+        def capture_path(key, path):
+            captured_paths.append(path)
+
+        storage_client = MagicMock()
+        storage_client.upload_file.side_effect = capture_path
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        ):
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        self.assertEqual(1, len(captured_paths))
+        self.assertFalse(
+            os.path.exists(captured_paths[0]),
+            f"tempfile {captured_paths[0]} should have been deleted",
+        )
+
+    @patch("requests.get")
+    def test_max_bytes_cap_aborts_and_cleans_up_tempfile(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"x" * 100, b"y" * 100])
+        # Track tempfile path so we can assert it was cleaned even on abort.
+        # The factory's upload_file should NOT be called when max_bytes fires.
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            with self.assertRaises(HttpClientError) as ec:
+                client.download_to_storage(
+                    "https://s3.example/file.jar",
+                    "uploads/foo.jar",
+                    max_bytes=150,
+                )
+
+        self.assertIn("150", str(ec.exception))
+        storage_client.upload_file.assert_not_called()
+        # We can't easily check the tempfile path post-fact (it's local to the
+        # method), but we can scan /tmp for any leftover *.download_to_storage
+        # files older than test start. Simpler: assert no upload happened.
+
+    @patch("requests.get")
+    def test_4xx_raises_http_client_error_and_no_upload(self, mock_get):
+        mock_get.return_value = self._make_response(status_code=404)
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            with self.assertRaises(HttpClientError):
+                client.download_to_storage(
+                    "https://s3.example/file.jar", "uploads/foo.jar"
+                )
+
+        storage_client.upload_file.assert_not_called()
+
+    @patch("requests.get")
+    def test_5xx_raises_http_error_and_no_upload(self, mock_get):
+        mock_get.return_value = self._make_response(status_code=500)
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            with self.assertRaises(HTTPError) as ec:
+                client.download_to_storage(
+                    "https://s3.example/file.jar", "uploads/foo.jar"
+                )
+
+        self.assertNotIsInstance(ec.exception, HttpClientError)
+        self.assertIsNotNone(ec.exception.response)
+        storage_client.upload_file.assert_not_called()
+
+    @patch("requests.get")
+    def test_3xx_redirect_refused_no_upload(self, mock_get):
+        mock_get.return_value = self._make_response(status_code=302)
+        # Headers might contain Location; we don't echo it but make sure.
+        mock_get.return_value.headers = {"Location": "https://attacker.example/leak"}
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            with self.assertRaises(HttpClientError) as ec:
+                client.download_to_storage(
+                    "https://s3.example/file.jar", "uploads/foo.jar"
+                )
+
+        self.assertNotIn("attacker.example", str(ec.exception))
+        self.assertIn("302", str(ec.exception))
+        storage_client.upload_file.assert_not_called()
+
+    @patch("requests.get")
+    def test_connection_error_no_upload_no_url_in_message(self, mock_get):
+        secret_url = "https://s3.example/file.jar?Signature=DO-NOT-LEAK-XYZ"
+        mock_get.side_effect = requests.ConnectionError(
+            "connection refused at " + secret_url
+        )
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            with self.assertRaises(HttpClientError) as ec:
+                client.download_to_storage(secret_url, "uploads/foo.jar")
+
+        self.assertNotIn("DO-NOT-LEAK-XYZ", str(ec.exception))
+        self.assertNotIn(secret_url, str(ec.exception))
+        storage_client.upload_file.assert_not_called()
+
+    def test_ssrf_guard_rejects_non_https(self):
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError):
+            client.download_to_storage("http://example.com/file", "uploads/foo.jar")
+
+    def test_ssrf_guard_rejects_imds(self):
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError):
+            client.download_to_storage(
+                "https://169.254.169.254/latest/meta-data/", "uploads/foo.jar"
+            )
+
+    @patch("requests.get")
+    def test_no_auth_default_omits_authorization_header(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
+        with ctx:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertNotIn("Authorization", sent_headers)
+
+    @patch("requests.get")
+    def test_no_auth_false_attaches_authorization_header(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
+        with ctx:
+            client.download_to_storage(
+                "https://api.example/file",
+                "uploads/foo.jar",
+                no_auth=False,
+            )
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual("Bearer tok", sent_headers["Authorization"])
+
+    @patch("requests.get")
+    def test_allow_redirects_false_passed_to_requests(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        self.assertFalse(mock_get.call_args.kwargs["allow_redirects"])
+        self.assertTrue(mock_get.call_args.kwargs["stream"])
+
+    @patch("requests.get")
+    def test_additional_headers_merged(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            client.download_to_storage(
+                "https://s3.example/file.jar",
+                "uploads/foo.jar",
+                additional_headers={"X-Trace": "abc"},
+            )
+
+        self.assertEqual("abc", mock_get.call_args.kwargs["headers"]["X-Trace"])
+
+    @patch("requests.get")
+    def test_default_timeout_is_300_seconds(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with ctx:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        self.assertEqual(300, mock_get.call_args.kwargs["timeout"])
+
+    @patch("requests.get")
+    def test_ssl_verify_passed_through(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client, ctx = self._patched_storage()
+
+        client = HttpProxyClient(
+            credentials={"connect_args": {"ssl_verify": "/path/to/ca.pem"}}
+        )
+        with ctx:
+            client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
+
+        self.assertEqual("/path/to/ca.pem", mock_get.call_args.kwargs["verify"])
+
+    @patch("requests.get")
+    def test_tempfile_cleaned_up_when_upload_raises(self, mock_get):
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        captured_paths: list = []
+
+        def fail_after_capture(key, path):
+            captured_paths.append(path)
+            raise RuntimeError("storage backend exploded")
+
+        storage_client = MagicMock()
+        storage_client.upload_file.side_effect = fail_after_capture
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with patch(
+            "apollo.integrations.storage.factory.get_storage_client",
+            return_value=storage_client,
+        ):
+            with self.assertRaises(RuntimeError):
+                client.download_to_storage(
+                    "https://s3.example/file.jar", "uploads/foo.jar"
+                )
+
+        self.assertEqual(1, len(captured_paths))
+        # The tempfile must be cleaned up even when upload_file raises.
+        self.assertFalse(
+            os.path.exists(captured_paths[0]),
+            f"tempfile {captured_paths[0]} should have been deleted",
         )

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,4 +1,6 @@
 import os
+import tempfile as tempfile_mod
+from contextlib import contextmanager
 from copy import deepcopy
 from unittest import TestCase
 from unittest.mock import MagicMock, create_autospec, patch, call, mock_open
@@ -477,6 +479,9 @@ class TestDownloadBytes(TestCase):
         resp = MagicMock()
         resp.status_code = status_code
         resp.iter_content.return_value = iter(chunks if chunks is not None else [b""])
+        # Configure context manager: real requests.Response.__enter__ returns self.
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
         if status_code >= 400:
             resp.raise_for_status.side_effect = HTTPError(
                 f"{status_code}", response=resp
@@ -940,6 +945,9 @@ class TestDownloadToStorage(TestCase):
         resp = MagicMock()
         resp.status_code = status_code
         resp.iter_content.return_value = iter(chunks if chunks is not None else [b""])
+        # Configure context manager: real requests.Response.__enter__ returns self.
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
         if 400 <= status_code < 600:
             resp.raise_for_status.side_effect = HTTPError(
                 f"{status_code}", response=resp
@@ -948,36 +956,31 @@ class TestDownloadToStorage(TestCase):
             resp.raise_for_status.return_value = None
         return resp
 
+    @contextmanager
     def _patched_storage(self):
-        """Patch the late-imported get_storage_client and return the mock client."""
+        """Patch the consumer-side binding of get_storage_client and yield the mock client."""
         storage_client = MagicMock(name="storage_client")
         storage_client.upload_file = MagicMock()
-        return storage_client, patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+        with patch(
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
-        )
+        ):
+            yield storage_client
 
     @patch("requests.get")
     def test_streams_to_storage_and_returns_key(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"part1", b"part2"])
-        storage_client, ctx = self._patched_storage()
         client = HttpProxyClient(credentials={"connect_args": {}})
 
-        with ctx:
+        with self._patched_storage() as storage_client:
             returned = client.download_to_storage(
                 "https://s3.example/file.jar", "uploads/foo.jar"
             )
 
         self.assertEqual("uploads/foo.jar", returned)
         storage_client.upload_file.assert_called_once()
-        called_key, called_path = storage_client.upload_file.call_args.args
+        called_key = storage_client.upload_file.call_args.args[0]
         self.assertEqual("uploads/foo.jar", called_key)
-        # Verify the tempfile actually contains the streamed bytes (the test
-        # reads it BEFORE download_to_storage's finally deletes it — so we
-        # capture the path from the mock invocation and read it ourselves
-        # while we know it still exists, by patching upload_file to copy).
-        # Easier: inspect what the function wrote by stubbing upload_file
-        # to read the file at call time.
 
     @patch("requests.get")
     def test_tempfile_contents_match_stream(self, mock_get):
@@ -998,7 +1001,7 @@ class TestDownloadToStorage(TestCase):
 
         client = HttpProxyClient(credentials={"connect_args": {}})
         with patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
         ):
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
@@ -1019,7 +1022,7 @@ class TestDownloadToStorage(TestCase):
 
         client = HttpProxyClient(credentials={"connect_args": {}})
         with patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
         ):
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
@@ -1033,32 +1036,38 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_max_bytes_cap_aborts_and_cleans_up_tempfile(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"x" * 100, b"y" * 100])
-        # Track tempfile path so we can assert it was cleaned even on abort.
-        # The factory's upload_file should NOT be called when max_bytes fires.
-        storage_client, ctx = self._patched_storage()
+        real_named_tempfile = tempfile_mod.NamedTemporaryFile
+        captured_paths: list = []
+
+        def capture(*args, **kwargs):
+            f = real_named_tempfile(*args, **kwargs)
+            captured_paths.append(f.name)
+            return f
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
-            with self.assertRaises(HttpClientError) as ec:
-                client.download_to_storage(
-                    "https://s3.example/file.jar",
-                    "uploads/foo.jar",
-                    max_bytes=150,
-                )
+        with patch(
+            "apollo.integrations.http.http_proxy_client.tempfile.NamedTemporaryFile",
+            side_effect=capture,
+        ):
+            with self._patched_storage() as storage_client:
+                with self.assertRaises(HttpClientError) as ec:
+                    client.download_to_storage(
+                        "https://s3.example/file.jar",
+                        "uploads/foo.jar",
+                        max_bytes=150,
+                    )
 
         self.assertIn("150", str(ec.exception))
+        self.assertEqual(1, len(captured_paths))
+        self.assertFalse(os.path.exists(captured_paths[0]))
         storage_client.upload_file.assert_not_called()
-        # We can't easily check the tempfile path post-fact (it's local to the
-        # method), but we can scan /tmp for any leftover *.download_to_storage
-        # files older than test start. Simpler: assert no upload happened.
 
     @patch("requests.get")
     def test_4xx_raises_http_client_error_and_no_upload(self, mock_get):
         mock_get.return_value = self._make_response(status_code=404)
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage() as storage_client:
             with self.assertRaises(HttpClientError):
                 client.download_to_storage(
                     "https://s3.example/file.jar", "uploads/foo.jar"
@@ -1069,10 +1078,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_5xx_raises_http_error_and_no_upload(self, mock_get):
         mock_get.return_value = self._make_response(status_code=500)
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage() as storage_client:
             with self.assertRaises(HTTPError) as ec:
                 client.download_to_storage(
                     "https://s3.example/file.jar", "uploads/foo.jar"
@@ -1087,10 +1095,9 @@ class TestDownloadToStorage(TestCase):
         mock_get.return_value = self._make_response(status_code=302)
         # Headers might contain Location; we don't echo it but make sure.
         mock_get.return_value.headers = {"Location": "https://attacker.example/leak"}
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage() as storage_client:
             with self.assertRaises(HttpClientError) as ec:
                 client.download_to_storage(
                     "https://s3.example/file.jar", "uploads/foo.jar"
@@ -1106,10 +1113,9 @@ class TestDownloadToStorage(TestCase):
         mock_get.side_effect = requests.ConnectionError(
             "connection refused at " + secret_url
         )
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage() as storage_client:
             with self.assertRaises(HttpClientError) as ec:
                 client.download_to_storage(secret_url, "uploads/foo.jar")
 
@@ -1132,10 +1138,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_no_auth_default_omits_authorization_header(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
 
         sent_headers = mock_get.call_args.kwargs["headers"]
@@ -1144,10 +1149,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_no_auth_false_attaches_authorization_header(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage(
                 "https://api.example/file",
                 "uploads/foo.jar",
@@ -1160,10 +1164,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_allow_redirects_false_passed_to_requests(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
 
         self.assertFalse(mock_get.call_args.kwargs["allow_redirects"])
@@ -1172,10 +1175,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_additional_headers_merged(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage(
                 "https://s3.example/file.jar",
                 "uploads/foo.jar",
@@ -1187,10 +1189,9 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_default_timeout_is_300_seconds(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(credentials={"connect_args": {}})
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
 
         self.assertEqual(300, mock_get.call_args.kwargs["timeout"])
@@ -1198,12 +1199,11 @@ class TestDownloadToStorage(TestCase):
     @patch("requests.get")
     def test_ssl_verify_passed_through(self, mock_get):
         mock_get.return_value = self._make_response(chunks=[b"data"])
-        storage_client, ctx = self._patched_storage()
 
         client = HttpProxyClient(
             credentials={"connect_args": {"ssl_verify": "/path/to/ca.pem"}}
         )
-        with ctx:
+        with self._patched_storage():
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
 
         self.assertEqual("/path/to/ca.pem", mock_get.call_args.kwargs["verify"])
@@ -1222,7 +1222,7 @@ class TestDownloadToStorage(TestCase):
 
         client = HttpProxyClient(credentials={"connect_args": {}})
         with patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
         ):
             with self.assertRaises(RuntimeError):
@@ -1253,7 +1253,7 @@ class TestDownloadToStorage(TestCase):
             credentials={"connect_args": {}}, platform=PLATFORM_AWS
         )
         with patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
         ) as mock_factory:
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
@@ -1271,7 +1271,7 @@ class TestDownloadToStorage(TestCase):
 
         client = HttpProxyClient(credentials={"connect_args": {}})
         with patch(
-            "apollo.integrations.storage.factory.get_storage_client",
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
             return_value=storage_client,
         ) as mock_factory:
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -683,6 +683,10 @@ class TestDownloadBytesUrlSafety(TestCase):
         resp.status_code = status_code
         resp.headers = headers or {}
         resp.iter_content.return_value = iter(chunks if chunks is not None else [b""])
+        # Match real requests.Response context-manager behavior so callers using
+        # `with response:` see the same object inside the block.
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
         if status_code >= 400:
             resp.raise_for_status.side_effect = HTTPError(
                 f"{status_code}", response=resp
@@ -775,6 +779,131 @@ class TestDownloadBytesUrlSafety(TestCase):
         # Error message must not echo the Location URL — it could itself point
         # at an internal/sensitive host.
         self.assertNotIn("attacker.example", str(ctx.exception))
+
+
+class TestOpenDownloadResponse(TestCase):
+    """Direct contract tests for HttpProxyClient._open_download_response.
+
+    The helper is the single source of truth for SSRF / redirect / status
+    guards used by both download_bytes and download_to_storage. The consumer
+    tests cover the happy path; this class pins (a) op_label plumbing into
+    error messages and (b) the connection is closed on every error-exit path.
+    """
+
+    def _make_response(self, status_code: int) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = {}
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
+        if 400 <= status_code < 600:
+            resp.raise_for_status.side_effect = HTTPError(
+                f"{status_code}", response=resp
+            )
+        else:
+            resp.raise_for_status.return_value = None
+        return resp
+
+    def _client(self) -> HttpProxyClient:
+        return HttpProxyClient(credentials={"connect_args": {}})
+
+    @patch("requests.get")
+    def test_3xx_closes_response_and_raises_with_op_label(self, mock_get):
+        resp = self._make_response(302)
+        mock_get.return_value = resp
+
+        with self.assertRaises(HttpClientError) as ctx:
+            with self._client()._open_download_response(
+                "https://s3.example/file",
+                timeout=30,
+                no_auth=True,
+                additional_headers=None,
+                op_label="custom_op",
+            ):
+                self.fail("body must not run on 3xx")
+
+        self.assertIn("custom_op", str(ctx.exception))
+        self.assertIn("302", str(ctx.exception))
+        resp.close.assert_called_once()
+
+    @patch("requests.get")
+    def test_4xx_closes_response_and_raises_http_client_error(self, mock_get):
+        resp = self._make_response(404)
+        mock_get.return_value = resp
+
+        with self.assertRaises(HttpClientError) as ctx:
+            with self._client()._open_download_response(
+                "https://s3.example/file",
+                timeout=30,
+                no_auth=True,
+                additional_headers=None,
+                op_label="custom_op",
+            ):
+                self.fail("body must not run on 4xx")
+
+        self.assertIn("custom_op", str(ctx.exception))
+        self.assertIn("404", str(ctx.exception))
+        resp.close.assert_called_once()
+
+    @patch("requests.get")
+    def test_5xx_closes_response_and_raises_http_error(self, mock_get):
+        resp = self._make_response(503)
+        mock_get.return_value = resp
+
+        with self.assertRaises(HTTPError) as ctx:
+            with self._client()._open_download_response(
+                "https://s3.example/file",
+                timeout=30,
+                no_auth=True,
+                additional_headers=None,
+                op_label="custom_op",
+            ):
+                self.fail("body must not run on 5xx")
+
+        self.assertIn("custom_op", str(ctx.exception))
+        self.assertIn("503", str(ctx.exception))
+        resp.close.assert_called_once()
+
+    @patch("requests.get")
+    def test_transport_error_raises_with_op_label_no_url(self, mock_get):
+        mock_get.side_effect = requests.ConnectionError(
+            "dns lookup failed for secret-host"
+        )
+
+        with self.assertRaises(HttpClientError) as ctx:
+            with self._client()._open_download_response(
+                "https://presigned.example/SECRET-TOKEN",
+                timeout=30,
+                no_auth=True,
+                additional_headers=None,
+                op_label="custom_op",
+            ):
+                self.fail("body must not run on transport error")
+
+        msg = str(ctx.exception)
+        self.assertIn("custom_op", msg)
+        self.assertIn("ConnectionError", msg)
+        # URL (and any pre-signed secret it carries) must not leak into the message.
+        self.assertNotIn("SECRET-TOKEN", msg)
+        self.assertNotIn("presigned.example", msg)
+
+    @patch("requests.get")
+    def test_success_closes_response_on_context_exit(self, mock_get):
+        resp = self._make_response(200)
+        mock_get.return_value = resp
+
+        with self._client()._open_download_response(
+            "https://s3.example/file",
+            timeout=30,
+            no_auth=True,
+            additional_headers=None,
+            op_label="custom_op",
+        ) as got:
+            self.assertIs(got, resp)
+            resp.close.assert_not_called()
+
+        # Generator's `finally` runs response.close() on context exit.
+        resp.close.assert_called_once()
 
 
 class TestMulesoftAgentEndToEnd(TestCase):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1406,3 +1406,29 @@ class TestDownloadToStorage(TestCase):
             client.download_to_storage("https://s3.example/file.jar", "uploads/foo.jar")
 
         mock_factory.assert_called_once_with(platform=None)
+
+    @patch("requests.get")
+    def test_storage_client_cached_across_multiple_downloads(self, mock_get):
+        """get_storage_client is invoked once per HttpProxyClient instance.
+        Repeated download_to_storage calls reuse the same SDK client — boto3 /
+        google-cloud-storage / azure-storage-blob construction is non-trivial
+        (credential resolution, connection-pool setup), and a DC fetching
+        multiple JARs in a loop should not pay it per file.
+        """
+        mock_get.return_value = self._make_response(chunks=[b"data"])
+        storage_client = MagicMock()
+        storage_client.upload_file = MagicMock()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with patch(
+            "apollo.integrations.http.http_proxy_client.get_storage_client",
+            return_value=storage_client,
+        ) as mock_factory:
+            client.download_to_storage("https://s3.example/a.jar", "uploads/a.jar")
+            mock_get.return_value = self._make_response(chunks=[b"data"])
+            client.download_to_storage("https://s3.example/b.jar", "uploads/b.jar")
+            mock_get.return_value = self._make_response(chunks=[b"data"])
+            client.download_to_storage("https://s3.example/c.jar", "uploads/c.jar")
+
+        self.assertEqual(1, mock_factory.call_count)
+        self.assertEqual(3, storage_client.upload_file.call_count)

--- a/tests/test_proxy_client_factory.py
+++ b/tests/test_proxy_client_factory.py
@@ -93,3 +93,34 @@ class TestGetNativeConnectionTypes(TestCase):
     def test_returns_strings(self):
         result = get_native_connection_types()
         self.assertTrue(all(isinstance(t, str) for t in result))
+
+
+class TestHttpProxyClientFactoryWiring(TestCase):
+    """Lock in that `_get_proxy_client_http` forwards `platform` to
+    `HttpProxyClient`. Required for `download_to_storage` to use the
+    platform-default storage backend (S3/GCS/Azure) when MCD_STORAGE
+    is unset — which is the production deployment shape."""
+
+    def test_http_factory_forwards_platform_to_client(self):
+        from apollo.agent.proxy_client_factory import _get_proxy_client_http
+        from apollo.common.agent.constants import PLATFORM_AWS
+
+        client = _get_proxy_client_http(
+            credentials={"connect_args": {}}, platform=PLATFORM_AWS
+        )
+        self.assertEqual(PLATFORM_AWS, client._platform)
+
+    def test_http_factory_forwards_platform_for_mulesoft(self):
+        # mulesoft routes through the same _get_proxy_client_http; explicit
+        # coverage that the dispatch keeps the platform wired.
+        from apollo.agent.proxy_client_factory import (
+            _CLIENT_FACTORY_MAPPING,
+            _get_proxy_client_http,
+        )
+        from apollo.common.agent.constants import PLATFORM_AZURE
+
+        self.assertIs(_CLIENT_FACTORY_MAPPING["mulesoft"], _get_proxy_client_http)
+        client = _CLIENT_FACTORY_MAPPING["mulesoft"](
+            {"connect_args": {}}, platform=PLATFORM_AZURE
+        )
+        self.assertEqual(PLATFORM_AZURE, client._platform)

--- a/tests/test_storage_factory.py
+++ b/tests/test_storage_factory.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 from apollo.common.agent.constants import (
     PLATFORM_AWS,
+    PLATFORM_AWS_GENERIC,
     PLATFORM_AZURE,
     PLATFORM_GCP,
     STORAGE_TYPE_AZURE,
@@ -19,23 +20,19 @@ from apollo.common.agent.constants import (
     STORAGE_TYPE_S3_COMPATIBLE,
 )
 from apollo.common.agent.env_vars import (
+    STORAGE_PREFIX_DEFAULT_VALUE,
     STORAGE_PREFIX_ENV_VAR,
     STORAGE_TYPE_ENV_VAR,
 )
 from apollo.common.agent.models import AgentConfigurationError
-from apollo.integrations.storage import factory as factory_module
 from apollo.integrations.storage.factory import get_storage_client
 
-
-def _patched_clients(stub: MagicMock) -> dict:
-    """Map every storage type to the same MagicMock — so tests can assert which
-    type was selected by inspecting the kwargs the mock was called with."""
-    return {
-        STORAGE_TYPE_AZURE: stub,
-        STORAGE_TYPE_GCS: stub,
-        STORAGE_TYPE_S3: stub,
-        STORAGE_TYPE_S3_COMPATIBLE: stub,
-    }
+_S3_PATH = "apollo.integrations.s3.s3_reader_writer.S3ReaderWriter"
+_GCS_PATH = "apollo.integrations.gcs.gcs_reader_writer.GcsReaderWriter"
+_AZURE_PATH = (
+    "apollo.integrations.azure_blob.azure_blob_reader_writer.AzureBlobReaderWriter"
+)
+_S3_COMPAT_PATH = "apollo.integrations.s3_compatible.s3_compatible_reader_writer.S3CompatibleReaderWriter"
 
 
 class TestGetStorageClient(TestCase):
@@ -53,61 +50,42 @@ class TestGetStorageClient(TestCase):
             else:
                 os.environ[k] = v
 
-    def _patch_clients_with_stub(self):
-        stub = MagicMock(name="storage_client_class")
-        return stub, patch.dict(
-            factory_module._STORAGE_CLIENTS, _patched_clients(stub), clear=True
-        )
-
     def test_env_var_wins_over_platform_default(self):
         os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3_COMPATIBLE
-        stub, ctx = self._patch_clients_with_stub()
-        with ctx:
-            get_storage_client(platform=PLATFORM_AZURE)  # would default to azure
-        # The env var pin (S3_COMPATIBLE) wins over the platform default (Azure).
-        # All four classes are the same stub, so we assert it was called once,
-        # not which class.
-        self.assertEqual(1, stub.call_count)
+        s3_compat_stub = MagicMock(name="s3-compat")
+        azure_stub = MagicMock(name="azure")
+        with patch(
+            _S3_COMPAT_PATH,
+            new=s3_compat_stub,
+        ), patch(
+            _AZURE_PATH,
+            new=azure_stub,
+        ):
+            get_storage_client(platform=PLATFORM_AZURE)  # would default to Azure
+        self.assertEqual(1, s3_compat_stub.call_count)
+        self.assertEqual(0, azure_stub.call_count)
 
     def test_platform_default_aws(self):
-        stub, ctx = self._patch_clients_with_stub()
-        with patch.dict(
-            factory_module._STORAGE_CLIENTS,
-            {
-                STORAGE_TYPE_S3: stub,
-                STORAGE_TYPE_GCS: MagicMock(),
-                STORAGE_TYPE_AZURE: MagicMock(),
-            },
-            clear=True,
-        ):
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub), patch(_GCS_PATH), patch(_AZURE_PATH):
             get_storage_client(platform=PLATFORM_AWS)
-        self.assertEqual(1, stub.call_count)
+        self.assertEqual(1, s3_stub.call_count)
+
+    def test_platform_default_aws_generic(self):
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub):
+            get_storage_client(platform=PLATFORM_AWS_GENERIC)
+        self.assertEqual(1, s3_stub.call_count)
 
     def test_platform_default_gcp(self):
         gcs_stub = MagicMock(name="gcs")
-        with patch.dict(
-            factory_module._STORAGE_CLIENTS,
-            {
-                STORAGE_TYPE_GCS: gcs_stub,
-                STORAGE_TYPE_S3: MagicMock(),
-                STORAGE_TYPE_AZURE: MagicMock(),
-            },
-            clear=True,
-        ):
+        with patch(_GCS_PATH, new=gcs_stub), patch(_S3_PATH), patch(_AZURE_PATH):
             get_storage_client(platform=PLATFORM_GCP)
         self.assertEqual(1, gcs_stub.call_count)
 
     def test_platform_default_azure(self):
         az_stub = MagicMock(name="azure")
-        with patch.dict(
-            factory_module._STORAGE_CLIENTS,
-            {
-                STORAGE_TYPE_AZURE: az_stub,
-                STORAGE_TYPE_S3: MagicMock(),
-                STORAGE_TYPE_GCS: MagicMock(),
-            },
-            clear=True,
-        ):
+        with patch(_AZURE_PATH, new=az_stub), patch(_S3_PATH), patch(_GCS_PATH):
             get_storage_client(platform=PLATFORM_AZURE)
         self.assertEqual(1, az_stub.call_count)
 
@@ -125,23 +103,31 @@ class TestGetStorageClient(TestCase):
     def test_prefix_env_var_passed_through(self):
         os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
         os.environ[STORAGE_PREFIX_ENV_VAR] = "my-prefix"
-        stub, ctx = self._patch_clients_with_stub()
-        with ctx:
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub):
             get_storage_client()
-        stub.assert_called_once_with(prefix="my-prefix")
+        s3_stub.assert_called_once_with(prefix="my-prefix")
 
     def test_empty_prefix_collapses_to_none(self):
         os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
         os.environ[STORAGE_PREFIX_ENV_VAR] = ""
-        stub, ctx = self._patch_clients_with_stub()
-        with ctx:
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub):
             get_storage_client()
-        stub.assert_called_once_with(prefix=None)
+        s3_stub.assert_called_once_with(prefix=None)
 
     def test_slash_prefix_collapses_to_none(self):
         os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
         os.environ[STORAGE_PREFIX_ENV_VAR] = "/"
-        stub, ctx = self._patch_clients_with_stub()
-        with ctx:
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub):
             get_storage_client()
-        stub.assert_called_once_with(prefix=None)
+        s3_stub.assert_called_once_with(prefix=None)
+
+    def test_default_prefix_used_when_env_var_unset(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
+        # STORAGE_PREFIX_ENV_VAR was stripped in setUp — should default to "mcd".
+        s3_stub = MagicMock(name="s3")
+        with patch(_S3_PATH, new=s3_stub):
+            get_storage_client()
+        s3_stub.assert_called_once_with(prefix=STORAGE_PREFIX_DEFAULT_VALUE)

--- a/tests/test_storage_factory.py
+++ b/tests/test_storage_factory.py
@@ -1,0 +1,147 @@
+"""Tests for the storage client factory.
+
+The factory is consumed by `StorageProxyClient` (which previously inlined the
+selection logic) and by `HttpProxyClient.download_to_storage`. These tests
+exercise the resolution rules without instantiating real cloud SDK clients.
+"""
+
+import os
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from apollo.common.agent.constants import (
+    PLATFORM_AWS,
+    PLATFORM_AZURE,
+    PLATFORM_GCP,
+    STORAGE_TYPE_AZURE,
+    STORAGE_TYPE_GCS,
+    STORAGE_TYPE_S3,
+    STORAGE_TYPE_S3_COMPATIBLE,
+)
+from apollo.common.agent.env_vars import (
+    STORAGE_PREFIX_ENV_VAR,
+    STORAGE_TYPE_ENV_VAR,
+)
+from apollo.common.agent.models import AgentConfigurationError
+from apollo.integrations.storage import factory as factory_module
+from apollo.integrations.storage.factory import get_storage_client
+
+
+def _patched_clients(stub: MagicMock) -> dict:
+    """Map every storage type to the same MagicMock — so tests can assert which
+    type was selected by inspecting the kwargs the mock was called with."""
+    return {
+        STORAGE_TYPE_AZURE: stub,
+        STORAGE_TYPE_GCS: stub,
+        STORAGE_TYPE_S3: stub,
+        STORAGE_TYPE_S3_COMPATIBLE: stub,
+    }
+
+
+class TestGetStorageClient(TestCase):
+    def setUp(self) -> None:
+        # Strip storage env vars so each test sets exactly what it intends.
+        self._saved_env = {
+            k: os.environ.pop(k, None)
+            for k in (STORAGE_TYPE_ENV_VAR, STORAGE_PREFIX_ENV_VAR)
+        }
+
+    def tearDown(self) -> None:
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def _patch_clients_with_stub(self):
+        stub = MagicMock(name="storage_client_class")
+        return stub, patch.dict(
+            factory_module._STORAGE_CLIENTS, _patched_clients(stub), clear=True
+        )
+
+    def test_env_var_wins_over_platform_default(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3_COMPATIBLE
+        stub, ctx = self._patch_clients_with_stub()
+        with ctx:
+            get_storage_client(platform=PLATFORM_AZURE)  # would default to azure
+        # The env var pin (S3_COMPATIBLE) wins over the platform default (Azure).
+        # All four classes are the same stub, so we assert it was called once,
+        # not which class.
+        self.assertEqual(1, stub.call_count)
+
+    def test_platform_default_aws(self):
+        stub, ctx = self._patch_clients_with_stub()
+        with patch.dict(
+            factory_module._STORAGE_CLIENTS,
+            {
+                STORAGE_TYPE_S3: stub,
+                STORAGE_TYPE_GCS: MagicMock(),
+                STORAGE_TYPE_AZURE: MagicMock(),
+            },
+            clear=True,
+        ):
+            get_storage_client(platform=PLATFORM_AWS)
+        self.assertEqual(1, stub.call_count)
+
+    def test_platform_default_gcp(self):
+        gcs_stub = MagicMock(name="gcs")
+        with patch.dict(
+            factory_module._STORAGE_CLIENTS,
+            {
+                STORAGE_TYPE_GCS: gcs_stub,
+                STORAGE_TYPE_S3: MagicMock(),
+                STORAGE_TYPE_AZURE: MagicMock(),
+            },
+            clear=True,
+        ):
+            get_storage_client(platform=PLATFORM_GCP)
+        self.assertEqual(1, gcs_stub.call_count)
+
+    def test_platform_default_azure(self):
+        az_stub = MagicMock(name="azure")
+        with patch.dict(
+            factory_module._STORAGE_CLIENTS,
+            {
+                STORAGE_TYPE_AZURE: az_stub,
+                STORAGE_TYPE_S3: MagicMock(),
+                STORAGE_TYPE_GCS: MagicMock(),
+            },
+            clear=True,
+        ):
+            get_storage_client(platform=PLATFORM_AZURE)
+        self.assertEqual(1, az_stub.call_count)
+
+    def test_no_env_no_platform_raises(self):
+        with self.assertRaises(AgentConfigurationError) as ctx:
+            get_storage_client()
+        self.assertIn(STORAGE_TYPE_ENV_VAR, str(ctx.exception))
+
+    def test_unknown_storage_type_raises(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = "unknown-storage-backend"
+        with self.assertRaises(AgentConfigurationError) as ctx:
+            get_storage_client()
+        self.assertIn("unknown-storage-backend", str(ctx.exception))
+
+    def test_prefix_env_var_passed_through(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
+        os.environ[STORAGE_PREFIX_ENV_VAR] = "my-prefix"
+        stub, ctx = self._patch_clients_with_stub()
+        with ctx:
+            get_storage_client()
+        stub.assert_called_once_with(prefix="my-prefix")
+
+    def test_empty_prefix_collapses_to_none(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
+        os.environ[STORAGE_PREFIX_ENV_VAR] = ""
+        stub, ctx = self._patch_clients_with_stub()
+        with ctx:
+            get_storage_client()
+        stub.assert_called_once_with(prefix=None)
+
+    def test_slash_prefix_collapses_to_none(self):
+        os.environ[STORAGE_TYPE_ENV_VAR] = STORAGE_TYPE_S3
+        os.environ[STORAGE_PREFIX_ENV_VAR] = "/"
+        stub, ctx = self._patch_clients_with_stub()
+        with ctx:
+            get_storage_client()
+        stub.assert_called_once_with(prefix=None)


### PR DESCRIPTION
[YET-1164](https://linear.app/montecarlodata/issue/YET-1164/stream-large-downloads-directly-to-storage-on-apollo-agent) — stacks on [#284](https://github.com/monte-carlo-data/apollo-agent/pull/284).

## Summary

`HttpProxyClient.download_bytes` accumulates the full response in memory before returning. That's fine for `/accounts/api/me`-style smoke calls; it's not fine for MuleSoft Mule-application JARs which can exceed 100 MiB.

This PR adds a sibling method `download_to_storage(url, storage_key, max_bytes=...)` that streams directly into the agent's existing storage backend (S3 / GCS / Azure Blob / S3-compatible). One 8 KiB chunk lives in memory at any time; bytes are spooled to a tempfile as they arrive, then handed to `BaseStorageClient.upload_file`, then the tempfile is deleted. Returns the `storage_key` so the DC consumer can read it back later.

Stacked on top of #284 (YET-1131). PR base is the YET-1131 branch — auto-retargets to `main` once #284 merges.

## What this enables

- **DC fetches a 100+ MiB MuleSoft JAR with bounded memory.** The DC sends `do_request_relative(\".../jarUrl\")` to learn the pre-signed URL, then `download_to_storage(presigned_url, \"path/in/bucket\")` to stream it into MC-side storage with a `max_bytes=200_000_000` cap. From there the JAR is processed by downstream services without re-touching the agent.
- **Same defense surface as `download_bytes`.** The new method calls `_assert_safe_download_url` (HTTPS-only + reject non-public IP literals incl. multicast + reject `localhost`), passes `allow_redirects=False`, explicitly rejects 3xx, releases the connection on every exit path (\`with response:\`), strips the URL from error messages (pre-signed URLs contain a signed secret), and cleans up the tempfile in a `finally` even when storage upload itself raises.
- **No new dependency on storage at HttpProxyClient construction time.** The platform→storage-class selection is factored out of `StorageProxyClient.__init__` into a new `apollo/integrations/storage/factory.py` helper, so the storage backend is grabbed only when `download_to_storage` is actually called. `StorageProxyClient` continues to behave identically.

## Key decisions

- **Tempfile spool, not direct streaming-to-S3.** `BaseStorageClient.write` requires the full payload in memory; `upload_file` writes a local file. The tempfile path is the only one that works across all four backends today. Lifting a streaming primitive to the abstraction is reasonable future work — gated on a real performance need on a specific backend, not pre-emptive.
- **Lives on `HttpProxyClient`, not `StorageProxyClient`.** Keeps the HTTP transport surface coherent with the rest of the connector machinery; the storage destination is just where the bytes land.
- **Default `no_auth=True`.** Matches `download_bytes` — the motivating use case is pre-signed URLs that carry the signature in the query string. Callers wanting a Bearer-attached download must opt in.
- **Default timeout 300s** (vs. `download_bytes`'s 120s). 100+ MiB at typical network speeds doesn't always fit in 2 minutes.
- **Late import of `get_storage_client` inside the method.** Avoids pulling in the cloud SDK chain at `HttpProxyClient` import time — the existing \`http\` connection_type doesn't need any of it.

## Out of scope

- Multipart streaming directly to S3 (would be backend-specific). Lift if a single backend ever needs true streaming.
- DC-side consumer wiring (separate ticket).
- A live integration test against a real cloud bucket — covered by mocking `BaseStorageClient.upload_file` with a side-effect that reads the tempfile and asserts the streamed bytes.

## Test plan

- [x] 17 new \`TestDownloadToStorage\` cases (happy path with tempfile-content assertion, max_bytes mid-stream cleanup, 4xx/5xx/3xx/ConnectionError → no upload + tempfile cleaned, SSRF guards, no_auth default + override, allow_redirects=False, ssl_verify, additional_headers, default timeout, tempfile-cleanup-when-upload-raises)
- [x] 9 new \`TestGetStorageClient\` cases (env-var wins; platform fallbacks for AWS/GCP/Azure; missing both raises; unknown backend raises; prefix env var honored; empty / \"/\" prefix collapses)
- [x] Existing \`StorageProxyClient\` tests pass unchanged (refactor is behavior-preserving)
- [x] All other existing tests pass (558 total, black + pyright clean)

## Notes

- Plan + review docs at \`.work/yet-1164-download-to-storage/\` (gitignored).
- The 3 \`tests/test_aws_ca_bundle.py\` failures predate both this branch and \`fbenitez/yet-1131-...\` — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)