### PR TITLE
YET-1256: Add list_dataspaces SOQL operation to Salesforce Data Cloud proxy client

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -45,19 +45,38 @@ _RETRY_KWARGS: dict[str, Any] = {
     "logger": logger,
 }
 
+# Salesforce core REST API version used by the SOQL dataspace discovery call
+# (see ``SalesforceDataCloudProxyClient.list_dataspaces``). Validated against
+# customer orgs returning DataSpaceApiName from the Dataspace SObject (YET-1256).
+_SOQL_API_VERSION = "v62.0"
+_LIST_DATASPACES_SOQL = "SELECT DataSpaceApiName FROM Dataspace"
+_DISCOVERY_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class _CapturingSession(requests.Session):
     """
-    Wraps the library's requests.Session to capture the Salesforce a360/token response
-    body regardless of status code.
+    Wraps requests.Session to capture the body and status of every HTTP call
+    made through this session, regardless of method, URL, or status code.
 
-    The salesforcecdpconnector library raises Error('CDP token retrieval failed with
-    code N') on non-200 and discards the body. On 200 responses with unexpected payloads
-    (e.g. Salesforce returning 200 with an error body for unknown dataspaces) the library
-    raises KeyError. In both cases the body is discarded before we can see it.
+    Two use patterns:
 
-    Capturing on all a360/token responses means we always have it available to include
-    in the RuntimeError that propagates back to the data-collector and into Datadog logs.
+    1. **Library-internal capture.** Caller swaps this session into the
+       salesforcecdpconnector library's authentication_helper via
+       `_attach_capturing_session` so the library's internal HTTP traffic is
+       captured. The library raises ``Error('CDP token retrieval failed with
+       code N')`` on non-200 a360/token responses and discards the body; on
+       200 responses with unexpected payloads it raises ``KeyError`` after
+       discarding the body. ``last_exchange_*`` reflects whichever request the
+       library last issued before raising, which is the call that caused the
+       error.
+    2. **Direct capture.** Caller instantiates and uses the session directly
+       (e.g. ``list_dataspaces`` makes raw OAuth + SOQL calls). After each call,
+       the caller can inspect ``last_exchange_*`` for response detail when
+       enriching errors or log records.
+
+    Bodies are pre-serialized to ``str(response.json())`` for ergonomic inclusion
+    in log fields; ``_redact_body`` masks ``access_token`` values before the
+    body is surfaced.
     """
 
     def __init__(self) -> None:
@@ -65,14 +84,21 @@ class _CapturingSession(requests.Session):
         self.last_exchange_body: str | None = None
         self.last_exchange_status: int | None = None
 
+    def _capture(self, response: requests.Response) -> None:
+        self.last_exchange_status = response.status_code
+        try:
+            self.last_exchange_body = str(response.json())
+        except Exception:
+            self.last_exchange_body = response.text[:500]
+
     def post(self, url: str, **kwargs: Any):  # type: ignore[override]
         response = super().post(url, **kwargs)
-        if "a360/token" in url:
-            self.last_exchange_status = response.status_code
-            try:
-                self.last_exchange_body = str(response.json())
-            except Exception:
-                self.last_exchange_body = response.text[:500]
+        self._capture(response)
+        return response
+
+    def get(self, url: str, **kwargs: Any):  # type: ignore[override]
+        response = super().get(url, **kwargs)
+        self._capture(response)
         return response
 
 
@@ -395,6 +421,142 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 extra={"table_count": len(tables)},
             )
         return [self._serialize_table(table) for table in tables]
+
+    def list_dataspaces(self) -> list[str]:
+        """
+        Discover Data Cloud dataspaces accessible to the run-as user via SOQL.
+
+        Mints a core OAuth token via the client-credentials grant against the
+        Salesforce core REST API (the ``salesforcecdpconnector`` library does
+        not expose its token-minting flow for arbitrary SOQL), then issues::
+
+            GET /services/data/{version}/query?q=SELECT DataSpaceApiName FROM Dataspace
+
+        with the core token as a Bearer credential. Pagination via
+        ``nextRecordsUrl`` is handled defensively even though the Dataspace
+        SObject typically returns a small result set.
+
+        The result is scoped to the integration user's Data Cloud permissions
+        in Salesforce. An empty list means the run-as user has no dataspace
+        access, not that the org has no dataspaces — surface the warning in
+        the caller (the data-collector) when this matters.
+
+        Raises ``RuntimeError`` with the HTTP status in the ``code NNN`` format
+        on any non-200 response. Both HTTP calls flow through a single
+        ``_CapturingSession`` so the redacted response body is surfaced in the
+        exception message and structured log record on failure.
+        """
+        domain = self._credentials.domain
+        session = _CapturingSession()
+
+        logger.info(
+            "Salesforce Data Cloud: discovering dataspaces via SOQL "
+            f"(domain={domain}, client_id={self._credentials.client_id[:8]}...)",
+        )
+
+        # 1. Mint a core OAuth token via the client-credentials grant.
+        token_url = f"https://{domain}/services/oauth2/token"
+        token_response = session.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self._credentials.client_id,
+                "client_secret": self._credentials.client_secret,
+            },
+            timeout=_DISCOVERY_REQUEST_TIMEOUT_SECONDS,
+        )
+        if token_response.status_code != 200:
+            body = _redact_body(session.last_exchange_body)
+            status = session.last_exchange_status
+            logger.warning(
+                "Salesforce Data Cloud: OAuth token mint failed during dataspace discovery",
+                extra={
+                    "exchange_status_code": status,
+                    "exchange_error_type": _classify_exchange_status(status),
+                    "exchange_response_body": body,
+                },
+            )
+            detail = f" (Salesforce response: {body})" if body else ""
+            raise RuntimeError(
+                f"Salesforce Data Cloud dataspace discovery: OAuth token mint "
+                f"failed with code {token_response.status_code}{detail}"
+            )
+
+        try:
+            access_token = token_response.json()["access_token"]
+        except (ValueError, KeyError) as e:
+            body = _redact_body(session.last_exchange_body)
+            raise RuntimeError(
+                f"Salesforce Data Cloud dataspace discovery: OAuth response missing "
+                f"access_token (HTTP {token_response.status_code}, "
+                f"Salesforce response: {body})"
+            ) from e
+
+        # 2. Issue SOQL query for the Dataspace SObject; follow nextRecordsUrl pagination.
+        dataspaces: list[str] = []
+        url: str | None = f"https://{domain}/services/data/{_SOQL_API_VERSION}/query"
+        params: dict[str, str] | None = {"q": _LIST_DATASPACES_SOQL}
+
+        while url is not None:
+            response = session.get(
+                url,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params=params,
+                timeout=_DISCOVERY_REQUEST_TIMEOUT_SECONDS,
+            )
+            if response.status_code != 200:
+                body = _redact_body(session.last_exchange_body)
+                status = session.last_exchange_status
+                logger.warning(
+                    "Salesforce Data Cloud: SOQL dataspace discovery failed",
+                    extra={
+                        "exchange_status_code": status,
+                        "exchange_error_type": _classify_exchange_status(status),
+                        "exchange_response_body": body,
+                    },
+                )
+                detail = f" (Salesforce response: {body})" if body else ""
+                raise RuntimeError(
+                    f"Salesforce Data Cloud dataspace discovery: SOQL query failed "
+                    f"with code {response.status_code}{detail}"
+                )
+
+            try:
+                payload = response.json()
+            except ValueError as e:
+                body = _redact_body(session.last_exchange_body)
+                raise RuntimeError(
+                    f"Salesforce Data Cloud dataspace discovery: non-JSON response "
+                    f"(HTTP {response.status_code}, Salesforce response: {body})"
+                ) from e
+
+            for record in payload.get("records", []):
+                name = record.get("DataSpaceApiName")
+                if name:
+                    dataspaces.append(name)
+
+            if payload.get("done", True):
+                url = None
+            else:
+                next_records_url = payload.get("nextRecordsUrl")
+                if not next_records_url:
+                    raise RuntimeError(
+                        "Salesforce Data Cloud dataspace discovery: done=False but "
+                        "no nextRecordsUrl in response"
+                    )
+                # nextRecordsUrl already encodes the cursor in the path.
+                url = f"https://{domain}{next_records_url}"
+                params = None
+
+        logger.info(
+            "Salesforce Data Cloud: discovered dataspaces via SOQL",
+            extra={
+                "discovered_dataspace_count": len(dataspaces),
+                # Lists/dicts may be redacted in the log pipeline; keep as a string.
+                "discovered_dataspaces_csv": ", ".join(dataspaces),
+            },
+        )
+        return dataspaces
 
     def _serialize_table(self, table: GenieTable) -> dict:
         fields: list[Field] = table.fields

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -449,7 +449,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         domain = self._credentials.domain
         session = _CapturingSession()
 
-        logger.info(
+        logger.debug(
             "Salesforce Data Cloud: discovering dataspaces via SOQL "
             f"(domain={domain}, client_id={self._credentials.client_id[:8]}...)",
         )

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -963,6 +963,220 @@ class SalesforceDataCloudProxyClientTests(TestCase):
                 "list_tables(None) on a scoped client must not include dataspace in a360/token POST",
             )
 
+    # -- Dataspace auto-discovery via SOQL (YET-1256) ---------------------------------
+
+    _PROXY_CLIENT_LOGGER = "apollo.integrations.db.salesforce_data_cloud_proxy_client"
+    _SOQL_QUERY_URL = "https://test.salesforce.com/services/data/v62.0/query"
+
+    def _add_soql_callback(self, callback):
+        """Register a callback for the SOQL dataspace discovery endpoint."""
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SOQL_QUERY_URL,
+            callback=callback,
+        )
+
+    def _list_dataspaces_operation(self) -> dict:
+        return {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [{"method": "list_dataspaces"}],
+        }
+
+    def test_list_dataspaces(self):
+        """Success: SOQL returns N dataspaces and `list_dataspaces` returns the API names."""
+        discovered = ["default", "CSG", "Unified_Knowledge", "Professional_Services"]
+        self._add_soql_callback(
+            Mock(
+                return_value=(
+                    200,
+                    {},
+                    json.dumps(
+                        {
+                            "records": [{"DataSpaceApiName": ds} for ds in discovered],
+                            "done": True,
+                        }
+                    ),
+                )
+            )
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_dataspaces",
+            operation_dict=self._list_dataspaces_operation(),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], discovered)
+
+    def test_list_dataspaces_empty(self):
+        """An empty `records` array returns an empty result. The caller (data-collector)
+        decides whether that's a permission gap worth surfacing — the agent just reports it.
+
+        The agent's RPC layer serializes Python `[]` to `{}` over the wire, so this test
+        asserts the result is falsy rather than pinning a specific representation."""
+        self._add_soql_callback(
+            Mock(return_value=(200, {}, json.dumps({"records": [], "done": True})))
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_dataspaces_empty",
+            operation_dict=self._list_dataspaces_operation(),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        self.assertFalse(
+            response.result[ATTRIBUTE_NAME_RESULT],
+            msg=f"expected empty result, got {response.result[ATTRIBUTE_NAME_RESULT]!r}",
+        )
+
+    def test_list_dataspaces_paginates_via_next_records_url(self):
+        """`done=False` with `nextRecordsUrl` triggers a follow-up GET; results accumulate."""
+        page_1 = {
+            "records": [
+                {"DataSpaceApiName": "page1_ds1"},
+                {"DataSpaceApiName": "page1_ds2"},
+            ],
+            "done": False,
+            "nextRecordsUrl": "/services/data/v62.0/query/01gXX-page2",
+        }
+        page_2 = {
+            "records": [{"DataSpaceApiName": "page2_ds1"}],
+            "done": True,
+        }
+
+        first_page_url = self._SOQL_QUERY_URL
+        next_page_url = (
+            "https://test.salesforce.com/services/data/v62.0/query/01gXX-page2"
+        )
+
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=first_page_url,
+            callback=Mock(return_value=(200, {}, json.dumps(page_1))),
+        )
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=next_page_url,
+            callback=Mock(return_value=(200, {}, json.dumps(page_2))),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_dataspaces_paginates",
+            operation_dict=self._list_dataspaces_operation(),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        self.assertEqual(
+            response.result[ATTRIBUTE_NAME_RESULT],
+            ["page1_ds1", "page1_ds2", "page2_ds1"],
+        )
+
+    def test_list_dataspaces_soql_http_error_surfaces_status(self):
+        """A non-200 from the SOQL endpoint propagates as a RuntimeError with `code NNN`
+        in the message so the data-collector's `_extract_exchange_http_status` can pick it up.
+        """
+        self._add_soql_callback(
+            Mock(
+                return_value=(
+                    401,
+                    {},
+                    json.dumps(
+                        [
+                            {
+                                "errorCode": "INVALID_SESSION_ID",
+                                "message": "Session expired",
+                            }
+                        ]
+                    ),
+                )
+            )
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_dataspaces_soql_http_error",
+            operation_dict=self._list_dataspaces_operation(),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        message = str(response.result)
+        self.assertIn("code 401", message)
+        self.assertIn("INVALID_SESSION_ID", message)
+
+    def test_list_dataspaces_oauth_http_error_redacts_body(self):
+        """A non-200 from the OAuth token mint propagates as a RuntimeError with
+        the response body redacted — no raw `access_token` string in the exception."""
+        leaked_token = "secret-token-should-be-redacted"
+        leaked_body = json.dumps(
+            {"error": "invalid_client", "access_token": leaked_token}
+        )
+
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/oauth2/token"
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/oauth2/token",
+            callback=Mock(return_value=(401, {}, leaked_body)),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_list_dataspaces_oauth_http_error",
+            operation_dict=self._list_dataspaces_operation(),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        message = str(response.result)
+        self.assertIn("code 401", message)
+        self.assertIn("[REDACTED]", message)
+        self.assertNotIn(leaked_token, message)
+
+    def test_list_dataspaces_rate_limit_logs_classification(self):
+        """A 429 surfaces as a RuntimeError AND the structured log record carries
+        `exchange_error_type=rate_limited` so Datadog queries (e.g.
+        `@exchange_error_type:rate_limited`) catch it."""
+        self._add_soql_callback(
+            Mock(
+                return_value=(
+                    429,
+                    {},
+                    json.dumps(
+                        [{"errorCode": "REQUEST_LIMIT_EXCEEDED", "message": "Too many"}]
+                    ),
+                )
+            )
+        )
+
+        with self.assertLogs(self._PROXY_CLIENT_LOGGER, level="WARNING") as logs:
+            response = self.agent.execute_operation(
+                connection_type="salesforce-data-cloud",
+                operation_name="test_list_dataspaces_rate_limit",
+                operation_dict=self._list_dataspaces_operation(),
+                credentials=self.credentials,
+            )
+
+        self.assertTrue(response.is_error)
+        self.assertIn("code 429", str(response.result))
+        rate_limited_records = [
+            r
+            for r in logs.records
+            if getattr(r, "exchange_error_type", None) == "rate_limited"
+        ]
+        self.assertTrue(
+            rate_limited_records,
+            f"expected a rate_limited classification in logs; got {logs.output}",
+        )
+
 
 class SalesforceDataCloudRetryTests(TestCase):
     """Cover the transient-network-error retry that wraps cursor and list_tables.


### PR DESCRIPTION
## Summary

Adds a `list_dataspaces() -> list[str]` method to `SalesforceDataCloudProxyClient` so the data-collector can dispatch SOQL dataspace discovery through the agent. This is the apollo-agent companion to [YET-1177](https://linear.app/montecarloai/issue/YET-1177) (DC-side auto-discovery for non-self-hosted credentials); it unblocks [YET-1257](https://linear.app/montecarloai/issue/YET-1257), which wires the DC's self-hosted branch through this operation so self-hosted customers can also avoid manually configuring `dataspaces`.

The method mints a core OAuth token via the client-credentials grant against `/services/oauth2/token` (the `salesforcecdpconnector` library does not expose its token-minting flow for arbitrary SOQL), then issues `GET /services/data/v62.0/query?q=SELECT DataSpaceApiName FROM Dataspace` with the core token as a Bearer credential. `nextRecordsUrl` pagination is handled defensively. The HTTP status is embedded in the `code NNN` format on any non-200 response so the data-collector's `_extract_exchange_http_status` can surface it for structured Datadog queries.

Both HTTP calls flow through a single `_CapturingSession`, so the redacted response body is surfaced in the exception message and structured log record on failure — no raw `access_token` strings can leak into errors or logs.

## Companion work (same Linear ticket)

A small data-collector PR will follow under YET-1256: add an `@agent_operation`-decorated `list_dataspaces` passthrough on `SalesforceDataCloudProxyConnection` so the DC can dispatch this new method. That's a fresh `/start-work` in `data-collector` once this PR is open and the method shape is locked.

## Key Decisions

- **OAuth is done by us, not the library.** The `salesforcecdpconnector` library owns OAuth for its Data Cloud endpoints but doesn't expose token minting for arbitrary SOQL against the core REST API. We POST to `/services/oauth2/token` directly — same shape as the data-collector's `_discover_dataspaces`.
- **No retry on either HTTP call.** Parity with `_discover_dataspaces` on the DC side. The cursor's `_RETRY_KWARGS` stays scoped to query execution where stale pooled connections are the actual failure mode.
- **`_CapturingSession` generalized to capture all GET/POST traffic** (was: only `a360/token` POSTs). New `get()` override, a private `_capture` method, and dropped URL filter. Library-internal callers still work — `last_exchange_*` now reflects whichever request the library last issued before raising, which is the call that caused the error. Strict improvement for error enrichment.
- **No version-bumping in source.** Agent version is generated by CI from git tags + pipeline number into `apollo/agent/version` at Docker build time. YET-1257's `SALESFORCE_DATA_CLOUD_AGENT_MIN_VERSION` bump on the DC side will gate on whatever version emerges from this release.
- **No `@agent_operation`-equivalent registration on the agent side** — confirmed via the proxy-client factory dispatch mechanism. The agent dispatches proxy-client methods by name lookup, so adding the method is sufficient.

## Testing

- 6 new tests in `tests/test_salesforce_data_cloud_client.py`: success, empty, pagination via `nextRecordsUrl`, SOQL HTTP 401 with status embedded, OAuth HTTP 401 with body redaction (verified no token leak), HTTP 429 with `exchange_error_type=rate_limited` in the structured log record.
- 22 existing tests continue to pass — the `_CapturingSession` generalization is benign for the existing `list_tables` flow.
- Black + pyright clean on changed files.

## Linked

- Predecessor: [YET-1177](https://linear.app/montecarloai/issue/YET-1177) — DC-side auto-discovery (non-self-hosted, shipped)
- This ticket: [YET-1256](https://linear.app/montecarloai/issue/YET-1256)
- Successor: [YET-1257](https://linear.app/montecarloai/issue/YET-1257) — DC self-hosted wiring + `SALESFORCE_DATA_CLOUD_AGENT_MIN_VERSION` bump (blocked on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)