### PR TITLE
feat(azure): support AuthLevel.ANONYMOUS when Easy Auth handles authentication

### DIFF
--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -69,7 +69,15 @@ main.agent.platform_provider = AzurePlatformProvider()
 main.agent.log_context = log_context
 wsgi_middleware = WsgiMiddleware(main.app.wsgi_app)
 
-app = df.DFApp(http_auth_level=func.AuthLevel.FUNCTION)
+# When Easy Auth (Azure App Service Authentication) handles authentication via
+# a service principal, function-level auth keys are redundant and must be
+# disabled — the DC only sends a Bearer token, not a function key.
+auth_level = (
+    func.AuthLevel.ANONYMOUS
+    if os.getenv("MCD_AUTH_TYPE") == "AZURE_FUNCTION_SERVICE_PRINCIPAL"
+    else func.AuthLevel.FUNCTION
+)
+app = df.DFApp(http_auth_level=auth_level)
 
 
 @app.route(route="async/api/v1/agent/execute/{connection_type}/{operation_name}")

--- a/tests/test_azure_auth_level.py
+++ b/tests/test_azure_auth_level.py
@@ -1,0 +1,58 @@
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+
+class TestAzureAuthLevel(TestCase):
+    """Tests for MCD_AUTH_TYPE-driven auth level selection in the Azure Function App."""
+
+    @staticmethod
+    def _resolve_auth_level():
+        """Replicates the auth_level logic from function_app.py for unit testing.
+
+        The actual auth_level is computed at module import time, making it
+        impractical to test via reimport.  This helper mirrors the exact
+        conditional so we can validate the env-var contract in isolation.
+        """
+        import azure.functions as func
+
+        return (
+            func.AuthLevel.ANONYMOUS
+            if os.getenv("MCD_AUTH_TYPE") == "AZURE_FUNCTION_SERVICE_PRINCIPAL"
+            else func.AuthLevel.FUNCTION
+        )
+
+    def test_auth_level_default_when_env_var_not_set(self):
+        """Without MCD_AUTH_TYPE, auth level should be FUNCTION (existing behavior)."""
+        import azure.functions as func
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MCD_AUTH_TYPE", None)
+            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION
+
+    def test_auth_level_function_when_app_key(self):
+        """With MCD_AUTH_TYPE=AZURE_FUNCTION_APP_KEY, auth level should be FUNCTION."""
+        import azure.functions as func
+
+        with patch.dict(
+            os.environ, {"MCD_AUTH_TYPE": "AZURE_FUNCTION_APP_KEY"}, clear=False
+        ):
+            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION
+
+    def test_auth_level_anonymous_when_service_principal(self):
+        """With MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL, auth level should be ANONYMOUS."""
+        import azure.functions as func
+
+        with patch.dict(
+            os.environ,
+            {"MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL"},
+            clear=False,
+        ):
+            assert self._resolve_auth_level() == func.AuthLevel.ANONYMOUS
+
+    def test_auth_level_function_for_unknown_value(self):
+        """An unrecognized MCD_AUTH_TYPE value should default to FUNCTION."""
+        import azure.functions as func
+
+        with patch.dict(os.environ, {"MCD_AUTH_TYPE": "SOMETHING_ELSE"}, clear=False):
+            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION


### PR DESCRIPTION
## Summary

- When `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL`, the Azure Function App auth level is set to `ANONYMOUS` so that Easy Auth (Azure App Service Authentication) handles Bearer token validation and function keys are not required.
- When `MCD_AUTH_TYPE` is unset or any other value (e.g. `AZURE_FUNCTION_APP_KEY`), behavior is unchanged — `AuthLevel.FUNCTION` requires function keys as before.
- This is the agent-side counterpart to the `terraform-azurerm-mcd-agent` SP auth support (YET-1216). The Terraform module sets `MCD_AUTH_TYPE` in the Function App's app settings.

## Changes

- **`apollo/interfaces/azure/function_app.py`**: Read `MCD_AUTH_TYPE` env var to conditionally set auth level to `ANONYMOUS` or `FUNCTION`.
- **`tests/test_azure_auth_level.py`**: 4 unit tests covering all env var states (unset, `AZURE_FUNCTION_APP_KEY`, `AZURE_FUNCTION_SERVICE_PRINCIPAL`, unknown value).

## Test plan

- [x] `MCD_AUTH_TYPE` not set → auth level is `FUNCTION`
- [x] `MCD_AUTH_TYPE=AZURE_FUNCTION_APP_KEY` → auth level is `FUNCTION`
- [x] `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL` → auth level is `ANONYMOUS`
- [x] Unknown `MCD_AUTH_TYPE` value → auth level is `FUNCTION`
- [ ] E2E: Deploy with SP auth enabled, verify requests with Bearer token (no function key) succeed
- [ ] E2E: Deploy without SP auth, verify function key is still required

🤖 Generated with [Claude Code](https://claude.com/claude-code)