### PR TITLE
feat(ctp): Fivetran CTP for self-hosted Basic auth (YET-1265)

### DIFF
--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -436,6 +436,7 @@ _CLIENT_FACTORY_MAPPING = {
     # — DC's MuleSoft REST client invokes both the inherited ops and the
     # MuleSoft-specific op through the same client instance.
     "mulesoft": _get_proxy_client_mulesoft,
+    "fivetran": _get_proxy_client_http,
 }
 
 

--- a/apollo/integrations/ctp/defaults/fivetran.py
+++ b/apollo/integrations/ctp/defaults/fivetran.py
@@ -1,0 +1,40 @@
+from typing import NotRequired, Required, TypedDict
+
+from apollo.integrations.ctp.models import CtpConfig, MapperConfig, TransformStep
+from apollo.integrations.ctp.registry import CtpRegistry
+
+
+class FivetranClientArgs(TypedDict):
+    # Shape consumed by HttpProxyClient. The DC supplies full Fivetran API URLs
+    # to `do_request` directly; the agent only attaches the Basic auth header.
+    token: Required[str]
+    auth_type: NotRequired[str]  # always "Basic"
+
+
+FIVETRAN_DEFAULT_CTP = CtpConfig(
+    name="fivetran-default",
+    steps=[
+        # Encode fivetran_api_key:fivetran_api_password into a base64 token.
+        # Skipped on the DC pre-shaped path (raw.token already present).
+        TransformStep(
+            type="encode_basic_auth",
+            when="raw.token is not defined",
+            input={
+                "username": "{{ raw.fivetran_api_key | default(none) }}",
+                "password": "{{ raw.fivetran_api_password | default(none) }}",
+            },
+            output={"token": "fivetran_basic_token"},
+        ),
+    ],
+    mapper=MapperConfig(
+        name="fivetran_client_args",
+        schema=FivetranClientArgs,
+        field_map={
+            "token": "{{ derived.fivetran_basic_token | default(raw.token | default(none)) }}",
+            "auth_type": "Basic",
+        },
+    ),
+)
+
+
+CtpRegistry.register("fivetran", FIVETRAN_DEFAULT_CTP)

--- a/apollo/integrations/ctp/registry.py
+++ b/apollo/integrations/ctp/registry.py
@@ -42,6 +42,7 @@ def _discover() -> None:
     import apollo.integrations.ctp.defaults.mysql  # noqa: F401
     import apollo.integrations.ctp.defaults.oracle  # noqa: F401
     import apollo.integrations.ctp.defaults.mulesoft  # noqa: F401
+    import apollo.integrations.ctp.defaults.fivetran  # noqa: F401
 
 
 def _ensure_initialized() -> None:

--- a/apollo/integrations/ctp/transforms/encode_basic_auth.py
+++ b/apollo/integrations/ctp/transforms/encode_basic_auth.py
@@ -1,0 +1,31 @@
+import base64
+
+from apollo.integrations.ctp.models import PipelineState, TransformStep
+from apollo.integrations.ctp.transforms.base import Transform
+from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+
+class EncodeBasicAuthTransform(Transform):
+    """Base64-encode username:password into a Basic auth token.
+
+    Step input:
+        username (required): template resolving to the username/key string.
+        password (required): template resolving to the password/secret string.
+
+    Step output:
+        token (required): derived key where the base64-encoded string is stored.
+    """
+
+    required_input_keys = ("username", "password")
+    optional_input_keys = ()
+    required_output_keys = ("token",)
+    optional_output_keys = ()
+
+    def _execute(self, step: TransformStep, state: PipelineState) -> None:
+        username = self._require(step, state, "username", "required for Basic auth")
+        password = self._require(step, state, "password", "required for Basic auth")
+        token = base64.b64encode(f"{username}:{password}".encode()).decode()
+        state.derived[step.output["token"]] = token
+
+
+TransformRegistry.register("encode_basic_auth", EncodeBasicAuthTransform)

--- a/apollo/integrations/ctp/transforms/registry.py
+++ b/apollo/integrations/ctp/transforms/registry.py
@@ -23,6 +23,7 @@ def _discover() -> None:
     import apollo.integrations.ctp.transforms.resolve_informatica_session  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_redshift_credentials  # noqa: F401
     import apollo.integrations.ctp.transforms.resolve_mulesoft_endpoints  # noqa: F401
+    import apollo.integrations.ctp.transforms.encode_basic_auth  # noqa: F401
 
 
 def _ensure_initialized() -> None:

--- a/tests/ctp/test_encode_basic_auth.py
+++ b/tests/ctp/test_encode_basic_auth.py
@@ -1,0 +1,91 @@
+"""Unit tests for the encode_basic_auth transform."""
+
+import base64
+from unittest import TestCase
+
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.models import PipelineState, TransformStep
+from apollo.integrations.ctp.transforms.encode_basic_auth import (
+    EncodeBasicAuthTransform,
+)
+
+
+def _make_step(
+    input_map: dict | None = None,
+    output_map: dict | None = None,
+) -> TransformStep:
+    return TransformStep(
+        type="encode_basic_auth",
+        input=input_map or {"username": "{{ raw.user }}", "password": "{{ raw.pass }}"},
+        output=output_map or {"token": "auth_token"},
+    )
+
+
+class TestEncodeBasicAuth(TestCase):
+    def test_encodes_username_password(self):
+        state = PipelineState(raw={"user": "alice", "pass": "secret"})
+        step = _make_step()
+
+        EncodeBasicAuthTransform().execute(step, state)
+
+        expected = base64.b64encode(b"alice:secret").decode()
+        self.assertEqual(expected, state.derived["auth_token"])
+
+    def test_special_characters(self):
+        state = PipelineState(raw={"user": "u:s@r", "pass": "p/a+ss="})
+        step = _make_step()
+
+        EncodeBasicAuthTransform().execute(step, state)
+
+        expected = base64.b64encode(b"u:s@r:p/a+ss=").decode()
+        self.assertEqual(expected, state.derived["auth_token"])
+
+    def test_missing_username_raises(self):
+        state = PipelineState(raw={"pass": "secret"})
+        step = _make_step()
+
+        with self.assertRaises((CtpPipelineError, Exception)):
+            EncodeBasicAuthTransform().execute(step, state)
+
+    def test_missing_password_raises(self):
+        state = PipelineState(raw={"user": "alice"})
+        step = _make_step()
+
+        with self.assertRaises((CtpPipelineError, Exception)):
+            EncodeBasicAuthTransform().execute(step, state)
+
+    def test_empty_username_raises(self):
+        state = PipelineState(raw={"user": "", "pass": "secret"})
+        step = _make_step()
+
+        with self.assertRaises(CtpPipelineError):
+            EncodeBasicAuthTransform().execute(step, state)
+
+    def test_empty_password_raises(self):
+        state = PipelineState(raw={"user": "alice", "pass": ""})
+        step = _make_step()
+
+        with self.assertRaises(CtpPipelineError):
+            EncodeBasicAuthTransform().execute(step, state)
+
+    def test_required_input_keys_enforced(self):
+        state = PipelineState(raw={"user": "alice", "pass": "secret"})
+        step = TransformStep(
+            type="encode_basic_auth",
+            input={"username": "{{ raw.user }}"},  # missing password
+            output={"token": "auth_token"},
+        )
+
+        with self.assertRaises(CtpPipelineError):
+            EncodeBasicAuthTransform().execute(step, state)
+
+    def test_required_output_keys_enforced(self):
+        state = PipelineState(raw={"user": "alice", "pass": "secret"})
+        step = TransformStep(
+            type="encode_basic_auth",
+            input={"username": "{{ raw.user }}", "password": "{{ raw.pass }}"},
+            output={},  # missing token
+        )
+
+        with self.assertRaises(CtpPipelineError):
+            EncodeBasicAuthTransform().execute(step, state)

--- a/tests/ctp/test_fivetran_ctp.py
+++ b/tests/ctp/test_fivetran_ctp.py
@@ -1,0 +1,146 @@
+"""
+Integration tests for the fivetran connection_type CTP pipeline.
+
+Verifies the self-hosted path (fivetran_api_key + fivetran_api_password → Basic
+auth token), the pre-shaped (DC) path, failure handling, and the assertion that
+resolved connect_args match what HttpProxyClient consumes.
+"""
+
+import base64
+from unittest import TestCase
+
+from apollo.integrations.ctp.defaults.fivetran import (
+    FIVETRAN_DEFAULT_CTP,
+    FivetranClientArgs,
+)
+from apollo.integrations.ctp.errors import CtpPipelineError
+from apollo.integrations.ctp.pipeline import CtpPipeline
+from apollo.integrations.ctp.registry import CtpRegistry
+
+
+def _resolve(credentials: dict) -> dict:
+    return CtpPipeline().execute(FIVETRAN_DEFAULT_CTP, credentials)
+
+
+_SELF_HOSTED_CREDS = {
+    "fivetran_api_key": "actual-key",
+    "fivetran_api_password": "actual-password",
+}
+
+
+class TestRegistration(TestCase):
+    def test_fivetran_registered(self):
+        self.assertIsNotNone(CtpRegistry.get("fivetran"))
+
+
+class TestSelfHostedPath(TestCase):
+    def test_basic_auth_token_encoded(self):
+        args = _resolve(_SELF_HOSTED_CREDS)
+
+        expected_token = base64.b64encode(b"actual-key:actual-password").decode()
+        self.assertEqual(expected_token, args["token"])
+
+    def test_auth_type_always_basic(self):
+        args = _resolve(_SELF_HOSTED_CREDS)
+
+        self.assertEqual("Basic", args["auth_type"])
+
+    def test_special_characters_in_credentials(self):
+        creds = {
+            "fivetran_api_key": "key:with:colons",
+            "fivetran_api_password": "p@ss=word/+",
+        }
+        args = _resolve(creds)
+
+        expected_token = base64.b64encode(b"key:with:colons:p@ss=word/+").decode()
+        self.assertEqual(expected_token, args["token"])
+        self.assertEqual("Basic", args["auth_type"])
+
+
+class TestPreShapedPath(TestCase):
+    def test_pre_shaped_token_skips_encoding(self):
+        args = _resolve({"token": "pre-computed-b64", "auth_type": "Basic"})
+
+        self.assertEqual("pre-computed-b64", args["token"])
+        self.assertEqual("Basic", args["auth_type"])
+
+    def test_pre_shaped_with_extra_credentials_still_skips(self):
+        # Even with api_key/password present, an existing token short-circuits
+        # the encode_basic_auth transform.
+        args = _resolve(
+            {
+                "token": "pre-computed-b64",
+                "fivetran_api_key": "key",
+                "fivetran_api_password": "password",
+            }
+        )
+
+        self.assertEqual("pre-computed-b64", args["token"])
+
+
+class TestFailurePaths(TestCase):
+    def test_missing_api_key_raises(self):
+        with self.assertRaises(CtpPipelineError):
+            _resolve({"fivetran_api_password": "password"})
+
+    def test_missing_api_password_raises(self):
+        with self.assertRaises(CtpPipelineError):
+            _resolve({"fivetran_api_key": "key"})
+
+    def test_empty_credentials_raises(self):
+        with self.assertRaises(CtpPipelineError):
+            _resolve({})
+
+
+class TestRegistryResolvePath(TestCase):
+    """End-to-end through CtpRegistry.resolve — verifies connect_args wrapping."""
+
+    def test_self_hosted_via_registry(self):
+        result = CtpRegistry.resolve("fivetran", _SELF_HOSTED_CREDS)
+
+        self.assertIn("connect_args", result)
+        args = result["connect_args"]
+        expected_token = base64.b64encode(b"actual-key:actual-password").decode()
+        self.assertEqual(expected_token, args["token"])
+        self.assertEqual("Basic", args["auth_type"])
+
+    def test_pre_shaped_via_registry(self):
+        """DC pre-shaped path: credentials arrive wrapped in connect_args."""
+        creds = {
+            "connect_args": {
+                "token": "pre-computed",
+                "auth_type": "Basic",
+            }
+        }
+        result = CtpRegistry.resolve("fivetran", creds)
+
+        args = result["connect_args"]
+        self.assertEqual("pre-computed", args["token"])
+        self.assertEqual("Basic", args["auth_type"])
+
+
+class TestHttpProxyClientContract(TestCase):
+    """Load-bearing bridge between CTP output and HttpProxyClient consumer.
+    If FivetranClientArgs drifts from what HttpProxyClient reads, this test
+    catches it before the integration fails at runtime.
+    """
+
+    def test_connect_args_match_http_proxy_client_contract(self):
+        args = _resolve(_SELF_HOSTED_CREDS)
+
+        # HttpProxyClient reads: token, auth_type, auth_header (default), ssl_verify (optional)
+        expected_required = {"token", "auth_type"}
+        self.assertTrue(
+            expected_required.issubset(args.keys()),
+            f"Missing required: {expected_required - args.keys()}",
+        )
+        # Any extra key must be in FivetranClientArgs schema.
+        allowed = (
+            FivetranClientArgs.__required_keys__ | FivetranClientArgs.__optional_keys__
+        )
+        unknown = args.keys() - allowed
+        self.assertEqual(
+            set(),
+            unknown,
+            f"connect_args has keys outside FivetranClientArgs: {unknown}",
+        )


### PR DESCRIPTION
## Summary

- Add a Fivetran CTP that converts self-hosted credentials (`fivetran_api_key` + `fivetran_api_password`) into `token` + `auth_type: "Basic"` for `HttpProxyClient`, fixing 401s on self-hosted Fivetran connections
- Introduce a generic `encode_basic_auth` transform (base64-encodes `username:password`) reusable by any future Basic auth connector
- Register `"fivetran"` connection type in `_CLIENT_FACTORY_MAPPING` → `_get_proxy_client_http` (no custom proxy client subclass needed)

## Context

Self-hosted Fivetran credentials are broken. DC forwards raw vault references to the agent, which resolves them into `fivetran_api_key` + `fivetran_api_password`. But `HttpProxyClient` only knows how to set an `Authorization` header from `token` + `auth_type` fields — it can't construct Basic auth from Fivetran's key+password fields. Result: requests go out with no auth header → 401.

The non-self-hosted path works because DC pre-computes the base64 token. For self-hosted, the agent resolves credentials from vault/file and needs to do the conversion itself.

## Credential flows

**Self-hosted**: `fivetran_api_key` + `fivetran_api_password` → `encode_basic_auth` transform → `base64(key:password)` → `token` + `auth_type: "Basic"`

**Pre-shaped (DC, after DC-side update)**: credentials arrive with `token` + `auth_type` already set → transform is skipped (`when="raw.token is not defined"`) → passthrough

## Changes

| File | What |
|------|------|
| `apollo/integrations/ctp/transforms/encode_basic_auth.py` | New generic transform: base64-encodes `username:password` |
| `apollo/integrations/ctp/defaults/fivetran.py` | Fivetran CTP config with `FivetranClientArgs` TypedDict |
| `apollo/integrations/ctp/registry.py` | Register fivetran CTP in `_discover()` |
| `apollo/integrations/ctp/transforms/registry.py` | Register `encode_basic_auth` transform in `_discover()` |
| `apollo/agent/proxy_client_factory.py` | Add `"fivetran": _get_proxy_client_http` to factory mapping |
| `tests/ctp/test_fivetran_ctp.py` | 12 integration tests (self-hosted, pre-shaped, failures, contract) |
| `tests/ctp/test_encode_basic_auth.py` | 8 unit tests for the transform |

## Test plan

- [x] All 20 new tests pass
- [x] All 510 existing CTP + proxy client factory tests pass
- [x] Lint passes (ruff)
- [ ] DC-side follow-up: switch `get_agent_client` to `FIVETRAN_AGENT_CONNECTION_TYPE`, add `FIVETRAN_SELF_HOSTED_AGENT_MIN_VERSION`, wrap non-self-hosted creds in `connect_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)