### PR TITLE
feat(azure): validate Easy Auth before allowing ANONYMOUS auth (YET-1216)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ gcloud run deploy CLOUD_RUN_SERVICE_NAME_HERE --image montecarlodata/pre-release
 
 ### Azure deployment
 You can check the README file for Azure [here](apollo/interfaces/azure/README.md).
-For authentication, you need to get the app-key for the Azure App and pass it in the `x-functions-key` header.
+For authentication, you can either use a function key (pass it in the `x-functions-key` header) or configure Service Principal authentication via Azure Easy Auth (set `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL`). See the [Azure README](apollo/interfaces/azure/README.md#authentication-modes) for details.
 
 ### Lambda deployment
 You can build the Docker image for the Lambda agent using:

--- a/apollo/interfaces/azure/README.md
+++ b/apollo/interfaces/azure/README.md
@@ -83,3 +83,24 @@ Updating the image using Azure Resource Manager
   ```shell
   curl -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -X PATCH "https://management.azure.com/subscriptions/<subscription_id>/resourceGroups/<resource_group_name>/providers/Microsoft.Web/sites/<function_name>/config/appsettings?api-version=2022-03-01" -d '{"properties": {"test_env_var": "1234"}}'
   ```
+
+### Authentication Modes
+
+The Azure Function supports two authentication modes, controlled by the `MCD_AUTH_TYPE` environment variable:
+
+**Function Key (default)**
+
+When `MCD_AUTH_TYPE` is unset or set to `AZURE_FUNCTION_APP_KEY`, the function requires a valid function key passed in the `x-functions-key` header. This is the default behavior.
+
+**Service Principal (Easy Auth)**
+
+When `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL`, the function sets `AuthLevel.ANONYMOUS` and relies on Azure Easy Auth (App Service Authentication) to validate Bearer tokens. The DC sends a Bearer token instead of a function key.
+
+Before starting, the function validates that Easy Auth is actually configured by checking these platform-injected environment variables:
+- `WEBSITE_AUTH_ENABLED` — must be `True` (read-only, set by Azure when Easy Auth is enabled)
+- `WEBSITE_AUTH_CLIENT_ID` — must be present (set by Azure during Easy Auth setup)
+- `WEBSITE_AUTH_OPENID_ISSUER` — must be present (set by Azure during Easy Auth setup)
+
+If any of these are missing or invalid, the function **refuses to start** with a `RuntimeError` — this fail-closed design prevents the function from running unauthenticated if Easy Auth was not properly configured.
+
+To enable Easy Auth on a Function App, configure Authentication in the Azure portal or via ARM/Bicep with a Microsoft Entra ID provider.

--- a/apollo/interfaces/azure/auth.py
+++ b/apollo/interfaces/azure/auth.py
@@ -1,0 +1,44 @@
+"""Resolve Azure Function auth level based on Easy Auth configuration.
+
+Extracted from function_app.py so the logic can be imported in tests
+without triggering module-level side effects (Azure Monitor, logging setup).
+"""
+
+import os
+
+import azure.functions as func
+
+# Presence-only check: these must be set (non-empty) for Easy Auth to be
+# considered configured.
+_EASY_AUTH_PRESENCE_VARS = (
+    "WEBSITE_AUTH_CLIENT_ID",
+    "WEBSITE_AUTH_OPENID_ISSUER",
+)
+
+
+def resolve_auth_level() -> func.AuthLevel:
+    """Determine the appropriate auth level for the Azure Function App.
+
+    When MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL, validates
+    that Easy Auth is actually enabled by checking platform-injected env vars.
+    Raises RuntimeError at startup if Easy Auth is not configured — fail-closed.
+    """
+    if os.getenv("MCD_AUTH_TYPE") != "AZURE_FUNCTION_SERVICE_PRINCIPAL":
+        return func.AuthLevel.FUNCTION
+
+    # WEBSITE_AUTH_ENABLED must be explicitly "True" (case-insensitive);
+    # CLIENT_ID and OPENID_ISSUER just need to be present.
+    missing = [v for v in _EASY_AUTH_PRESENCE_VARS if not os.getenv(v)]
+    if os.getenv("WEBSITE_AUTH_ENABLED", "").lower() != "true":
+        missing.insert(0, "WEBSITE_AUTH_ENABLED")
+    if missing:
+        raise RuntimeError(
+            "MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL but Easy "
+            "Auth does not appear to be enabled — the following platform "
+            f"environment variables are missing or invalid: {', '.join(missing)}. "
+            "Refusing to start with AuthLevel.ANONYMOUS because the function "
+            "would be unauthenticated. Enable Easy Auth on the Function App "
+            "or switch to Function Key authentication."
+        )
+
+    return func.AuthLevel.ANONYMOUS

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -72,12 +72,45 @@ wsgi_middleware = WsgiMiddleware(main.app.wsgi_app)
 # When Easy Auth (Azure App Service Authentication) handles authentication via
 # a service principal, function-level auth keys are redundant and must be
 # disabled — the DC only sends a Bearer token, not a function key.
-auth_level = (
-    func.AuthLevel.ANONYMOUS
-    if os.getenv("MCD_AUTH_TYPE") == "AZURE_FUNCTION_SERVICE_PRINCIPAL"
-    else func.AuthLevel.FUNCTION
+#
+# Safety: before going ANONYMOUS, validate that Easy Auth is actually enabled.
+# WEBSITE_AUTH_ENABLED is read-only and platform-injected by Azure when Easy
+# Auth is configured.  WEBSITE_AUTH_CLIENT_ID and WEBSITE_AUTH_OPENID_ISSUER
+# are set by the platform during Easy Auth setup — if either is missing, Easy
+# Auth is definitely not configured and we must refuse to drop function-key
+# auth, otherwise the function would be completely unauthenticated.
+_EASY_AUTH_REQUIRED_VARS = (
+    "WEBSITE_AUTH_ENABLED",
+    "WEBSITE_AUTH_CLIENT_ID",
+    "WEBSITE_AUTH_OPENID_ISSUER",
 )
-app = df.DFApp(http_auth_level=auth_level)
+
+
+def _resolve_auth_level() -> func.AuthLevel:
+    if os.getenv("MCD_AUTH_TYPE") != "AZURE_FUNCTION_SERVICE_PRINCIPAL":
+        return func.AuthLevel.FUNCTION
+
+    # WEBSITE_AUTH_ENABLED must be explicitly "True" (platform sets this
+    # value); the others just need to be present.
+    missing = [v for v in _EASY_AUTH_REQUIRED_VARS if not os.getenv(v)]
+    if os.getenv("WEBSITE_AUTH_ENABLED", "").lower() != "true":
+        missing.append("WEBSITE_AUTH_ENABLED")
+    # dedupe while preserving order (WEBSITE_AUTH_ENABLED may appear twice)
+    missing = list(dict.fromkeys(missing))
+    if missing:
+        raise RuntimeError(
+            "MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL but Easy "
+            "Auth does not appear to be enabled — the following platform "
+            f"environment variables are missing or invalid: {', '.join(missing)}. "
+            "Refusing to start with AuthLevel.ANONYMOUS because the function "
+            "would be unauthenticated. Enable Easy Auth on the Function App "
+            "or switch to Function Key authentication."
+        )
+
+    return func.AuthLevel.ANONYMOUS
+
+
+app = df.DFApp(http_auth_level=_resolve_auth_level())
 
 
 @app.route(route="async/api/v1/agent/execute/{connection_type}/{operation_name}")

--- a/apollo/interfaces/azure/function_app.py
+++ b/apollo/interfaces/azure/function_app.py
@@ -74,43 +74,16 @@ wsgi_middleware = WsgiMiddleware(main.app.wsgi_app)
 # disabled — the DC only sends a Bearer token, not a function key.
 #
 # Safety: before going ANONYMOUS, validate that Easy Auth is actually enabled.
-# WEBSITE_AUTH_ENABLED is read-only and platform-injected by Azure when Easy
-# Auth is configured.  WEBSITE_AUTH_CLIENT_ID and WEBSITE_AUTH_OPENID_ISSUER
-# are set by the platform during Easy Auth setup — if either is missing, Easy
+# WEBSITE_AUTH_ENABLED is platform-injected when Easy Auth is configured —
+# this check is defense-in-depth against misconfiguration, not a tamper-proof
+# guarantee (a privileged Azure principal can still modify app settings via
+# the ARM API).  WEBSITE_AUTH_CLIENT_ID and WEBSITE_AUTH_OPENID_ISSUER are
+# set by the platform during Easy Auth setup — if either is missing, Easy
 # Auth is definitely not configured and we must refuse to drop function-key
 # auth, otherwise the function would be completely unauthenticated.
-_EASY_AUTH_REQUIRED_VARS = (
-    "WEBSITE_AUTH_ENABLED",
-    "WEBSITE_AUTH_CLIENT_ID",
-    "WEBSITE_AUTH_OPENID_ISSUER",
-)
+from apollo.interfaces.azure.auth import resolve_auth_level
 
-
-def _resolve_auth_level() -> func.AuthLevel:
-    if os.getenv("MCD_AUTH_TYPE") != "AZURE_FUNCTION_SERVICE_PRINCIPAL":
-        return func.AuthLevel.FUNCTION
-
-    # WEBSITE_AUTH_ENABLED must be explicitly "True" (platform sets this
-    # value); the others just need to be present.
-    missing = [v for v in _EASY_AUTH_REQUIRED_VARS if not os.getenv(v)]
-    if os.getenv("WEBSITE_AUTH_ENABLED", "").lower() != "true":
-        missing.append("WEBSITE_AUTH_ENABLED")
-    # dedupe while preserving order (WEBSITE_AUTH_ENABLED may appear twice)
-    missing = list(dict.fromkeys(missing))
-    if missing:
-        raise RuntimeError(
-            "MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL but Easy "
-            "Auth does not appear to be enabled — the following platform "
-            f"environment variables are missing or invalid: {', '.join(missing)}. "
-            "Refusing to start with AuthLevel.ANONYMOUS because the function "
-            "would be unauthenticated. Enable Easy Auth on the Function App "
-            "or switch to Function Key authentication."
-        )
-
-    return func.AuthLevel.ANONYMOUS
-
-
-app = df.DFApp(http_auth_level=_resolve_auth_level())
+app = df.DFApp(http_auth_level=resolve_auth_level())
 
 
 @app.route(route="async/api/v1/agent/execute/{connection_type}/{operation_name}")

--- a/tests/test_azure_auth_level.py
+++ b/tests/test_azure_auth_level.py
@@ -4,15 +4,9 @@ from unittest.mock import patch
 
 import azure.functions as func
 
+from apollo.interfaces.azure.auth import resolve_auth_level
 
-# Mirrors _EASY_AUTH_REQUIRED_VARS from function_app.py
-_EASY_AUTH_REQUIRED_VARS = (
-    "WEBSITE_AUTH_ENABLED",
-    "WEBSITE_AUTH_CLIENT_ID",
-    "WEBSITE_AUTH_OPENID_ISSUER",
-)
-
-# Convenience: a full set of Easy Auth env vars as the platform would inject.
+# Full set of Easy Auth env vars as the platform would inject.
 _EASY_AUTH_ENV = {
     "WEBSITE_AUTH_ENABLED": "True",
     "WEBSITE_AUTH_CLIENT_ID": "00000000-0000-0000-0000-000000000000",
@@ -20,119 +14,96 @@ _EASY_AUTH_ENV = {
 }
 
 
-def _resolve_auth_level() -> func.AuthLevel:
-    """Mirrors _resolve_auth_level from function_app.py for unit testing.
-
-    The actual function is computed at module import time, making it
-    impractical to test via reimport.  This helper mirrors the exact
-    logic so we can validate the env-var contract in isolation.
-    """
-    if os.getenv("MCD_AUTH_TYPE") != "AZURE_FUNCTION_SERVICE_PRINCIPAL":
-        return func.AuthLevel.FUNCTION
-
-    missing = [v for v in _EASY_AUTH_REQUIRED_VARS if not os.getenv(v)]
-    if os.getenv("WEBSITE_AUTH_ENABLED", "").lower() != "true":
-        missing.append("WEBSITE_AUTH_ENABLED")
-    missing = list(dict.fromkeys(missing))
-    if missing:
-        raise RuntimeError(
-            "MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL but Easy "
-            "Auth does not appear to be enabled — the following platform "
-            f"environment variables are missing or invalid: {', '.join(missing)}. "
-            "Refusing to start with AuthLevel.ANONYMOUS because the function "
-            "would be unauthenticated. Enable Easy Auth on the Function App "
-            "or switch to Function Key authentication."
-        )
-
-    return func.AuthLevel.ANONYMOUS
-
-
-def _clean_env():
-    """Remove all auth-related env vars so tests start from a known state."""
-    for var in ("MCD_AUTH_TYPE", *_EASY_AUTH_REQUIRED_VARS):
-        os.environ.pop(var, None)
-
-
 class TestAzureAuthLevel(TestCase):
     """Tests for MCD_AUTH_TYPE-driven auth level selection in the Azure Function App."""
 
     def test_auth_level_default_when_env_var_not_set(self):
         """Without MCD_AUTH_TYPE, auth level should be FUNCTION."""
-        with patch.dict(os.environ, {}, clear=False):
-            _clean_env()
-            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
+        with patch.dict(os.environ, {}, clear=True):
+            assert resolve_auth_level() == func.AuthLevel.FUNCTION
 
     def test_auth_level_function_when_app_key(self):
         """With MCD_AUTH_TYPE=AZURE_FUNCTION_APP_KEY, auth level should be FUNCTION."""
         with patch.dict(
-            os.environ, {"MCD_AUTH_TYPE": "AZURE_FUNCTION_APP_KEY"}, clear=False
+            os.environ, {"MCD_AUTH_TYPE": "AZURE_FUNCTION_APP_KEY"}, clear=True
         ):
-            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
+            assert resolve_auth_level() == func.AuthLevel.FUNCTION
 
     def test_auth_level_function_for_unknown_value(self):
         """An unrecognized MCD_AUTH_TYPE value should default to FUNCTION."""
-        with patch.dict(os.environ, {"MCD_AUTH_TYPE": "SOMETHING_ELSE"}, clear=False):
-            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
+        with patch.dict(os.environ, {"MCD_AUTH_TYPE": "SOMETHING_ELSE"}, clear=True):
+            assert resolve_auth_level() == func.AuthLevel.FUNCTION
 
     def test_auth_level_anonymous_when_service_principal_and_easy_auth(self):
-        """SP auth + all Easy Auth vars present → ANONYMOUS."""
+        """SP auth + all Easy Auth vars present -> ANONYMOUS."""
         with patch.dict(
             os.environ,
             {"MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL", **_EASY_AUTH_ENV},
-            clear=False,
+            clear=True,
         ):
-            assert _resolve_auth_level() == func.AuthLevel.ANONYMOUS
+            assert resolve_auth_level() == func.AuthLevel.ANONYMOUS
 
     def test_raises_when_service_principal_but_no_easy_auth(self):
-        """SP auth requested but no Easy Auth vars → RuntimeError (fail closed)."""
-        with patch.dict(os.environ, {}, clear=False):
-            _clean_env()
-            os.environ["MCD_AUTH_TYPE"] = "AZURE_FUNCTION_SERVICE_PRINCIPAL"
+        """SP auth requested but no Easy Auth vars -> RuntimeError (fail closed)."""
+        with patch.dict(
+            os.environ,
+            {"MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL"},
+            clear=True,
+        ):
             with self.assertRaises(RuntimeError) as ctx:
-                _resolve_auth_level()
+                resolve_auth_level()
             assert "WEBSITE_AUTH_ENABLED" in str(ctx.exception)
             assert "WEBSITE_AUTH_CLIENT_ID" in str(ctx.exception)
             assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
 
     def test_raises_when_service_principal_and_partial_easy_auth(self):
-        """SP auth + only WEBSITE_AUTH_ENABLED → RuntimeError listing missing vars."""
-        with patch.dict(os.environ, {}, clear=False):
-            _clean_env()
-            os.environ["MCD_AUTH_TYPE"] = "AZURE_FUNCTION_SERVICE_PRINCIPAL"
-            os.environ["WEBSITE_AUTH_ENABLED"] = "True"
+        """SP auth + only WEBSITE_AUTH_ENABLED -> RuntimeError listing missing vars."""
+        with patch.dict(
+            os.environ,
+            {
+                "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
+                "WEBSITE_AUTH_ENABLED": "True",
+            },
+            clear=True,
+        ):
             with self.assertRaises(RuntimeError) as ctx:
-                _resolve_auth_level()
+                resolve_auth_level()
             # Only the two missing vars should be listed
             assert "WEBSITE_AUTH_ENABLED" not in str(ctx.exception)
             assert "WEBSITE_AUTH_CLIENT_ID" in str(ctx.exception)
             assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
 
     def test_raises_when_auth_enabled_is_false(self):
-        """SP auth + WEBSITE_AUTH_ENABLED=False → RuntimeError (value must be True)."""
-        env = {
-            "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
-            "WEBSITE_AUTH_ENABLED": "False",
-            "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
-            "WEBSITE_AUTH_OPENID_ISSUER": "https://login.microsoftonline.com/tid",
-        }
-        with patch.dict(os.environ, env, clear=False):
+        """SP auth + WEBSITE_AUTH_ENABLED=False -> RuntimeError (value must be True)."""
+        with patch.dict(
+            os.environ,
+            {
+                "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
+                "WEBSITE_AUTH_ENABLED": "False",
+                "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
+                "WEBSITE_AUTH_OPENID_ISSUER": "https://login.microsoftonline.com/tid",
+            },
+            clear=True,
+        ):
             with self.assertRaises(RuntimeError) as ctx:
-                _resolve_auth_level()
+                resolve_auth_level()
             assert "WEBSITE_AUTH_ENABLED" in str(ctx.exception)
             # The other two are present, so they shouldn't be listed
             assert "WEBSITE_AUTH_CLIENT_ID" not in str(ctx.exception)
             assert "WEBSITE_AUTH_OPENID_ISSUER" not in str(ctx.exception)
 
     def test_raises_when_service_principal_missing_only_issuer(self):
-        """SP auth + ENABLED + CLIENT_ID but no ISSUER → RuntimeError."""
-        env = {
-            "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
-            "WEBSITE_AUTH_ENABLED": "True",
-            "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
-        }
-        with patch.dict(os.environ, env, clear=False):
-            os.environ.pop("WEBSITE_AUTH_OPENID_ISSUER", None)
+        """SP auth + ENABLED + CLIENT_ID but no ISSUER -> RuntimeError."""
+        with patch.dict(
+            os.environ,
+            {
+                "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
+                "WEBSITE_AUTH_ENABLED": "True",
+                "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
+            },
+            clear=True,
+        ):
             with self.assertRaises(RuntimeError) as ctx:
-                _resolve_auth_level()
+                resolve_auth_level()
             assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
             assert "WEBSITE_AUTH_CLIENT_ID" not in str(ctx.exception)

--- a/tests/test_azure_auth_level.py
+++ b/tests/test_azure_auth_level.py
@@ -2,57 +2,137 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
+import azure.functions as func
+
+
+# Mirrors _EASY_AUTH_REQUIRED_VARS from function_app.py
+_EASY_AUTH_REQUIRED_VARS = (
+    "WEBSITE_AUTH_ENABLED",
+    "WEBSITE_AUTH_CLIENT_ID",
+    "WEBSITE_AUTH_OPENID_ISSUER",
+)
+
+# Convenience: a full set of Easy Auth env vars as the platform would inject.
+_EASY_AUTH_ENV = {
+    "WEBSITE_AUTH_ENABLED": "True",
+    "WEBSITE_AUTH_CLIENT_ID": "00000000-0000-0000-0000-000000000000",
+    "WEBSITE_AUTH_OPENID_ISSUER": "https://login.microsoftonline.com/tenant-id",
+}
+
+
+def _resolve_auth_level() -> func.AuthLevel:
+    """Mirrors _resolve_auth_level from function_app.py for unit testing.
+
+    The actual function is computed at module import time, making it
+    impractical to test via reimport.  This helper mirrors the exact
+    logic so we can validate the env-var contract in isolation.
+    """
+    if os.getenv("MCD_AUTH_TYPE") != "AZURE_FUNCTION_SERVICE_PRINCIPAL":
+        return func.AuthLevel.FUNCTION
+
+    missing = [v for v in _EASY_AUTH_REQUIRED_VARS if not os.getenv(v)]
+    if os.getenv("WEBSITE_AUTH_ENABLED", "").lower() != "true":
+        missing.append("WEBSITE_AUTH_ENABLED")
+    missing = list(dict.fromkeys(missing))
+    if missing:
+        raise RuntimeError(
+            "MCD_AUTH_TYPE is set to AZURE_FUNCTION_SERVICE_PRINCIPAL but Easy "
+            "Auth does not appear to be enabled — the following platform "
+            f"environment variables are missing or invalid: {', '.join(missing)}. "
+            "Refusing to start with AuthLevel.ANONYMOUS because the function "
+            "would be unauthenticated. Enable Easy Auth on the Function App "
+            "or switch to Function Key authentication."
+        )
+
+    return func.AuthLevel.ANONYMOUS
+
+
+def _clean_env():
+    """Remove all auth-related env vars so tests start from a known state."""
+    for var in ("MCD_AUTH_TYPE", *_EASY_AUTH_REQUIRED_VARS):
+        os.environ.pop(var, None)
+
 
 class TestAzureAuthLevel(TestCase):
     """Tests for MCD_AUTH_TYPE-driven auth level selection in the Azure Function App."""
 
-    @staticmethod
-    def _resolve_auth_level():
-        """Replicates the auth_level logic from function_app.py for unit testing.
-
-        The actual auth_level is computed at module import time, making it
-        impractical to test via reimport.  This helper mirrors the exact
-        conditional so we can validate the env-var contract in isolation.
-        """
-        import azure.functions as func
-
-        return (
-            func.AuthLevel.ANONYMOUS
-            if os.getenv("MCD_AUTH_TYPE") == "AZURE_FUNCTION_SERVICE_PRINCIPAL"
-            else func.AuthLevel.FUNCTION
-        )
-
     def test_auth_level_default_when_env_var_not_set(self):
-        """Without MCD_AUTH_TYPE, auth level should be FUNCTION (existing behavior)."""
-        import azure.functions as func
-
+        """Without MCD_AUTH_TYPE, auth level should be FUNCTION."""
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("MCD_AUTH_TYPE", None)
-            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION
+            _clean_env()
+            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
 
     def test_auth_level_function_when_app_key(self):
         """With MCD_AUTH_TYPE=AZURE_FUNCTION_APP_KEY, auth level should be FUNCTION."""
-        import azure.functions as func
-
         with patch.dict(
             os.environ, {"MCD_AUTH_TYPE": "AZURE_FUNCTION_APP_KEY"}, clear=False
         ):
-            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION
-
-    def test_auth_level_anonymous_when_service_principal(self):
-        """With MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL, auth level should be ANONYMOUS."""
-        import azure.functions as func
-
-        with patch.dict(
-            os.environ,
-            {"MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL"},
-            clear=False,
-        ):
-            assert self._resolve_auth_level() == func.AuthLevel.ANONYMOUS
+            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
 
     def test_auth_level_function_for_unknown_value(self):
         """An unrecognized MCD_AUTH_TYPE value should default to FUNCTION."""
-        import azure.functions as func
-
         with patch.dict(os.environ, {"MCD_AUTH_TYPE": "SOMETHING_ELSE"}, clear=False):
-            assert self._resolve_auth_level() == func.AuthLevel.FUNCTION
+            assert _resolve_auth_level() == func.AuthLevel.FUNCTION
+
+    def test_auth_level_anonymous_when_service_principal_and_easy_auth(self):
+        """SP auth + all Easy Auth vars present → ANONYMOUS."""
+        with patch.dict(
+            os.environ,
+            {"MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL", **_EASY_AUTH_ENV},
+            clear=False,
+        ):
+            assert _resolve_auth_level() == func.AuthLevel.ANONYMOUS
+
+    def test_raises_when_service_principal_but_no_easy_auth(self):
+        """SP auth requested but no Easy Auth vars → RuntimeError (fail closed)."""
+        with patch.dict(os.environ, {}, clear=False):
+            _clean_env()
+            os.environ["MCD_AUTH_TYPE"] = "AZURE_FUNCTION_SERVICE_PRINCIPAL"
+            with self.assertRaises(RuntimeError) as ctx:
+                _resolve_auth_level()
+            assert "WEBSITE_AUTH_ENABLED" in str(ctx.exception)
+            assert "WEBSITE_AUTH_CLIENT_ID" in str(ctx.exception)
+            assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
+
+    def test_raises_when_service_principal_and_partial_easy_auth(self):
+        """SP auth + only WEBSITE_AUTH_ENABLED → RuntimeError listing missing vars."""
+        with patch.dict(os.environ, {}, clear=False):
+            _clean_env()
+            os.environ["MCD_AUTH_TYPE"] = "AZURE_FUNCTION_SERVICE_PRINCIPAL"
+            os.environ["WEBSITE_AUTH_ENABLED"] = "True"
+            with self.assertRaises(RuntimeError) as ctx:
+                _resolve_auth_level()
+            # Only the two missing vars should be listed
+            assert "WEBSITE_AUTH_ENABLED" not in str(ctx.exception)
+            assert "WEBSITE_AUTH_CLIENT_ID" in str(ctx.exception)
+            assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
+
+    def test_raises_when_auth_enabled_is_false(self):
+        """SP auth + WEBSITE_AUTH_ENABLED=False → RuntimeError (value must be True)."""
+        env = {
+            "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
+            "WEBSITE_AUTH_ENABLED": "False",
+            "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
+            "WEBSITE_AUTH_OPENID_ISSUER": "https://login.microsoftonline.com/tid",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with self.assertRaises(RuntimeError) as ctx:
+                _resolve_auth_level()
+            assert "WEBSITE_AUTH_ENABLED" in str(ctx.exception)
+            # The other two are present, so they shouldn't be listed
+            assert "WEBSITE_AUTH_CLIENT_ID" not in str(ctx.exception)
+            assert "WEBSITE_AUTH_OPENID_ISSUER" not in str(ctx.exception)
+
+    def test_raises_when_service_principal_missing_only_issuer(self):
+        """SP auth + ENABLED + CLIENT_ID but no ISSUER → RuntimeError."""
+        env = {
+            "MCD_AUTH_TYPE": "AZURE_FUNCTION_SERVICE_PRINCIPAL",
+            "WEBSITE_AUTH_ENABLED": "True",
+            "WEBSITE_AUTH_CLIENT_ID": "some-client-id",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("WEBSITE_AUTH_OPENID_ISSUER", None)
+            with self.assertRaises(RuntimeError) as ctx:
+                _resolve_auth_level()
+            assert "WEBSITE_AUTH_OPENID_ISSUER" in str(ctx.exception)
+            assert "WEBSITE_AUTH_CLIENT_ID" not in str(ctx.exception)


### PR DESCRIPTION
## Summary

- When `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL` is set, the Azure Function drops to `AuthLevel.ANONYMOUS` so Easy Auth can handle authentication via Bearer tokens. **However**, if Easy Auth isn't actually configured, this leaves the function completely unauthenticated.
- Adds a startup validation gate that checks three platform-injected Easy Auth environment variables before allowing ANONYMOUS: `WEBSITE_AUTH_ENABLED` (must be `True`), `WEBSITE_AUTH_CLIENT_ID` (must be present), and `WEBSITE_AUTH_OPENID_ISSUER` (must be present). If any are missing or invalid, the function refuses to start with a clear `RuntimeError`.
- Fail-closed design — if there's any doubt about Easy Auth being configured, the function won't start rather than running unauthenticated.

## Test plan

- [x] Unit tests cover all scenarios: default, app-key, unknown, SP+Easy Auth (happy path), SP with no Easy Auth vars, SP with partial vars, SP with `WEBSITE_AUTH_ENABLED=False`, SP missing only issuer
- [ ] Deploy to Azure Function App with Easy Auth enabled + `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL` → function starts normally
- [ ] Deploy with `MCD_AUTH_TYPE=AZURE_FUNCTION_SERVICE_PRINCIPAL` but **without** Easy Auth → function fails to start with RuntimeError
- [ ] Deploy without `MCD_AUTH_TYPE` set → function starts with `AuthLevel.FUNCTION` (existing behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)