### PR TITLE
ci: add nightly Docker Scout vulnerability scan pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
             python -m venv .venv
             . .venv/bin/activate
             pip install --no-cache-dir --upgrade pip
-            pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt -r requirements-cloudrun.txt -r requirements-lambda.txt -r requirements-azure.txt
+            pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt -r requirements-cloudrun.txt -r requirements-lambda.txt -r requirements-azure.txt -r scripts/vuln_scan/requirements.txt
       - run:
           name: 'Run black / pyright'
           command: |

--- a/.circleci/vuln-scan-config.yml
+++ b/.circleci/vuln-scan-config.yml
@@ -1,0 +1,81 @@
+version: 2.1
+
+# Nightly vulnerability scan for published montecarlodata/agent images.
+# Lives as a separate CircleCI pipeline (configured in CircleCI project settings)
+# so it can be triggered on a daily schedule independently of the main build.
+#
+# The scan logic lives in scripts/vuln_scan/scan.py. State (which CVEs have been
+# notified, when, and for which digest) is persisted in S3 so each run only
+# alerts on deltas.
+
+orbs:
+  aws-cli: circleci/aws-cli@4.1.3
+  docker: circleci/docker@2.2.0
+
+jobs:
+  scan-images:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+
+      - docker/check:
+          use-docker-credentials-store: true
+
+      - aws-cli/setup:
+          role_arn: arn:aws:iam::637423407294:role/mc-circleci
+          region: us-east-1
+          profile_name: default
+
+      - run:
+          name: Install Docker Scout CLI
+          command: |
+            mkdir -p ~/.docker/cli-plugins
+            # Pin to a known-good release rather than ":latest" so a Scout
+            # release that changes SARIF output can't silently break us.
+            SCOUT_VERSION="1.18.2"
+            ARCH="$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')"
+            curl -fsSL \
+              "https://github.com/docker/scout-cli/releases/download/v${SCOUT_VERSION}/docker-scout_${SCOUT_VERSION}_linux_${ARCH}.tar.gz" \
+              -o /tmp/scout.tar.gz
+            tar -xzf /tmp/scout.tar.gz -C /tmp
+            install -m 0755 /tmp/docker-scout ~/.docker/cli-plugins/docker-scout
+            docker scout version
+
+      - run:
+          name: Install Python dependencies
+          command: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install --no-cache-dir --upgrade pip
+            pip install --no-cache-dir -r scripts/vuln_scan/requirements.txt
+
+      - run:
+          name: Run vulnerability scan
+          no_output_timeout: 30m
+          # All operational inputs are passed as CLI flags so the repo, tags,
+          # channel, and bucket can change without a code edit. The tag list
+          # below intentionally excludes:
+          #   - latest-aws-generic   (mirrors latest-aws-proxied's digest)
+          #   - latest-generic-base  (intermediate build artifact)
+          #   - latest-system-base   (published base layer; vulns surface in
+          #                           downstream images anyway)
+          command: |
+            . .venv/bin/activate
+            python scripts/vuln_scan/scan.py \
+              --repo montecarlodata/agent \
+              --bucket dev-mc-caas-infrastructure-templates \
+              --slack-channel '#aaa-dev-error-alerts' \
+              --tag latest-aws-proxied \
+              --tag latest-azure \
+              --tag latest-cloudrun \
+              --tag latest-generic \
+              --tag latest-lambda
+
+workflows:
+  nightly-vuln-scan:
+    jobs:
+      - scan-images:
+          context:
+            - docker
+            - slack-secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,13 +64,16 @@ FROM base AS tests
 COPY requirements-dev.txt ./
 COPY requirements-cloudrun.txt ./
 COPY requirements-azure.txt ./
+COPY scripts/vuln_scan/requirements.txt ./scripts/vuln_scan/requirements.txt
 RUN . $VENV_DIR/bin/activate \
     && pip install --no-cache-dir \
     -r requirements-dev.txt \
     -r requirements-cloudrun.txt \
-    -r requirements-azure.txt
+    -r requirements-azure.txt \
+    -r scripts/vuln_scan/requirements.txt
 
 COPY tests ./tests
+COPY scripts ./scripts
 ARG CACHEBUST=1
 RUN . $VENV_DIR/bin/activate && \
     PYTHONPATH=. pytest tests

--- a/scripts/vuln_scan/requirements.txt
+++ b/scripts/vuln_scan/requirements.txt
@@ -1,0 +1,3 @@
+boto3==1.34.151
+requests==2.32.4
+slack-sdk==3.33.4

--- a/scripts/vuln_scan/scan.py
+++ b/scripts/vuln_scan/scan.py
@@ -1,0 +1,590 @@
+"""Apollo Agent nightly vulnerability scan.
+
+Runs Docker Scout against the production `latest-*` tags of montecarlodata/agent,
+diffs results against the previous run (state stored in S3), and posts a Slack
+notification when there are deltas in HIGH/CRITICAL findings (or scan errors).
+
+Designed to run from CircleCI on a daily schedule. See .circleci/vuln-scan-config.yml.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+import requests
+from slack_sdk import WebClient
+
+
+# --- Configuration -----------------------------------------------------------
+#
+# Repo, tag list, S3 bucket, and Slack channel are all CLI args (see
+# parse_args) — pinned by the pipeline so they can change (dedicated channel,
+# different AWS account, different image repo or tag matrix) without a code
+# edit. See .circleci/vuln-scan-config.yml for the apollo-agent values.
+
+# Days after which we re-notify on a still-open HIGH/CRITICAL CVE.
+REMINDER_DAYS = 4
+
+# Docker Scout indexes a newly-pushed image asynchronously; running `scout cves`
+# before indexing completes can return an empty or partial result, which would
+# look like all previous CVEs were resolved. Skip any image whose tag was pushed
+# more recently than this. The next nightly run picks it up.
+FRESHNESS_GRACE_HOURS = 6
+
+# Severities we list individually in Slack; others are summarized as counts.
+DETAILED_SEVERITIES = ("CRITICAL", "HIGH")
+ALL_SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")
+
+# Slack mrkdwn section text has a 3000-char limit; cap the per-section bullet
+# count to stay well under that and keep the message scannable.
+MAX_ITEMS_PER_SECTION = 40
+
+
+# --- Data structures ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FindingKey:
+    cve_id: str
+    package: str
+    installed: str
+
+
+@dataclass
+class Finding:
+    cve_id: str
+    package: str
+    installed: str
+    severity: str  # CRITICAL | HIGH | MEDIUM | LOW | UNKNOWN
+    fixed_in: str | None
+
+    @property
+    def key(self) -> FindingKey:
+        return FindingKey(self.cve_id, self.package, self.installed)
+
+
+@dataclass
+class DiffSummary:
+    new_detailed: list[tuple[str, Finding]] = field(default_factory=list)
+    reminders: list[tuple[str, Finding, str]] = field(default_factory=list)
+    resolved_detailed: list[tuple[str, dict[str, Any]]] = field(default_factory=list)
+    new_by_severity: dict[str, int] = field(default_factory=dict)
+    totals_by_severity: dict[str, int] = field(default_factory=dict)
+    # Tags we didn't scan this run (e.g. pushed too recently for Scout to have
+    # indexed). Their previous state is preserved verbatim — no false deltas.
+    skipped: list[tuple[str, str]] = field(default_factory=list)  # (tag, reason)
+
+
+# --- Docker Hub: tag -> digest -----------------------------------------------
+
+
+@dataclass
+class TagInfo:
+    digest: str
+    last_pushed: datetime
+
+
+def get_tag_info(repo: str, tag: str) -> TagInfo:
+    """Look up the current digest and last-pushed timestamp for a tag."""
+    url = f"https://hub.docker.com/v2/repositories/{repo}/tags/{tag}"
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    digest = data.get("digest")
+    if not digest and data.get("images"):
+        digest = data["images"][0].get("digest")
+    if not digest:
+        raise RuntimeError(f"No digest found for {repo}:{tag}")
+    pushed_raw = (
+        data.get("tag_last_pushed")
+        or data.get("last_updated")
+        or data.get("last_pushed")
+    )
+    if not pushed_raw:
+        raise RuntimeError(f"No last_pushed timestamp found for {repo}:{tag}")
+    return TagInfo(digest=digest, last_pushed=_parse_iso(pushed_raw))
+
+
+# --- Docker Scout -------------------------------------------------------------
+
+
+def scan_with_scout(repo: str, digest: str) -> list[Finding]:
+    """Run docker scout cves and return parsed findings."""
+    image_ref = f"{repo}@{digest}"
+    proc = subprocess.run(
+        ["docker", "scout", "cves", image_ref, "--format", "sarif"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return parse_sarif(proc.stdout)
+
+
+def parse_sarif(sarif_text: str) -> list[Finding]:
+    """Parse a Docker Scout SARIF document into Finding records.
+
+    Scout puts CVE metadata in `tool.driver.rules` (severity, fixed version) and
+    per-package matches in `results` (location URI is a Package URL).
+    """
+    sarif = json.loads(sarif_text)
+    findings: list[Finding] = []
+
+    for run in sarif.get("runs", []):
+        rules_by_id: dict[str, dict[str, Any]] = {
+            r["id"]: r for r in run.get("tool", {}).get("driver", {}).get("rules", [])
+        }
+        for result in run.get("results", []):
+            rule_id = result.get("ruleId", "")
+            rule = rules_by_id.get(rule_id, {})
+            severity = _severity_from_rule(rule, result)
+            pkg, installed = _pkg_from_location(result)
+            fixed_in = _fixed_in_from_rule(rule)
+            findings.append(
+                Finding(
+                    cve_id=rule_id,
+                    package=pkg,
+                    installed=installed,
+                    severity=severity,
+                    fixed_in=fixed_in,
+                )
+            )
+    return findings
+
+
+def _severity_from_rule(rule: dict[str, Any], result: dict[str, Any]) -> str:
+    props = rule.get("properties", {})
+    # CVSS score is the most reliable source.
+    cvss = props.get("cvss")
+    if isinstance(cvss, dict):
+        score = (
+            cvss.get("v3", {}).get("score")
+            if isinstance(cvss.get("v3"), dict)
+            else cvss.get("score")
+        )
+        if score is not None:
+            try:
+                return _cvss_to_severity(float(score))
+            except (TypeError, ValueError):
+                pass
+    sec_sev = props.get("security-severity")
+    if sec_sev is not None:
+        try:
+            return _cvss_to_severity(float(sec_sev))
+        except (TypeError, ValueError):
+            pass
+    for tag in props.get("tags") or []:
+        upper = str(tag).upper()
+        if upper in ALL_SEVERITIES:
+            return upper
+    # SARIF level is a coarser fallback.
+    level = result.get("level", "warning")
+    return {"error": "HIGH", "warning": "MEDIUM", "note": "LOW"}.get(level, "UNKNOWN")
+
+
+def _cvss_to_severity(score: float) -> str:
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _pkg_from_location(result: dict[str, Any]) -> tuple[str, str]:
+    locs = result.get("locations") or []
+    if not locs:
+        return ("?", "?")
+    uri = locs[0].get("physicalLocation", {}).get("artifactLocation", {}).get("uri", "")
+    return _parse_purl(uri)
+
+
+def _parse_purl(purl: str) -> tuple[str, str]:
+    # pkg:<type>/[<namespace>/]<name>@<version>[?qualifiers]
+    if not purl.startswith("pkg:"):
+        return (purl or "?", "?")
+    body = purl[len("pkg:") :]
+    name_ver = body.split("?", 1)[0]
+    if "@" not in name_ver:
+        return (name_ver, "?")
+    name, ver = name_ver.rsplit("@", 1)
+    pkg = name.rsplit("/", 1)[-1]
+    return (pkg, ver)
+
+
+def _fixed_in_from_rule(rule: dict[str, Any]) -> str | None:
+    props = rule.get("properties", {})
+    for key in ("fixed-version", "fixed_version", "fix-version", "fixVersion"):
+        if props.get(key):
+            return str(props[key])
+    return None
+
+
+# --- State (S3) ---------------------------------------------------------------
+
+
+def load_state(bucket: str, key: str, s3: Any = None) -> dict[str, Any]:
+    s3 = s3 or boto3.client("s3")
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        return json.loads(obj["Body"].read())
+    except s3.exceptions.NoSuchKey:
+        return {"version": 1, "last_run": None, "images": {}}
+
+
+def save_state(state: dict[str, Any], bucket: str, key: str, s3: Any = None) -> None:
+    s3 = s3 or boto3.client("s3")
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(state, indent=2, sort_keys=True).encode(),
+        ContentType="application/json",
+    )
+
+
+# --- Diffing ------------------------------------------------------------------
+
+
+def diff_and_update_state(
+    tag_findings: dict[str, list[Finding]],
+    tag_digests: dict[str, str],
+    state: dict[str, Any],
+    now: datetime,
+    skipped: list[tuple[str, str]] | None = None,
+) -> tuple[DiffSummary, dict[str, Any]]:
+    summary = DiffSummary(skipped=list(skipped or []))
+    now_iso = now.isoformat()
+    new_state: dict[str, Any] = {"version": 1, "last_run": now_iso, "images": {}}
+
+    # For tags we skipped this run, preserve the previous state entry verbatim
+    # so that next run's diff is correct and no false-resolved deltas appear.
+    for tag, _reason in summary.skipped:
+        prev_image = state.get("images", {}).get(tag)
+        if prev_image is not None:
+            new_state["images"][tag] = prev_image
+
+    for tag, findings in tag_findings.items():
+        prev_image = state.get("images", {}).get(tag, {})
+        prev_by_key: dict[FindingKey, dict[str, Any]] = {
+            FindingKey(v["cve_id"], v["package"], v["installed"]): v
+            for v in prev_image.get("vulns", [])
+        }
+
+        new_records: list[dict[str, Any]] = []
+        current_keys: set[FindingKey] = set()
+
+        for f in findings:
+            current_keys.add(f.key)
+            summary.totals_by_severity[f.severity] = (
+                summary.totals_by_severity.get(f.severity, 0) + 1
+            )
+
+            prev = prev_by_key.get(f.key)
+            if prev is None:
+                # First time we've seen this CVE on this tag.
+                summary.new_by_severity[f.severity] = (
+                    summary.new_by_severity.get(f.severity, 0) + 1
+                )
+                if f.severity in DETAILED_SEVERITIES:
+                    summary.new_detailed.append((tag, f))
+                first_seen = now_iso
+                last_notified = now_iso
+            else:
+                first_seen = prev.get("first_seen", now_iso)
+                last_notified = prev.get("last_notified", first_seen)
+                if f.severity in DETAILED_SEVERITIES:
+                    last_dt = _parse_iso(last_notified)
+                    if (now - last_dt).days >= REMINDER_DAYS:
+                        summary.reminders.append((tag, f, first_seen))
+                        last_notified = now_iso
+
+            new_records.append(
+                {
+                    "cve_id": f.cve_id,
+                    "package": f.package,
+                    "installed": f.installed,
+                    "severity": f.severity,
+                    "fixed_in": f.fixed_in,
+                    "first_seen": first_seen,
+                    "last_notified": last_notified,
+                }
+            )
+
+        # Anything in the previous state that's no longer present was resolved.
+        for k, v in prev_by_key.items():
+            if k not in current_keys and v.get("severity") in DETAILED_SEVERITIES:
+                summary.resolved_detailed.append((tag, v))
+
+        new_state["images"][tag] = {
+            "digest": tag_digests[tag],
+            "vulns": new_records,
+        }
+
+    return summary, new_state
+
+
+def _parse_iso(s: str) -> datetime:
+    # Tolerate both "...Z" and "...+00:00" forms.
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+# --- Slack --------------------------------------------------------------------
+
+
+def build_slack_blocks(
+    summary: DiffSummary,
+    scan_errors: list[tuple[str, str]],
+    tag_digests: dict[str, str],
+) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "header",
+            "text": {
+                "type": "plain_text",
+                "text": "Apollo Agent — Vulnerability Scan",
+            },
+        }
+    ]
+
+    if scan_errors:
+        err_lines = "\n".join(f"• `{ref}`: {msg}" for ref, msg in scan_errors)
+        blocks.append(_section(f":x: *Scan errors ({len(scan_errors)})*\n{err_lines}"))
+
+    if summary.new_detailed:
+        blocks.extend(
+            _findings_section(
+                f":warning: *New HIGH/CRITICAL ({len(summary.new_detailed)})*",
+                [_format_new(tag, f) for tag, f in summary.new_detailed],
+            )
+        )
+
+    if summary.reminders:
+        blocks.extend(
+            _findings_section(
+                f":hourglass: *Still open ≥{REMINDER_DAYS}d ({len(summary.reminders)})*",
+                [_format_reminder(tag, f, fs) for tag, f, fs in summary.reminders],
+            )
+        )
+
+    if summary.resolved_detailed:
+        blocks.extend(
+            _findings_section(
+                f":white_check_mark: *Resolved ({len(summary.resolved_detailed)})*",
+                [_format_resolved(tag, v) for tag, v in summary.resolved_detailed],
+            )
+        )
+
+    # Totals (all severities) and scanned images.
+    totals_line = " · ".join(
+        f"{sev}: {summary.totals_by_severity.get(sev, 0)} "
+        f"({summary.new_by_severity.get(sev, 0)} new)"
+        for sev in ALL_SEVERITIES
+    )
+    blocks.append({"type": "divider"})
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"Totals: {totals_line}"}],
+        }
+    )
+    scanned_line = " · ".join(f"`{tag}@{tag_digests[tag][:19]}`" for tag in tag_digests)
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"Scanned: {scanned_line}"}],
+        }
+    )
+    if summary.skipped:
+        skipped_line = " · ".join(
+            f"`{tag}` ({reason})" for tag, reason in summary.skipped
+        )
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"Skipped: {skipped_line}"}],
+            }
+        )
+    return blocks
+
+
+def _section(text: str) -> dict[str, Any]:
+    return {"type": "section", "text": {"type": "mrkdwn", "text": text}}
+
+
+def _findings_section(header: str, lines: list[str]) -> list[dict[str, Any]]:
+    """Split a long bullet list across multiple section blocks if needed."""
+    blocks: list[dict[str, Any]] = []
+    first = True
+    for chunk_start in range(0, len(lines), MAX_ITEMS_PER_SECTION):
+        chunk = lines[chunk_start : chunk_start + MAX_ITEMS_PER_SECTION]
+        prefix = f"{header}\n" if first else ""
+        blocks.append(_section(prefix + "\n".join(chunk)))
+        first = False
+    return blocks
+
+
+def _format_new(tag: str, f: Finding) -> str:
+    fix = f" → fix in `{f.fixed_in}`" if f.fixed_in else ""
+    return f"• *{tag}* — `{f.cve_id}` ({f.severity}) `{f.package} {f.installed}`{fix}"
+
+
+def _format_reminder(tag: str, f: Finding, first_seen: str) -> str:
+    fix = f" → fix in `{f.fixed_in}`" if f.fixed_in else ""
+    return (
+        f"• *{tag}* — `{f.cve_id}` ({f.severity}) `{f.package} {f.installed}`{fix} "
+        f"_first seen {first_seen[:10]}_"
+    )
+
+
+def _format_resolved(tag: str, v: dict[str, Any]) -> str:
+    return f"• *{tag}* — `{v['cve_id']}` ({v['severity']}) `{v['package']} {v['installed']}`"
+
+
+def post_slack(blocks: list[dict[str, Any]], channel: str) -> None:
+    token = os.environ.get("SLACK_ACCESS_TOKEN")
+    if not token:
+        print("SLACK_ACCESS_TOKEN not set; skipping Slack post", file=sys.stderr)
+        print(json.dumps(blocks, indent=2))
+        return
+    client = WebClient(token=token)
+    client.chat_postMessage(
+        channel=channel,
+        blocks=blocks,
+        text=":rotating_light: Apollo Agent vuln scan",
+    )
+
+
+# --- Main ---------------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Nightly Docker Scout vulnerability scan for a Docker Hub repo.",
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help="Docker Hub repository to scan (e.g. montecarlodata/agent)",
+    )
+    parser.add_argument(
+        "--bucket",
+        required=True,
+        help="S3 bucket name where scan state is persisted",
+    )
+    parser.add_argument(
+        "--slack-channel",
+        required=True,
+        help="Slack channel to post deltas to (e.g. #vuln-alerts)",
+    )
+    parser.add_argument(
+        "--tag",
+        dest="tags",
+        action="append",
+        required=True,
+        help="Tag to scan within --repo; pass once per tag (e.g. --tag latest-aws-proxied)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo: str = args.repo
+    bucket: str = args.bucket
+    slack_channel: str = args.slack_channel
+    tags: list[str] = args.tags
+    # Same bucket can host state for multiple repos without collision.
+    s3_key = f"vuln-scan/{repo.split('/')[-1]}/state.json"
+
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    freshness_cutoff = now - timedelta(hours=FRESHNESS_GRACE_HOURS)
+
+    print(f"Resolving tag info for {len(tags)} tags of {repo}…")
+    tag_digests: dict[str, str] = {}
+    skipped: list[tuple[str, str]] = []
+    resolve_errors: list[tuple[str, str]] = []
+    for tag in tags:
+        try:
+            info = get_tag_info(repo, tag)
+            if info.last_pushed > freshness_cutoff:
+                reason = f"pushed <{FRESHNESS_GRACE_HOURS}h ago, Scout may not be indexed yet"
+                print(f"  {tag} -> SKIP ({reason})")
+                skipped.append((tag, reason))
+                continue
+            tag_digests[tag] = info.digest
+            print(f"  {tag} -> {info.digest}")
+        except Exception as e:
+            print(f"  ERROR resolving {tag}: {e}", file=sys.stderr)
+            resolve_errors.append((f"{repo}:{tag}", str(e)))
+
+    # Dedupe by digest so we don't scan the same bytes twice.
+    digest_to_tags: dict[str, list[str]] = {}
+    for tag, digest in tag_digests.items():
+        digest_to_tags.setdefault(digest, []).append(tag)
+
+    print(f"\nScanning {len(digest_to_tags)} unique digests…")
+    scan_errors: list[tuple[str, str]] = list(resolve_errors)
+    findings_by_digest: dict[str, list[Finding]] = {}
+    for digest, tags in digest_to_tags.items():
+        try:
+            print(f"  scanning {digest} (tags: {', '.join(tags)})")
+            findings_by_digest[digest] = scan_with_scout(repo, digest)
+            print(f"    {len(findings_by_digest[digest])} findings")
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "")[:500]
+            err = f"scout failed (exit {e.returncode}): {stderr}"
+            print(f"    ERROR: {err}", file=sys.stderr)
+            scan_errors.append((digest, err))
+        except Exception as e:
+            print(f"    ERROR: {e}", file=sys.stderr)
+            scan_errors.append((digest, str(e)))
+
+    tag_findings = {
+        tag: findings_by_digest[digest]
+        for tag, digest in tag_digests.items()
+        if digest in findings_by_digest
+    }
+
+    state = load_state(bucket, s3_key)
+    print(f"\nLoaded state: {len(state.get('images', {}))} images previously tracked")
+
+    summary, new_state = diff_and_update_state(
+        tag_findings, tag_digests, state, now, skipped=skipped
+    )
+
+    print("\nSummary:")
+    print(f"  new detailed (HIGH+): {len(summary.new_detailed)}")
+    print(f"  reminders (HIGH+):    {len(summary.reminders)}")
+    print(f"  resolved (HIGH+):     {len(summary.resolved_detailed)}")
+    print(f"  skipped (fresh):      {len(summary.skipped)}")
+    print(f"  scan errors:          {len(scan_errors)}")
+
+    should_notify = bool(
+        summary.new_detailed
+        or summary.reminders
+        or summary.resolved_detailed
+        or scan_errors
+    )
+    if should_notify:
+        blocks = build_slack_blocks(summary, scan_errors, tag_digests)
+        post_slack(blocks, slack_channel)
+        print("Posted to Slack.")
+    else:
+        print("No HIGH+ delta and no errors; skipping Slack post.")
+
+    save_state(new_state, bucket, s3_key)
+    print("State saved to S3.")
+    return 1 if scan_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_vuln_scan.py
+++ b/tests/test_vuln_scan.py
@@ -1,0 +1,450 @@
+"""Tests for scripts/vuln_scan/scan.py.
+
+Covers SARIF parsing, severity classification, purl parsing, and the diff
+state-machine (bootstrap, new finding, reminder cadence, resolved finding).
+No network or Docker calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from scripts.vuln_scan.scan import (
+    REMINDER_DAYS,
+    DiffSummary,
+    Finding,
+    FindingKey,
+    _cvss_to_severity,
+    _parse_purl,
+    build_slack_blocks,
+    diff_and_update_state,
+    parse_sarif,
+)
+
+
+# --- _cvss_to_severity -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (9.0, "CRITICAL"),
+        (9.5, "CRITICAL"),
+        (8.9, "HIGH"),
+        (7.0, "HIGH"),
+        (6.9, "MEDIUM"),
+        (4.0, "MEDIUM"),
+        (3.9, "LOW"),
+        (0.1, "LOW"),
+        (0.0, "UNKNOWN"),
+    ],
+)
+def test_cvss_to_severity_boundaries(score: float, expected: str) -> None:
+    assert _cvss_to_severity(score) == expected
+
+
+# --- _parse_purl -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "purl,expected",
+    [
+        ("pkg:pypi/urllib3@2.6.3", ("urllib3", "2.6.3")),
+        ("pkg:deb/debian/libc6@2.41-12", ("libc6", "2.41-12")),
+        ("pkg:golang/stdlib@go1.22.0", ("stdlib", "go1.22.0")),
+        ("pkg:pypi/foo@1.0?qualifier=x", ("foo", "1.0")),
+        ("pkg:pypi/no-version", ("pypi/no-version", "?")),
+        ("not-a-purl", ("not-a-purl", "?")),
+        ("", ("?", "?")),
+    ],
+)
+def test_parse_purl(purl: str, expected: tuple[str, str]) -> None:
+    assert _parse_purl(purl) == expected
+
+
+# --- parse_sarif -------------------------------------------------------------
+
+
+def _sarif_doc(rules: list[dict], results: list[dict]) -> str:
+    return json.dumps(
+        {
+            "runs": [
+                {
+                    "tool": {"driver": {"rules": rules}},
+                    "results": results,
+                }
+            ]
+        }
+    )
+
+
+def test_parse_sarif_extracts_severity_from_cvss_score() -> None:
+    sarif = _sarif_doc(
+        rules=[
+            {
+                "id": "CVE-2026-44432",
+                "properties": {
+                    "cvss": {"v3": {"score": 8.9}},
+                    "fixed-version": "2.6.4",
+                },
+            }
+        ],
+        results=[
+            {
+                "ruleId": "CVE-2026-44432",
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "pkg:pypi/urllib3@2.6.3"}
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+    findings = parse_sarif(sarif)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.cve_id == "CVE-2026-44432"
+    assert f.package == "urllib3"
+    assert f.installed == "2.6.3"
+    assert f.severity == "HIGH"
+    assert f.fixed_in == "2.6.4"
+
+
+def test_parse_sarif_uses_security_severity_when_cvss_dict_missing() -> None:
+    sarif = _sarif_doc(
+        rules=[{"id": "CVE-X", "properties": {"security-severity": "9.1"}}],
+        results=[
+            {
+                "ruleId": "CVE-X",
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "pkg:deb/debian/libc6@2.41-12"}
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+    findings = parse_sarif(sarif)
+    assert findings[0].severity == "CRITICAL"
+
+
+def test_parse_sarif_falls_back_to_sarif_level() -> None:
+    sarif = _sarif_doc(
+        rules=[{"id": "CVE-Y", "properties": {}}],
+        results=[
+            {
+                "ruleId": "CVE-Y",
+                "level": "note",
+                "locations": [
+                    {
+                        "physicalLocation": {
+                            "artifactLocation": {"uri": "pkg:pypi/foo@1.0"}
+                        }
+                    }
+                ],
+            }
+        ],
+    )
+    findings = parse_sarif(sarif)
+    assert findings[0].severity == "LOW"
+
+
+def test_parse_sarif_handles_empty_runs() -> None:
+    assert parse_sarif(json.dumps({"runs": []})) == []
+
+
+# --- diff_and_update_state ---------------------------------------------------
+
+
+def _finding(
+    cve: str, pkg: str = "urllib3", ver: str = "2.6.3", sev: str = "HIGH"
+) -> Finding:
+    return Finding(cve_id=cve, package=pkg, installed=ver, severity=sev, fixed_in=None)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 13, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def test_bootstrap_first_run_treats_everything_as_new() -> None:
+    findings = {
+        "latest-cloudrun": [_finding("CVE-1", sev="HIGH"), _finding("CVE-2", sev="LOW")]
+    }
+    digests = {"latest-cloudrun": "sha256:abc"}
+    summary, new_state = diff_and_update_state(findings, digests, state={}, now=_now())
+
+    assert len(summary.new_detailed) == 1
+    assert summary.new_detailed[0][1].cve_id == "CVE-1"
+    assert summary.new_by_severity == {"HIGH": 1, "LOW": 1}
+    assert summary.totals_by_severity == {"HIGH": 1, "LOW": 1}
+    assert summary.reminders == []
+    assert summary.resolved_detailed == []
+    assert new_state["images"]["latest-cloudrun"]["digest"] == "sha256:abc"
+    assert len(new_state["images"]["latest-cloudrun"]["vulns"]) == 2
+
+
+def test_unchanged_high_below_reminder_threshold_is_silent() -> None:
+    now = _now()
+    one_day_ago = (now - timedelta(days=1)).isoformat()
+    state = {
+        "images": {
+            "latest-cloudrun": {
+                "digest": "sha256:abc",
+                "vulns": [
+                    {
+                        "cve_id": "CVE-1",
+                        "package": "urllib3",
+                        "installed": "2.6.3",
+                        "severity": "HIGH",
+                        "fixed_in": None,
+                        "first_seen": one_day_ago,
+                        "last_notified": one_day_ago,
+                    }
+                ],
+            }
+        }
+    }
+    findings = {"latest-cloudrun": [_finding("CVE-1")]}
+    digests = {"latest-cloudrun": "sha256:abc"}
+    summary, _ = diff_and_update_state(findings, digests, state, now)
+
+    assert summary.new_detailed == []
+    assert summary.reminders == []
+    assert summary.resolved_detailed == []
+
+
+def test_high_open_for_reminder_threshold_re_notifies() -> None:
+    now = _now()
+    long_ago = (now - timedelta(days=REMINDER_DAYS + 1)).isoformat()
+    state = {
+        "images": {
+            "latest-cloudrun": {
+                "digest": "sha256:abc",
+                "vulns": [
+                    {
+                        "cve_id": "CVE-1",
+                        "package": "urllib3",
+                        "installed": "2.6.3",
+                        "severity": "HIGH",
+                        "fixed_in": None,
+                        "first_seen": long_ago,
+                        "last_notified": long_ago,
+                    }
+                ],
+            }
+        }
+    }
+    findings = {"latest-cloudrun": [_finding("CVE-1")]}
+    digests = {"latest-cloudrun": "sha256:abc"}
+    summary, new_state = diff_and_update_state(findings, digests, state, now)
+
+    assert len(summary.reminders) == 1
+    tag, finding, first_seen = summary.reminders[0]
+    assert tag == "latest-cloudrun"
+    assert finding.cve_id == "CVE-1"
+    assert first_seen == long_ago
+    # last_notified should bump forward
+    updated = new_state["images"]["latest-cloudrun"]["vulns"][0]
+    assert updated["last_notified"] == now.isoformat()
+    assert updated["first_seen"] == long_ago
+
+
+def test_resolved_high_appears_in_resolved_list() -> None:
+    now = _now()
+    state = {
+        "images": {
+            "latest-cloudrun": {
+                "digest": "sha256:abc",
+                "vulns": [
+                    {
+                        "cve_id": "CVE-RESOLVED",
+                        "package": "urllib3",
+                        "installed": "2.6.3",
+                        "severity": "HIGH",
+                        "fixed_in": "2.6.4",
+                        "first_seen": now.isoformat(),
+                        "last_notified": now.isoformat(),
+                    }
+                ],
+            }
+        }
+    }
+    findings: dict[str, list[Finding]] = {"latest-cloudrun": []}
+    digests = {"latest-cloudrun": "sha256:abc"}
+    summary, new_state = diff_and_update_state(findings, digests, state, now)
+
+    assert len(summary.resolved_detailed) == 1
+    tag, vuln = summary.resolved_detailed[0]
+    assert tag == "latest-cloudrun"
+    assert vuln["cve_id"] == "CVE-RESOLVED"
+    assert new_state["images"]["latest-cloudrun"]["vulns"] == []
+
+
+def test_skipped_tag_preserves_previous_state_verbatim() -> None:
+    """If a tag is skipped (e.g. pushed too recently), its previous state
+    record is copied into the new state unchanged so the next run produces a
+    correct diff and no false-resolved deltas appear in the meantime."""
+    now = _now()
+    prev_image = {
+        "digest": "sha256:old",
+        "vulns": [
+            {
+                "cve_id": "CVE-99",
+                "package": "urllib3",
+                "installed": "2.6.3",
+                "severity": "HIGH",
+                "fixed_in": None,
+                "first_seen": (now - timedelta(days=2)).isoformat(),
+                "last_notified": (now - timedelta(days=2)).isoformat(),
+            }
+        ],
+    }
+    state = {"images": {"latest-cloudrun": prev_image}}
+    summary, new_state = diff_and_update_state(
+        tag_findings={},
+        tag_digests={},
+        state=state,
+        now=now,
+        skipped=[("latest-cloudrun", "pushed <6h ago")],
+    )
+    # Skipped image's state is preserved verbatim.
+    assert new_state["images"]["latest-cloudrun"] == prev_image
+    # No deltas reported for the skipped tag.
+    assert summary.new_detailed == []
+    assert summary.resolved_detailed == []
+    assert summary.reminders == []
+    # The skip itself is recorded on the summary.
+    assert summary.skipped == [("latest-cloudrun", "pushed <6h ago")]
+
+
+def test_skipped_tag_with_no_previous_state_is_omitted_from_new_state() -> None:
+    """A skipped tag we've never seen before just isn't in the new state."""
+    now = _now()
+    summary, new_state = diff_and_update_state(
+        tag_findings={},
+        tag_digests={},
+        state={"images": {}},
+        now=now,
+        skipped=[("latest-newthing", "pushed <6h ago")],
+    )
+    assert "latest-newthing" not in new_state["images"]
+    assert summary.skipped == [("latest-newthing", "pushed <6h ago")]
+
+
+def test_low_severity_resolved_is_not_in_detailed_resolved() -> None:
+    """Only HIGH/CRITICAL are surfaced as resolved; lower severities go silent."""
+    now = _now()
+    state = {
+        "images": {
+            "latest-cloudrun": {
+                "digest": "sha256:abc",
+                "vulns": [
+                    {
+                        "cve_id": "CVE-LOW",
+                        "package": "foo",
+                        "installed": "1.0",
+                        "severity": "LOW",
+                        "fixed_in": None,
+                        "first_seen": now.isoformat(),
+                        "last_notified": now.isoformat(),
+                    }
+                ],
+            }
+        }
+    }
+    findings: dict[str, list[Finding]] = {"latest-cloudrun": []}
+    digests = {"latest-cloudrun": "sha256:abc"}
+    summary, _ = diff_and_update_state(findings, digests, state, now)
+    assert summary.resolved_detailed == []
+
+
+# --- build_slack_blocks ------------------------------------------------------
+
+
+def test_slack_blocks_include_header_totals_and_scanned() -> None:
+    summary = DiffSummary(
+        new_detailed=[("latest-cloudrun", _finding("CVE-1"))],
+        totals_by_severity={"HIGH": 1, "MEDIUM": 12},
+        new_by_severity={"HIGH": 1, "MEDIUM": 3},
+    )
+    blocks = build_slack_blocks(
+        summary, scan_errors=[], tag_digests={"latest-cloudrun": "sha256:abc1234567890"}
+    )
+    # First block is the header.
+    assert blocks[0]["type"] == "header"
+    # Totals + scanned context blocks appear at the bottom.
+    context_texts = [
+        el["text"]
+        for b in blocks
+        if b["type"] == "context"
+        for el in b.get("elements", [])
+    ]
+    assert any("Totals:" in t for t in context_texts)
+    assert any("Scanned:" in t and "latest-cloudrun" in t for t in context_texts)
+
+
+def test_slack_blocks_chunk_long_new_lists() -> None:
+    """Section text > 3000 chars would be rejected by Slack; we split."""
+    many = [("latest-cloudrun", _finding(f"CVE-{i}")) for i in range(85)]
+    summary = DiffSummary(
+        new_detailed=many,
+        totals_by_severity={"HIGH": 85},
+        new_by_severity={"HIGH": 85},
+    )
+    blocks = build_slack_blocks(
+        summary, scan_errors=[], tag_digests={"latest-cloudrun": "sha256:abc1234567890"}
+    )
+    section_blocks = [b for b in blocks if b["type"] == "section"]
+    # 85 items / 40 per section = 3 section blocks for the new-detailed group.
+    assert len(section_blocks) >= 3
+
+
+def test_slack_blocks_include_skipped_context_line() -> None:
+    summary = DiffSummary(
+        skipped=[("latest-cloudrun", "pushed <6h ago")],
+        totals_by_severity={"HIGH": 1},
+        new_by_severity={"HIGH": 1},
+        new_detailed=[("latest-azure", _finding("CVE-X"))],
+    )
+    blocks = build_slack_blocks(
+        summary, scan_errors=[], tag_digests={"latest-azure": "sha256:abc1234567890"}
+    )
+    context_texts = [
+        el["text"]
+        for b in blocks
+        if b["type"] == "context"
+        for el in b.get("elements", [])
+    ]
+    assert any("Skipped:" in t and "latest-cloudrun" in t for t in context_texts)
+
+
+def test_slack_blocks_show_scan_errors_section() -> None:
+    summary = DiffSummary()
+    blocks = build_slack_blocks(
+        summary,
+        scan_errors=[("sha256:abc", "scout failed: timeout")],
+        tag_digests={"latest-cloudrun": "sha256:abc1234567890"},
+    )
+    sections = [b for b in blocks if b["type"] == "section"]
+    assert any(":x:" in b["text"]["text"] for b in sections)
+    assert any("Scan errors" in b["text"]["text"] for b in sections)
+
+
+# --- FindingKey -------------------------------------------------------------
+
+
+def test_finding_key_is_hashable_and_value_based() -> None:
+    a = FindingKey("CVE-1", "urllib3", "2.6.3")
+    b = FindingKey("CVE-1", "urllib3", "2.6.3")
+    c = FindingKey("CVE-1", "urllib3", "2.6.4")
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c
+    assert {a, b} == {a}


### PR DESCRIPTION
## Summary

- Adds a new CircleCI pipeline (`.circleci/vuln-scan-config.yml`) that runs Docker Scout against the production `latest-*` tags of `montecarlodata/agent`, diffs results against state in S3, and posts deltas to `#aaa-dev-error-alerts`.
- Motivation: Aikido is under-reporting container CVEs vs. Scout/Trivy on the same image digest (3 vs 104 vs 293 findings on `sha256:68e5754f10e8…` for `1.6.2-aws-proxied`). This adds defense-in-depth for already-published images.
- Pipeline is **scheduled separately in CircleCI UI** (daily 09:00 UTC). The intent is for @mrostan to wire that up and run the first build manually.

## How it works

- Script: `scripts/vuln_scan/scan.py` — all operational inputs (`--repo`, `--bucket`, `--slack-channel`, `--tag` × N) come from the pipeline config, not from code. State lives at `s3://<bucket>/vuln-scan/<repo-name>/state.json`.
- Skips any tag whose digest was pushed in the last 6h (Scout indexing delay would otherwise produce false "resolved" deltas).
- Alerts only on HIGH/CRITICAL deltas: new ones listed in full, MEDIUM/LOW/UNKNOWN summarized as counts. Reminders fire every 4 days while a HIGH+ CVE stays open. Resolved HIGH+ items also surfaced.
- First-run behaviour is intentionally "loud" — full backlog of HIGH/CRITICAL on every tracked image will post on the first scan.

## Tag list (one source of truth, in the CircleCI config)

Scanned: `latest-aws-proxied`, `latest-azure`, `latest-cloudrun`, `latest-generic`, `latest-lambda`

Excluded (with rationale inline in `vuln-scan-config.yml`):
- `latest-aws-generic` — mirrors `latest-aws-proxied`'s digest
- `latest-generic-base` — intermediate build artifact
- `latest-system-base` — published base layer; vulns surface in downstream images anyway

## Test plan

- [ ] Local: `pytest tests/test_vuln_scan.py` (32 tests; covers SARIF parsing, severity mapping, diff state machine for new/reminder/resolved/skipped/bootstrap, Slack block builder)
- [ ] Local: `black --check` and `pyright` against `scripts/vuln_scan/scan.py`
- [ ] CircleCI: add the new pipeline in project settings pointing at `.circleci/vuln-scan-config.yml`
- [ ] CircleCI: trigger the pipeline manually to verify auth (Docker Hub via `docker` context, S3 via `mc-circleci` role, Slack via `slack-secrets` context), Scout install, and a successful end-to-end run
- [ ] Verify state JSON is written to `s3://dev-mc-caas-infrastructure-templates/vuln-scan/agent/state.json`
- [ ] Verify Slack message lands in `#aaa-dev-error-alerts` with the bootstrap backlog
- [ ] Once stable, configure the daily 09:00 UTC scheduled trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)