### PR TITLE
feat(http): add probe_response_headers Range-GET op for change-detection (YET-1234)

### DIFF
--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -405,6 +405,70 @@ class HttpProxyClient(BaseProxyClient):
         ) as response:
             return dict(response.headers)
 
+    def probe_response_headers(
+        self,
+        url: str,
+        *,
+        range_spec: str = "bytes=0-0",
+        timeout: int = 60,
+        no_auth: bool = True,
+        additional_headers: Optional[Dict] = None,
+    ) -> Dict[str, str]:
+        """Issue a GET with a ``Range`` header and return only the response
+        headers as a plain dict. The body is discarded on response close.
+
+        Designed as a sibling to ``head_bytes`` for endpoints where HEAD is
+        forbidden. The motivating case is AWS pre-signed URLs, whose
+        signatures are method-bound — a URL signed for GET returns 403 on
+        HEAD. A Range-GET sidesteps that: the signature matches (still a
+        GET) and the response carries the headers the caller cares about
+        (``ETag`` / ``Last-Modified`` / ``Content-Length``) plus a tiny
+        bounded body that the connection-close throws away.
+
+        ``range_spec`` defaults to ``bytes=0-0`` (1 byte). Hosts that
+        honour Range respond ``206 Partial Content``; hosts that don't
+        respond ``200 OK`` with the full body — the connection close
+        still discards it without ever reading more than the headers.
+        Callers can override ``range_spec`` for use cases like format
+        sniffing (``bytes=0-4095``).
+
+        ``additional_headers`` win on key collision with the implicit
+        ``Range`` header, so a caller passing their own ``Range`` overrides
+        ``range_spec``. This matters because the caller may want a
+        different byte range than the default for the same probe.
+
+        Same safety surface as ``head_bytes`` / ``download_bytes``:
+        HTTPS-only, non-public IP literals rejected, redirects refused,
+        error messages strip the URL, connection released on every exit
+        path. ``no_auth`` defaults to True for parity — the motivating
+        use case is pre-signed URLs that already carry their auth.
+
+        Returns:
+            A plain ``dict`` of header name → value. Header names follow
+            the case the upstream server sent; callers should match
+            case-insensitively. JSON-serializable so the value survives
+            the ``@agent_operation`` round-trip back to data-collector.
+
+        Raises:
+            HttpClientError: SSRF guard rejection, transport error,
+                or 3xx/4xx response.
+            HTTPError: 5xx response.
+        """
+        # Implicit Range goes first so a caller-supplied Range in
+        # additional_headers wins via dict-merge order.
+        merged_headers: Dict = {"Range": range_spec}
+        if additional_headers:
+            merged_headers.update(additional_headers)
+        with self._open_download_response(
+            url,
+            timeout=timeout,
+            no_auth=no_auth,
+            additional_headers=merged_headers,
+            op_label="probe_response_headers",
+            method="GET",
+        ) as response:
+            return dict(response.headers)
+
     def download_to_storage(
         self,
         url: str,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -950,6 +950,215 @@ class TestHeadBytes(TestCase):
             client.head_bytes("http://s3.example/file.jar")
 
 
+class TestProbeResponseHeaders(TestCase):
+    """Tests for HttpProxyClient.probe_response_headers — Range-GET probe used
+    for change-detection (ETag / Last-Modified) against endpoints where HEAD
+    is forbidden (motivating case: AWS pre-signed URLs, whose method-bound
+    signatures cause HEAD to return 403 even though the URL is reachable).
+
+    Same safety surface as head_bytes / download_bytes — SSRF guard, redirects
+    refused, URL-stripped errors. This class pins (a) GET-not-HEAD dispatch,
+    (b) implicit ``Range`` header injection + caller-override semantics, and
+    (c) 206 Partial Content acceptance.
+    """
+
+    def _make_response(
+        self,
+        status_code: int = 206,
+        headers: dict | None = None,
+    ) -> MagicMock:
+        # Default to 206 Partial Content — that's the realistic success status
+        # for a Range request honoured by S3 / any RFC 7233-compliant origin.
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        # Mirror real requests.Response context-manager behavior.
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = None
+        if status_code >= 400:
+            resp.raise_for_status.side_effect = HTTPError(
+                f"{status_code}", response=resp
+            )
+        else:
+            resp.raise_for_status.return_value = None
+        return resp
+
+    @patch("requests.get")
+    def test_returns_response_headers_as_dict(self, mock_get):
+        mock_get.return_value = self._make_response(
+            headers={
+                "ETag": '"abc123"',
+                "Last-Modified": "Wed, 12 May 2026 18:00:00 GMT",
+                "Content-Length": "1",
+                "Content-Range": "bytes 0-0/12345",
+            }
+        )
+
+        client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
+        result = client.probe_response_headers("https://s3.example/file.jar")
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual('"abc123"', result["ETag"])
+        self.assertEqual("Wed, 12 May 2026 18:00:00 GMT", result["Last-Modified"])
+        self.assertEqual("bytes 0-0/12345", result["Content-Range"])
+
+    @patch("requests.get")
+    def test_uses_http_get_not_head(self, mock_get):
+        # probe_response_headers must dispatch via requests.get — patching
+        # requests.head would not intercept the call (the whole point of this
+        # method is that the target rejects HEAD).
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        client.probe_response_headers("https://s3.example/file.jar")
+
+        self.assertEqual(1, mock_get.call_count)
+
+    @patch("requests.get")
+    def test_default_range_header_is_bytes_0_0(self, mock_get):
+        # Default range_spec="bytes=0-0" produces a 1-byte probe — the minimum
+        # the response carries the headers we want.
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        client.probe_response_headers("https://s3.example/file.jar")
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual("bytes=0-0", sent_headers["Range"])
+
+    @patch("requests.get")
+    def test_custom_range_spec_passed_through(self, mock_get):
+        # Callers can override range_spec for use cases like format sniffing
+        # (bytes=0-4095 to read the first 4 KB).
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        client.probe_response_headers(
+            "https://s3.example/file.jar", range_spec="bytes=0-4095"
+        )
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual("bytes=0-4095", sent_headers["Range"])
+
+    @patch("requests.get")
+    def test_caller_range_in_additional_headers_wins(self, mock_get):
+        # When both range_spec and additional_headers={"Range": ...} are
+        # supplied, the caller's explicit Range header wins. This is the
+        # documented contract — lets callers pass their own without having to
+        # know about the range_spec kwarg.
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        client.probe_response_headers(
+            "https://s3.example/file.jar",
+            range_spec="bytes=0-0",
+            additional_headers={"Range": "bytes=100-199"},
+        )
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual("bytes=100-199", sent_headers["Range"])
+
+    @patch("requests.get")
+    def test_no_auth_default_strips_authorization_header(self, mock_get):
+        # Parity with head_bytes / download_bytes: no_auth defaults to True so
+        # the bearer token is NOT leaked to the pre-signed URL host.
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
+        client.probe_response_headers("https://s3.example/file.jar")
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertNotIn("Authorization", sent_headers)
+
+    @patch("requests.get")
+    def test_auth_header_present_when_no_auth_false(self, mock_get):
+        mock_get.return_value = self._make_response()
+
+        client = HttpProxyClient(credentials={"connect_args": {"token": "tok"}})
+        client.probe_response_headers("https://api.example/file", no_auth=False)
+
+        sent_headers = mock_get.call_args.kwargs["headers"]
+        self.assertEqual("Bearer tok", sent_headers["Authorization"])
+
+    @patch("requests.get")
+    def test_206_partial_content_treated_as_success(self, mock_get):
+        # The canonical Range-honouring response. raise_for_status() does not
+        # flag 206 (RFC 7233 §4.1); the probe must surface the headers.
+        mock_get.return_value = self._make_response(
+            status_code=206, headers={"ETag": '"v1"'}
+        )
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        result = client.probe_response_headers("https://s3.example/file.jar")
+
+        self.assertEqual('"v1"', result["ETag"])
+
+    @patch("requests.get")
+    def test_200_ok_still_returns_headers(self, mock_get):
+        # Hosts that don't honour Range respond 200 OK with the full body.
+        # The connection close still discards the body without reading; we
+        # just need the headers.
+        mock_get.return_value = self._make_response(
+            status_code=200, headers={"ETag": '"v1"'}
+        )
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        result = client.probe_response_headers("https://s3.example/file.jar")
+
+        self.assertEqual('"v1"', result["ETag"])
+
+    @patch("requests.get")
+    def test_404_raises_http_client_error(self, mock_get):
+        mock_get.return_value = self._make_response(status_code=404)
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError):
+            client.probe_response_headers("https://s3.example/file.jar")
+
+    @patch("requests.get")
+    def test_500_raises_http_error_not_http_client_error(self, mock_get):
+        mock_get.return_value = self._make_response(status_code=500)
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HTTPError) as ctx:
+            client.probe_response_headers("https://s3.example/file.jar")
+        self.assertIsInstance(ctx.exception, HTTPError)
+        self.assertNotIsInstance(ctx.exception, HttpClientError)
+
+    @patch("requests.get")
+    def test_3xx_refuses_redirect(self, mock_get):
+        # SSRF defense — a 30x must not be re-fetched. allow_redirects=False
+        # ensures requests doesn't follow; the explicit guard catches the
+        # response.
+        mock_get.return_value = self._make_response(
+            status_code=302,
+            headers={"Location": "https://attacker.example/exfil"},
+        )
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError) as ctx:
+            client.probe_response_headers("https://s3.example/file.jar")
+        self.assertIn("302", str(ctx.exception))
+        self.assertNotIn("attacker.example", str(ctx.exception))
+
+    @patch("requests.get")
+    def test_connection_error_does_not_leak_url(self, mock_get):
+        secret_url = "https://s3.example/file.jar?Signature=DO-NOT-LEAK-XYZ"
+        mock_get.side_effect = requests.ConnectionError("conn refused at " + secret_url)
+
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError) as ctx:
+            client.probe_response_headers(secret_url)
+        self.assertNotIn("DO-NOT-LEAK-XYZ", str(ctx.exception))
+        self.assertNotIn(secret_url, str(ctx.exception))
+
+    def test_rejects_non_https_url(self):
+        # SSRF guard runs before any request — no need to patch requests.get.
+        client = HttpProxyClient(credentials={"connect_args": {}})
+        with self.assertRaises(HttpClientError):
+            client.probe_response_headers("http://s3.example/file.jar")
+
+
 class TestOpenDownloadResponse(TestCase):
     """Direct contract tests for HttpProxyClient._open_download_response.
 


### PR DESCRIPTION
## Summary

Adds `HttpProxyClient.probe_response_headers(url, *, range_spec="bytes=0-0", ...) -> dict[str, str]` — a Range-GET sibling to YET-1229's `head_bytes`. Issues a `GET` with a `Range` header, returns the response headers as a plain dict, discards the body on response close.

**Why**: live E2E run for [YET-1229](https://linear.app/montecarloai/issue/YET-1229) surfaced that AWS pre-signed URLs are **method-bound** — a URL signed for `GET` returns `403 Forbidden` on `HEAD` because the signature is computed over the HTTP method. So `head_bytes` is correctly wired but unusable against the live Anypoint Exchange JAR URLs that DC's change-detection layer needs to probe. A Range-GET sidesteps this: the signature matches (still a GET) and the response carries the headers we care about (`ETag` / `Last-Modified` / `Content-Length`) plus a tiny bounded body the connection-close throws away.

Companion DC PR: [data-collector #TBD](https://github.com/monte-carlo-data/data-collector/pull/2328) — routes `MulesoftAnypointRestClient.head_external_url` through this new op.

## What's in this PR

- **Production code** (`apollo/integrations/http/http_proxy_client.py`, +64 LOC): new `probe_response_headers` method right after `head_bytes`. Reuses the YET-1229 `_open_download_response` helper — same SSRF / redirect / status / connection-close guards as `head_bytes` and `download_bytes`. Caller-supplied `Range` in `additional_headers` wins over the implicit one (documented contract).
- **Tests** (`tests/test_http_client.py`, +209 LOC): new `TestProbeResponseHeaders` class with 14 cases covering happy path, GET-not-HEAD dispatch, default + custom + caller-override range semantics, no_auth default + opt-in, 206 Partial Content acceptance, 200 OK fallback for hosts that don't honour Range, 4xx → HttpClientError, 5xx → HTTPError, redirect refusal with Location-stripping, connection-error URL-stripping, non-https rejection.

## Stacked on

Base: `fbenitez/yet-1229-mulesoft-extract-sources` (PR #288). Will rebase to `master` if YET-1229 merges first.

## Test plan

- [x] `python -m pytest tests/test_http_client.py -q` — 91 passed (14 new in `TestProbeResponseHeaders`)
- [x] `python -m pytest tests/test_http_client.py tests/test_mulesoft_proxy_client.py tests/test_proxy_client_factory.py tests/ctp/test_proxy_client_factory_ctp.py -q` — 120 passed, no regressions
- [x] `black --check apollo/integrations/http/http_proxy_client.py tests/test_http_client.py` — clean
- [x] `pyright apollo/integrations/http/http_proxy_client.py` — 0 errors, 0 warnings
- [ ] Live E2E (DC-driven, runs against real Anypoint tenant) — verified separately on the DC PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)