### PR TITLE
fix(sup-373): preserve outer credential siblings when CtpRegistry unwraps connect_args

### DIFF
--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -88,12 +88,12 @@ class CtpRegistry:
                 **registered.connect_args_defaults,
                 **config.connect_args_defaults,
             }
-        raw_or_connect_args = credentials.get(_ATTR_CONNECT_ARGS, credentials)
-        if not isinstance(raw_or_connect_args, dict):
+        pipeline_input = _build_pipeline_input(credentials)
+        if pipeline_input is None:
             return credentials
         return {
             _ATTR_CONNECT_ARGS: CtpPipeline().execute(
-                config, raw_or_connect_args, context=context or {}
+                config, pipeline_input, context=context or {}
             )
         }
 
@@ -119,15 +119,36 @@ class CtpRegistry:
                 stage="registry",
                 message=f"No CTP config registered for '{connection_type}'. Call CtpRegistry.get() before resolve().",
             )
-        # Unwrap pre-shaped connect_args so both flat and DC-pre-shaped credentials
-        # follow the same transform path through the pipeline.
-        # If connect_args is not a dict (e.g. a pre-built ODBC string), pass through
-        # unchanged — the pipeline cannot interpret non-dict credentials.
-        raw_or_connect_args = credentials.get(_ATTR_CONNECT_ARGS, credentials)
-        if not isinstance(raw_or_connect_args, dict):
+        pipeline_input = _build_pipeline_input(credentials)
+        if pipeline_input is None:
             return credentials
         return {
             _ATTR_CONNECT_ARGS: CtpPipeline().execute(
-                config, raw_or_connect_args, context=context or {}
+                config, pipeline_input, context=context or {}
             )
         }
+
+
+def _build_pipeline_input(credentials: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the dict to feed the CTP pipeline, or None if credentials cannot
+    be processed (e.g. pre-built ODBC string).
+
+    For DC pre-shaped credentials (a ``connect_args`` dict alongside other
+    credential fields like ``ssl_options``), merge the outer fields with the
+    inner ``connect_args`` so the pipeline sees the full credential picture.
+    Inner ``connect_args`` keys take precedence — they're driver-direct and
+    have been explicitly named.
+
+    SUP-373: without this merge, the data-collector's mysql agent path
+    (clients/plugins/plugin_mysql.py:48-51) sends ``ssl_options`` as a
+    sibling of ``connect_args``; the previous unwrap discarded it, no SSL
+    context was built, and pymysql connected without TLS — MySQL with
+    ``require_secure_transport=ON`` rejected with error 3159.
+    """
+    inner = credentials.get(_ATTR_CONNECT_ARGS)
+    if inner is None:
+        return credentials
+    if not isinstance(inner, dict):
+        return None
+    outer_siblings = {k: v for k, v in credentials.items() if k != _ATTR_CONNECT_ARGS}
+    return {**outer_siblings, **inner}

--- a/tests/ctp/test_mysql_ctp.py
+++ b/tests/ctp/test_mysql_ctp.py
@@ -131,3 +131,11 @@ class TestMysqlCtp(TestCase):
             ssl_module.SSLContext,
             f"ssl is set but not an SSLContext: {connect_args['ssl']!r}",
         )
+
+        # F8 follow-up: explicitly verify inner connect_args fields survive the merge.
+        # Without these assertions a regression that drops the inner dict would still
+        # pass the SSL check above (ssl_options would still merge in from outer).
+        self.assertEqual("db.example.com", connect_args["host"])
+        self.assertEqual(3306, connect_args["port"])
+        self.assertEqual("admin", connect_args["user"])
+        self.assertEqual("secret", connect_args["password"])

--- a/tests/ctp/test_mysql_ctp.py
+++ b/tests/ctp/test_mysql_ctp.py
@@ -1,4 +1,5 @@
 import os
+import ssl as ssl_module
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -78,3 +79,53 @@ class TestMysqlCtp(TestCase):
 
         self.assertIn("ssl", result)
         self.assertIsInstance(result["ssl"], ssl.SSLContext)
+
+    @patch("ssl.SSLContext.load_verify_locations")
+    def test_resolve_mysql_dc_pre_shaped_credentials_with_outer_ssl_options(self, _mock_load):
+        """SUP-373: this is the credentials shape the data-collector actually sends to apollo
+        for the mysql agent path (see DC clients/plugins/plugin_mysql.py:48-51):
+
+            {
+                "connect_args": {host, port, user, password},   # wrapped
+                "ssl_options": {"ca_data": "..."},                # OUTER level, sibling to connect_args
+            }
+
+        CtpRegistry.resolve unwraps connect_args (registry.py:91, 126) and runs the
+        pipeline with only the inner dict. If this test fails, ssl_options at the outer
+        level is discarded by the unwrap — the mysql CTP's `when="raw.ssl_options is
+        defined"` doesn't fire, connect_args["ssl"] never gets set, pymysql connects
+        without TLS, and MySQL with require_secure_transport=ON returns error 3159.
+
+        This is PennyMac's failure mode.
+        """
+        dc_pre_shaped_credentials = {
+            "connect_args": {
+                "host": "db.example.com",
+                "port": 3306,
+                "user": "admin",
+                "password": "secret",
+            },
+            "ssl_options": {
+                "ca_data": "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"
+            },
+        }
+
+        resolved = CtpRegistry.resolve("mysql", dc_pre_shaped_credentials)
+
+        # The post-resolve credentials must contain a usable ssl context for pymysql.
+        # If the unwrap discarded the outer ssl_options, this assertion will fail.
+        self.assertIn("connect_args", resolved)
+        connect_args = resolved["connect_args"]
+        self.assertIn(
+            "ssl",
+            connect_args,
+            "SUP-373: outer ssl_options got dropped by CtpRegistry.resolve's "
+            "connect_args unwrap. The DC sends ssl_options as a SIBLING of "
+            "connect_args, not nested inside it. The unwrap at registry.py:91/126 "
+            "discards everything outside connect_args before the pipeline runs.",
+        )
+        self.assertIsInstance(
+            connect_args["ssl"],
+            ssl_module.SSLContext,
+            f"ssl is set but not an SSLContext: {connect_args['ssl']!r}",
+        )

--- a/tests/ctp/test_mysql_ctp.py
+++ b/tests/ctp/test_mysql_ctp.py
@@ -81,7 +81,9 @@ class TestMysqlCtp(TestCase):
         self.assertIsInstance(result["ssl"], ssl.SSLContext)
 
     @patch("ssl.SSLContext.load_verify_locations")
-    def test_resolve_mysql_dc_pre_shaped_credentials_with_outer_ssl_options(self, _mock_load):
+    def test_resolve_mysql_dc_pre_shaped_credentials_with_outer_ssl_options(
+        self, _mock_load
+    ):
         """SUP-373: this is the credentials shape the data-collector actually sends to apollo
         for the mysql agent path (see DC clients/plugins/plugin_mysql.py:48-51):
 

--- a/tests/ctp/test_registry.py
+++ b/tests/ctp/test_registry.py
@@ -57,6 +57,75 @@ class TestNonDictConnectArgsPassthrough(TestCase):
         self.assertIs(credentials, result)
 
 
+class TestSiblingMergePrecedence(TestCase):
+    """SUP-373 follow-up: lock in the inner-wins precedence rule of _build_pipeline_input.
+
+    On collision between an outer-sibling field and an inner connect_args field, the
+    inner value MUST win — driver-direct values are most specific. A refactor flipping
+    the merge order (e.g. ``{**inner, **outer}``) would silently change pipeline-visible
+    values for any DC payload that includes overlap, with no other test catching it.
+    """
+
+    def test_inner_connect_args_wins_on_collision(self):
+        credentials = {
+            "connect_args": {
+                "host": "INNER_HOST",
+                "port": 3306,
+                "user": "inner_user",
+                "password": "inner_password",
+            },
+            # Sibling outer fields with the same names — must be shadowed by inner.
+            "host": "OUTER_HOST",
+            "port": 9999,
+            "user": "outer_user",
+            "password": "outer_password",
+        }
+
+        resolved = CtpRegistry.resolve("mysql", credentials)
+        connect_args = resolved["connect_args"]
+
+        self.assertEqual("INNER_HOST", connect_args["host"])
+        self.assertEqual(3306, connect_args["port"])
+        self.assertEqual("inner_user", connect_args["user"])
+        self.assertEqual("inner_password", connect_args["password"])
+
+
+class TestEmptyAndNoneConnectArgs(TestCase):
+    """SUP-373 follow-up: pin the behavior of degenerate ``connect_args`` shapes.
+
+    Pre-PR, ``connect_args=None`` was returned unchanged (pipeline skipped) — which
+    crashed downstream proxy clients that expected a dict. ``connect_args={}`` ran
+    the pipeline against an empty dict, producing empty output. Post-PR, both shapes
+    are treated as 'no usable inner connect_args' and the pipeline runs against the
+    outer/flat fields, which is more useful and matches the flat-credentials path.
+    """
+
+    _FLAT_FIELDS = {
+        "host": "db.example.com",
+        "port": 3306,
+        "user": "admin",
+        "password": "secret",
+    }
+
+    def test_connect_args_none_falls_back_to_outer_fields(self):
+        credentials = {"connect_args": None, **self._FLAT_FIELDS}
+        resolved = CtpRegistry.resolve("mysql", credentials)
+        connect_args = resolved["connect_args"]
+        self.assertEqual("db.example.com", connect_args["host"])
+        self.assertEqual(3306, connect_args["port"])
+        self.assertEqual("admin", connect_args["user"])
+        self.assertEqual("secret", connect_args["password"])
+
+    def test_connect_args_empty_dict_falls_back_to_outer_fields(self):
+        credentials = {"connect_args": {}, **self._FLAT_FIELDS}
+        resolved = CtpRegistry.resolve("mysql", credentials)
+        connect_args = resolved["connect_args"]
+        self.assertEqual("db.example.com", connect_args["host"])
+        self.assertEqual(3306, connect_args["port"])
+        self.assertEqual("admin", connect_args["user"])
+        self.assertEqual("secret", connect_args["password"])
+
+
 class TestStarburstGalaxyCtp(TestCase):
     def test_starburst_galaxy_registered(self):
         config = CtpRegistry.get("starburst-galaxy")

--- a/tests/test_custom_ctp.py
+++ b/tests/test_custom_ctp.py
@@ -4,6 +4,7 @@
 Uses the databricks-rest connection type as the test vehicle because it has a
 simple CTP (PAT → token) and a well-defined TypedDict output contract.
 """
+
 from unittest import TestCase
 from unittest.mock import create_autospec, patch
 
@@ -198,6 +199,31 @@ class TestCustomCtpSchemaInjection(TestCase):
             _CUSTOM_CTP,
         )
         self.assertIs(credentials, result)
+
+    def test_outer_siblings_merged_with_inner_connect_args(self):
+        """SUP-373 follow-up: resolve_custom mirrors resolve's sibling-merge behavior.
+
+        Outer credential fields are merged with the inner connect_args dict before
+        the custom pipeline runs — so a custom CTP whose mapper references an outer
+        field can read it from DC pre-shaped credentials. Without this symmetry,
+        resolve and resolve_custom would diverge for DC payloads with sibling fields.
+        """
+        credentials = {
+            "connect_args": {"custom_token": _CUSTOM_TOKEN},  # inner
+            "databricks_workspace_url": _WORKSPACE_URL,  # outer sibling
+        }
+
+        result = CtpRegistry.resolve_custom(
+            "databricks-rest",
+            credentials,
+            _CUSTOM_CTP,
+        )
+
+        self.assertIn("connect_args", result)
+        self.assertEqual(_CUSTOM_TOKEN, result["connect_args"]["token"])
+        self.assertEqual(
+            _WORKSPACE_URL, result["connect_args"]["databricks_workspace_url"]
+        )
 
 
 class TestValidateCtp(TestCase):


### PR DESCRIPTION
## Summary

`CtpRegistry.resolve` / `resolve_custom` were unwrapping `connect_args` from the incoming credentials dict and running the CTP pipeline with **only** the inner dict — silently discarding any sibling fields. The data-collector's mysql agent path (`clients/plugins/plugin_mysql.py:48-51`) sends `ssl_options` as a **sibling** of `connect_args`, not nested inside it:

```python
agent_credentials = {
    "connect_args": {host, port, user, password},
    "ssl_options": {"ca_data": "<inline PEM>"},  # sibling — got dropped
}
```

After the unwrap, the pipeline ran on `{host, port, user, password}` only. The mysql CTP's `when="raw.ssl_options is defined"` clause was always False, the SSL transform never fired, `connect_args["ssl"]` was never set, and `pymysql.connect` ran without TLS. MySQL with `require_secure_transport=ON` rejected with `(3159, '... --require_secure_transport=ON.')`.

This is the root cause of [SUP-373](https://linear.app/montecarlodata/issue/SUP-373) — PennyMac's MySQL agent has been failing every 12h since 2026-04-30. Same root cause as [YET-321](https://linear.app/montecarlodata/issue/YET-321) (DB2 RDS SSL via agent), which closes transitively.

## Fix

New `_build_pipeline_input` helper in `apollo/integrations/ctp/registry.py` merges sibling fields with the inner `connect_args` dict before pipeline execution. Inner `connect_args` keys win on collision (driver-direct values are most specific). Non-dict `connect_args` (legacy pre-built ODBC strings) pass through unchanged — the proxy client's own ssl_options handling still works for that path. Both `resolve` and `resolve_custom` go through the helper, so they stay symmetric.

## Blast radius

This change is at the registry layer, so every CTP-registered integration runs through it. Three reasons it's safe:

1. **Inner wins on collision.** `{**outer_siblings, **inner}` means any field already in `connect_args` keeps its existing pipeline-visible value. No change for fields the pipeline already saw.
2. **Legacy ODBC-string path preserved exactly.** When `connect_args` is a non-dict, `_build_pipeline_input` returns `None` and `resolve` returns the original credentials dict unchanged — matching the pre-fix behavior the db2 proxy client (and others) rely on for top-level `ssl_options` handling.
3. **All 444 CTP tests pass** with no regressions across mysql, postgres, snowflake, databricks, informatica (v1 + v2), presto, power_bi, redshift, starburst, db2, oracle, etc.

**Positive blast radius:** the same unwrap-discard pattern was silently breaking ssl_options for every transactional-DB CTP that uses the `when="raw.ssl_options is defined"` pattern (postgres, redshift, starburst-enterprise, starburst-galaxy, db2, http, git). They share the registry-level path; they get fixed too.

**Theoretical risk worth a reviewer's eye:** other `when` clauses across CTPs (`raw.session_id is not defined`, `raw.auth_mode == 'oauth'`, `raw.auth is defined`, etc.) could in principle flip behavior if any DC plugin sends those fields as outer siblings rather than inside `connect_args`. The 444 existing tests cover the realistic shapes for each CTP — but I haven't audited every DC plugin's payload shape against every CTP's `when` clauses. Would value a sanity check from someone who has end-to-end visibility into DC payload shapes for non-mysql CTPs.

## Test plan

- [x] New repro test: `tests/ctp/test_mysql_ctp.py::TestMysqlCtp::test_resolve_mysql_dc_pre_shaped_credentials_with_outer_ssl_options` — exercises `CtpRegistry.resolve("mysql", ...)` with the realistic DC pre-shaped payload, asserts `connect_args["ssl"]` is an `ssl.SSLContext`. Failed before the fix; passes after.
- [x] Full CTP suite: `pytest tests/ctp/` → 444 passed, no regressions.
- [x] Black + pyright clean on changed files.
- [ ] Post-merge: verify PennyMac (account `959c52ae-f98b-47b6-b51c-ff40cdc2224b`) — once the apollo build with this fix deploys, the 12h `(3159, ...)` failure cycle on connection 128437 should stop. No customer action needed; their persisted credentials are correctly shaped.

## Coordination

Out of scope for this PR but locally on `nobeirn/sup-373-ssl-ca-nesting` in `monolith-django` and `data-collector` are diagnostic/regression tests that pin the working contract at each layer (monolith persistence and DC plugin forwarding both produce the right shape — the bug is purely apollo-side). Holding those locally for now to keep this PR focused on the fix; will follow up separately if we want the cross-layer regression coverage in CI.

## Context

Linear ticket has the full 8-step end-to-end credential trace, Datadog evidence for PennyMac's failure cycle, customer DB record details, and the affected-scope table covering mysql, oracle, mariadb, db2, and starburst-enterprise: https://linear.app/montecarlodata/issue/SUP-373

Original ticket pinned the bug to CLI-side nesting of `ssl_options` under `connection_settings`. That hypothesis was empirically refuted — monolith's GraphQL schema for transactional DBs requires the nesting, and a CLI-only fix would have regressed production. The actual bug is downstream of monolith persistence, in apollo's CTP registry — what this PR addresses.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>