### PR TITLE
feat(databricks): cache OAuth HeaderFactory across operations

### DIFF
--- a/apollo/integrations/ctp/transforms/_oauth_cache.py
+++ b/apollo/integrations/ctp/transforms/_oauth_cache.py
@@ -1,0 +1,115 @@
+"""
+Process-wide cache for Databricks OAuth HeaderFactory objects.
+
+Shared by the ``resolve_databricks_token`` transform (REST API path) and the
+``resolve_databricks_oauth`` transform (SQL warehouse path). Both build a fresh
+``HeaderFactory`` from a fresh ``Config`` per invocation by default; without
+caching, that defeats the Databricks SDK's per-Config token caching and forces
+an IdP round-trip per operation.
+
+The cache is keyed by a sha256 digest of the credential tuple, so the raw
+``client_secret`` never appears in the cache key. (The secret is still held in
+the ``Config`` object the cached HeaderFactory owns — that's unavoidable.)
+
+Thread-safety and LRU eviction are delegated to ``cachetools.cached``.
+``info=True`` adds ``cache_info()`` / ``cache_clear()`` methods on the wrapped
+function for diagnostic logging and tests.
+"""
+
+import logging
+import time
+from hashlib import sha256
+from threading import Lock
+from typing import Callable, Optional
+
+from cachetools import LRUCache, cached
+from databricks.sdk.core import (
+    Config,
+    azure_service_principal,
+    oauth_service_principal,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_OAUTH_CACHE: LRUCache = LRUCache(maxsize=128)
+_OAUTH_CACHE_LOCK = Lock()
+
+
+def _oauth_cache_key(
+    workspace_url: str,
+    client_id: str,
+    client_secret: str,
+    azure_tenant_id: Optional[str],
+    azure_workspace_resource_id: Optional[str],
+) -> str:
+    """sha256-digest cache key derived from the credential tuple."""
+    h = sha256()
+    for part in (
+        workspace_url,
+        client_id,
+        client_secret,
+        azure_tenant_id,
+        azure_workspace_resource_id,
+    ):
+        h.update((part or "").encode("utf-8"))
+        h.update(b"|")
+    return h.hexdigest()
+
+
+@cached(_OAUTH_CACHE, key=_oauth_cache_key, lock=_OAUTH_CACHE_LOCK, info=True)
+def cached_header_factory(
+    workspace_url: str,
+    client_id: str,
+    client_secret: str,
+    azure_tenant_id: Optional[str],
+    azure_workspace_resource_id: Optional[str],
+) -> Callable[[], dict]:
+    """
+    Return a cached Databricks SDK ``HeaderFactory`` for the given credentials.
+
+    The HeaderFactory owns the SDK's internal TokenSource, which caches access
+    tokens and refreshes them before expiry. Reusing the same factory across
+    operations is what lets the SDK's token cache work; rebuilding it per call
+    (the previous behaviour) defeated the cache and forced an IdP round-trip
+    per operation.
+    """
+    t0 = time.monotonic()
+    is_azure = bool(azure_tenant_id and azure_workspace_resource_id)
+    if is_azure:
+        config = Config(
+            host=workspace_url,
+            azure_client_id=client_id,
+            azure_client_secret=client_secret,
+            azure_tenant_id=azure_tenant_id,
+            azure_workspace_resource_id=azure_workspace_resource_id,
+        )
+        factory = azure_service_principal(config)
+    else:
+        config = Config(
+            host=workspace_url,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+        factory = oauth_service_principal(config)
+    logger.info(
+        f"Built Databricks OAuth header factory (cache miss), "
+        f"duration_s={time.monotonic() - t0:.3f}, is_azure={is_azure}"
+    )
+    return factory
+
+
+def cache_stats() -> dict:
+    """Return a snapshot of cache stats for diagnostic logging."""
+    info = cached_header_factory.cache_info()
+    return {
+        "hits": info.hits,
+        "misses": info.misses,
+        "size": info.currsize,
+        "max_size": info.maxsize,
+    }
+
+
+def _reset_for_tests() -> None:
+    """Clear cache state — for use in unit tests only."""
+    cached_header_factory.cache_clear()

--- a/apollo/integrations/ctp/transforms/resolve_databricks_oauth.py
+++ b/apollo/integrations/ctp/transforms/resolve_databricks_oauth.py
@@ -1,12 +1,17 @@
+import logging
 from typing import Callable
-
-from databricks.sdk.core import Config, azure_service_principal, oauth_service_principal
 
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.models import PipelineState, TransformStep
 from apollo.integrations.ctp.template import TemplateEngine
+from apollo.integrations.ctp.transforms._oauth_cache import (
+    cache_stats,
+    cached_header_factory,
+)
 from apollo.integrations.ctp.transforms.base import Transform
 from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+logger = logging.getLogger(__name__)
 
 
 class ResolveDatabricksOauthTransform(Transform):
@@ -30,8 +35,10 @@ class ResolveDatabricksOauthTransform(Transform):
     Output keys:
       - ``credentials_provider``: key in ``state.derived`` where the callable is stored
 
-    The stored value is ``lambda: provider(config)`` — a zero-argument callable that
-    ``databricks-sql-connector`` invokes when it needs fresh credentials.
+    The stored value is ``lambda: header_factory`` — a zero-argument callable that
+    ``databricks-sql-connector`` invokes when it needs fresh credentials. The
+    HeaderFactory itself is cached across operations by ``_oauth_cache`` so the
+    Databricks SDK's per-Config TokenSource cache survives across calls.
     """
 
     required_input_keys = ("server_hostname", "client_id", "client_secret")
@@ -69,31 +76,35 @@ class ResolveDatabricksOauthTransform(Transform):
                 step.input["azure_workspace_resource_id"], state
             )
 
-        is_azure = bool(azure_tenant_id and azure_workspace_resource_id)
-
-        if is_azure:
-            config = Config(
-                host=host,
-                azure_client_id=client_id,
-                azure_client_secret=client_secret,
-                azure_tenant_id=azure_tenant_id,
-                azure_workspace_resource_id=azure_workspace_resource_id,
-            )
-            provider = azure_service_principal
-        else:
-            config = Config(
-                host=host,
-                client_id=client_id,
-                client_secret=client_secret,
-            )
-            provider = oauth_service_principal
-
-        state.derived[output_key] = _make_provider(provider, config)
+        header_factory = cached_header_factory(
+            host,
+            client_id,
+            client_secret,
+            azure_tenant_id or None,
+            azure_workspace_resource_id or None,
+        )
+        stats = cache_stats()
+        logger.info(
+            f"Resolved Databricks OAuth credentials_provider, "
+            f"cache_hits={stats['hits']}, "
+            f"cache_misses={stats['misses']}, "
+            f"cache_size={stats['size']}"
+        )
+        state.derived[output_key] = _wrap_factory(header_factory)
 
 
-def _make_provider(provider: Callable, config: Config) -> Callable:
-    """Return a zero-argument callable that invokes ``provider(config)``."""
-    return lambda: provider(config)
+def _wrap_factory(
+    header_factory: Callable[[], dict]
+) -> Callable[[], Callable[[], dict]]:
+    """Return a zero-argument callable that yields the (cached) HeaderFactory.
+
+    The ``databricks-sql-connector`` invokes the stored credentials_provider
+    once per ``sql.connect()`` to obtain a HeaderFactory it then uses to fetch
+    auth headers. By returning the *same* cached HeaderFactory each time
+    (rather than rebuilding one via ``provider(config)``), the Databricks SDK's
+    internal TokenSource cache survives across operations.
+    """
+    return lambda: header_factory
 
 
 TransformRegistry.register("resolve_databricks_oauth", ResolveDatabricksOauthTransform)

--- a/apollo/integrations/ctp/transforms/resolve_databricks_token.py
+++ b/apollo/integrations/ctp/transforms/resolve_databricks_token.py
@@ -1,12 +1,18 @@
+import logging
+import time
 from typing import Optional
-
-from databricks.sdk.core import Config, azure_service_principal, oauth_service_principal
 
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.models import PipelineState, TransformStep
 from apollo.integrations.ctp.template import TemplateEngine
+from apollo.integrations.ctp.transforms._oauth_cache import (
+    cache_stats,
+    cached_header_factory,
+)
 from apollo.integrations.ctp.transforms.base import Transform
 from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+logger = logging.getLogger(__name__)
 
 
 class ResolveDatabricksTokenTransform(Transform):
@@ -99,27 +105,24 @@ class ResolveDatabricksTokenTransform(Transform):
     ) -> str:
         # OAuth takes priority over PAT — customers who migrated may have stale PAT present.
         if client_id and client_secret:
-            is_azure = bool(azure_tenant_id and azure_workspace_resource_id)
-            if is_azure:
-                config = Config(
-                    host=workspace_url,
-                    azure_client_id=client_id,
-                    azure_client_secret=client_secret,
-                    azure_tenant_id=azure_tenant_id,
-                    azure_workspace_resource_id=azure_workspace_resource_id,
-                )
-                provider = azure_service_principal
-            else:
-                config = Config(
-                    host=workspace_url,
-                    client_id=client_id,
-                    client_secret=client_secret,
-                )
-                provider = oauth_service_principal
-
-            header_factory = provider(config)
+            header_factory = cached_header_factory(
+                workspace_url,
+                client_id,
+                client_secret,
+                azure_tenant_id,
+                azure_workspace_resource_id,
+            )
+            t0 = time.monotonic()
             auth_header = header_factory().get("Authorization", "")
             token = auth_header.removeprefix("Bearer ").strip()
+            stats = cache_stats()
+            logger.info(
+                f"Resolved Databricks OAuth token, "
+                f"duration_s={time.monotonic() - t0:.3f}, "
+                f"cache_hits={stats['hits']}, "
+                f"cache_misses={stats['misses']}, "
+                f"cache_size={stats['size']}"
+            )
             if not token:
                 raise CtpPipelineError(
                     stage="transform_execute",

--- a/tests/ctp/test_databricks_ctp.py
+++ b/tests/ctp/test_databricks_ctp.py
@@ -8,6 +8,7 @@ from apollo.integrations.ctp.defaults.databricks import (
 )
 from apollo.integrations.ctp.pipeline import CtpPipeline
 from apollo.integrations.ctp.registry import CtpRegistry
+from apollo.integrations.ctp.transforms import _oauth_cache as _oauth_cache_mod
 
 
 def _resolve_sql(credentials: dict) -> dict:
@@ -39,6 +40,11 @@ _SQL_AZURE_OAUTH_CREDS = {
 
 
 class TestDatabricksSqlCtp(TestCase):
+    def setUp(self):
+        # Clear the OAuth HeaderFactory cache between tests so each test sees
+        # a fresh cache miss and exercises the build path under its own mocks.
+        _oauth_cache_mod._reset_for_tests()
+
     def test_registered(self):
         self.assertIsNotNone(CtpRegistry.get("databricks"))
 
@@ -90,10 +96,8 @@ class TestDatabricksSqlCtp(TestCase):
 
     # ── Databricks-managed OAuth ──────────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.oauth_service_principal"
-    )
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
     def test_databricks_oauth_produces_credentials_provider(
         self, mock_provider, mock_config
     ):
@@ -101,10 +105,8 @@ class TestDatabricksSqlCtp(TestCase):
         self.assertIn("credentials_provider", args)
         self.assertTrue(callable(args["credentials_provider"]))
 
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.oauth_service_principal"
-    )
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
     def test_databricks_oauth_client_id_not_in_connect_args(
         self, mock_provider, mock_config
     ):
@@ -114,20 +116,16 @@ class TestDatabricksSqlCtp(TestCase):
         self.assertNotIn("databricks_client_id", args)
         self.assertNotIn("databricks_client_secret", args)
 
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.oauth_service_principal"
-    )
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
     def test_databricks_oauth_no_access_token(self, mock_provider, mock_config):
         args = _resolve_sql(_SQL_OAUTH_CREDS)
         self.assertNotIn("access_token", args)
 
     # ── Azure-managed OAuth ───────────────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.azure_service_principal"
-    )
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
     def test_azure_oauth_uses_azure_service_principal(self, mock_provider, mock_config):
         args = _resolve_sql(_SQL_AZURE_OAUTH_CREDS)
         self.assertIn("credentials_provider", args)
@@ -149,6 +147,11 @@ _REST_AZURE_OAUTH_CREDS = {
 
 
 class TestDatabricksRestCtp(TestCase):
+    def setUp(self):
+        # Clear the OAuth HeaderFactory cache between tests so each test sees
+        # a fresh cache miss and exercises the build path under its own mocks.
+        _oauth_cache_mod._reset_for_tests()
+
     def test_registered(self):
         self.assertIsNotNone(CtpRegistry.get("databricks-rest"))
 
@@ -176,19 +179,15 @@ class TestDatabricksRestCtp(TestCase):
 
     # ── Databricks-managed OAuth ──────────────────────────────────────
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_databricks_oauth_resolves_token(self, mock_config, mock_provider):
         mock_provider.return_value = lambda: {"Authorization": "Bearer oauth-token-db"}
         args = _resolve_rest(_REST_OAUTH_CREDS)
         self.assertEqual("oauth-token-db", args["token"])
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_databricks_oauth_no_raw_cred_fields_in_output(
         self, mock_config, mock_provider
     ):
@@ -220,10 +219,8 @@ class TestDatabricksRestCtp(TestCase):
 
     # ── Azure-managed OAuth ───────────────────────────────────────────
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.azure_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_azure_oauth_resolves_token(self, mock_config, mock_provider):
         mock_provider.return_value = lambda: {
             "Authorization": "Bearer oauth-token-azure"
@@ -231,10 +228,8 @@ class TestDatabricksRestCtp(TestCase):
         args = _resolve_rest(_REST_AZURE_OAUTH_CREDS)
         self.assertEqual("oauth-token-azure", args["token"])
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.azure_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_azure_oauth_uses_azure_service_principal(self, mock_config, mock_provider):
         mock_provider.return_value = lambda: {"Authorization": "Bearer t"}
         _resolve_rest(_REST_AZURE_OAUTH_CREDS)
@@ -249,11 +244,182 @@ class TestDatabricksRestCtp(TestCase):
 
     # ── OAuth priority over PAT ───────────────────────────────────────
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_oauth_takes_priority_over_stale_pat(self, mock_config, mock_provider):
         mock_provider.return_value = lambda: {"Authorization": "Bearer oauth-wins"}
         args = _resolve_rest({**_REST_OAUTH_CREDS, "databricks_token": "stale-pat"})
         self.assertEqual("oauth-wins", args["token"])
+
+
+class TestOAuthCache(TestCase):
+    """
+    Tests for the shared OAuth HeaderFactory cache (``_oauth_cache``).
+
+    The cache lives at module scope, so each test must reset it via setUp to
+    avoid leakage from earlier tests (including those in the classes above).
+    """
+
+    def setUp(self):
+        _oauth_cache_mod._reset_for_tests()
+
+    # ── cache key shape ───────────────────────────────────────────────
+
+    def test_secret_not_in_cache_key(self):
+        key = _oauth_cache_mod._oauth_cache_key(
+            "workspace.azuredatabricks.net",
+            "client-id",
+            "super-secret-do-not-leak",
+            None,
+            None,
+        )
+        self.assertNotIn("super-secret-do-not-leak", key)
+        self.assertEqual(len(key), 64)  # sha256 hex digest
+
+    def test_same_credentials_produce_same_key(self):
+        k1 = _oauth_cache_mod._oauth_cache_key("w", "id", "sec", "t", "r")
+        k2 = _oauth_cache_mod._oauth_cache_key("w", "id", "sec", "t", "r")
+        self.assertEqual(k1, k2)
+
+    def test_different_client_id_produces_different_key(self):
+        k1 = _oauth_cache_mod._oauth_cache_key("w", "id-1", "sec", None, None)
+        k2 = _oauth_cache_mod._oauth_cache_key("w", "id-2", "sec", None, None)
+        self.assertNotEqual(k1, k2)
+
+    def test_different_secret_produces_different_key(self):
+        k1 = _oauth_cache_mod._oauth_cache_key("w", "id", "sec-1", None, None)
+        k2 = _oauth_cache_mod._oauth_cache_key("w", "id", "sec-2", None, None)
+        self.assertNotEqual(k1, k2)
+
+    def test_different_workspace_produces_different_key(self):
+        k1 = _oauth_cache_mod._oauth_cache_key("w1", "id", "sec", None, None)
+        k2 = _oauth_cache_mod._oauth_cache_key("w2", "id", "sec", None, None)
+        self.assertNotEqual(k1, k2)
+
+    def test_azure_fields_change_key(self):
+        databricks = _oauth_cache_mod._oauth_cache_key("w", "id", "sec", None, None)
+        azure = _oauth_cache_mod._oauth_cache_key("w", "id", "sec", "t", "r")
+        self.assertNotEqual(databricks, azure)
+
+    # ── cache hit/miss behavior ───────────────────────────────────────
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_same_credentials_hit_cache(self, mock_config, mock_provider):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer tok"}
+        _oauth_cache_mod.cached_header_factory("w", "id", "sec", None, None)
+        _oauth_cache_mod.cached_header_factory("w", "id", "sec", None, None)
+        # Factory built once; second call serves from cache.
+        mock_provider.assert_called_once()
+        info = _oauth_cache_mod.cached_header_factory.cache_info()
+        self.assertEqual(1, info.hits)
+        self.assertEqual(1, info.misses)
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_different_credentials_miss_cache(self, mock_config, mock_provider):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer tok"}
+        _oauth_cache_mod.cached_header_factory("w", "id-1", "sec", None, None)
+        _oauth_cache_mod.cached_header_factory("w", "id-2", "sec", None, None)
+        self.assertEqual(2, mock_provider.call_count)
+        info = _oauth_cache_mod.cached_header_factory.cache_info()
+        self.assertEqual(0, info.hits)
+        self.assertEqual(2, info.misses)
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_rotated_secret_misses_cache(self, mock_config, mock_provider):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer tok"}
+        _oauth_cache_mod.cached_header_factory("w", "id", "old-sec", None, None)
+        _oauth_cache_mod.cached_header_factory("w", "id", "new-sec", None, None)
+        self.assertEqual(2, mock_provider.call_count)
+
+    # ── provider selection ────────────────────────────────────────────
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_databricks_oauth_uses_databricks_service_principal(
+        self, mock_config, mock_oauth, mock_azure
+    ):
+        mock_oauth.return_value = lambda: {"Authorization": "Bearer t"}
+        _oauth_cache_mod.cached_header_factory("w", "id", "sec", None, None)
+        mock_oauth.assert_called_once()
+        mock_azure.assert_not_called()
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_azure_oauth_uses_azure_service_principal(
+        self, mock_config, mock_oauth, mock_azure
+    ):
+        mock_azure.return_value = lambda: {"Authorization": "Bearer t"}
+        _oauth_cache_mod.cached_header_factory("w", "id", "sec", "tenant", "rsrc")
+        mock_azure.assert_called_once()
+        mock_oauth.assert_not_called()
+
+    # ── LRU eviction ──────────────────────────────────────────────────
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_lru_eviction_caps_cache_size(self, mock_config, mock_provider):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer t"}
+        max_size = _oauth_cache_mod.cached_header_factory.cache_info().maxsize
+        # Insert max_size + 5 distinct entries; cache should never exceed max.
+        for i in range(max_size + 5):
+            _oauth_cache_mod.cached_header_factory(
+                "w", f"client-{i}", "sec", None, None
+            )
+        info = _oauth_cache_mod.cached_header_factory.cache_info()
+        self.assertEqual(max_size, info.currsize)
+        self.assertEqual(max_size + 5, info.misses)
+
+    # ── REST transform uses the cache ─────────────────────────────────
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_rest_transform_reuses_factory_across_calls(
+        self, mock_config, mock_provider
+    ):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer t"}
+        _resolve_rest(_REST_OAUTH_CREDS)
+        _resolve_rest(_REST_OAUTH_CREDS)
+        # The transform should hit the cache on the second call.
+        mock_provider.assert_called_once()
+
+    def test_rest_pat_path_does_not_touch_cache(self):
+        # PAT-only credentials should not invoke the OAuth path at all.
+        _resolve_rest(_REST_PAT_CREDS)
+        info = _oauth_cache_mod.cached_header_factory.cache_info()
+        self.assertEqual(0, info.currsize)
+        self.assertEqual(0, info.hits)
+        self.assertEqual(0, info.misses)
+
+    # ── SQL transform uses the cache ──────────────────────────────────
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_sql_transform_reuses_factory_across_calls(
+        self, mock_config, mock_provider
+    ):
+        mock_provider.return_value = lambda: {"Authorization": "Bearer t"}
+        _resolve_sql(_SQL_OAUTH_CREDS)
+        _resolve_sql(_SQL_OAUTH_CREDS)
+        mock_provider.assert_called_once()
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
+    def test_sql_credentials_provider_returns_same_cached_factory(
+        self, mock_config, mock_provider
+    ):
+        header_factory = MagicMock()
+        mock_provider.return_value = header_factory
+        args = _resolve_sql(_SQL_OAUTH_CREDS)
+        # The stored credentials_provider is a zero-arg callable that returns
+        # the *cached* HeaderFactory. Calling it multiple times returns the
+        # same object — this is what lets the SDK's TokenSource cache survive
+        # across SQL connector invocations.
+        cp = args["credentials_provider"]
+        self.assertIs(header_factory, cp())
+        self.assertIs(header_factory, cp())
+        self.assertIs(cp(), cp())

--- a/tests/ctp/test_transforms.py
+++ b/tests/ctp/test_transforms.py
@@ -722,10 +722,20 @@ def _make_databricks_step(raw_keys, output_key="databricks_provider"):
 
 
 class TestResolveDatabricksOauthTransform(TestCase):
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
+    def setUp(self):
+        # Clear the shared OAuth HeaderFactory cache between tests so each test
+        # exercises a fresh cache miss against its own mocks. The cache is
+        # module-scoped, so without this, the second test in this class would
+        # hit a cached factory from the first test and the mocks wouldn't be
+        # invoked.
+        from apollo.integrations.ctp.transforms import (
+            _oauth_cache as _oauth_cache_mod,
+        )
+
+        _oauth_cache_mod._reset_for_tests()
+
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_databricks_managed_oauth_produces_callable(
         self, mock_config, mock_provider
     ):
@@ -736,10 +746,8 @@ class TestResolveDatabricksOauthTransform(TestCase):
         provider = state.derived["databricks_provider"]
         self.assertTrue(callable(provider))
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.azure_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_azure_managed_oauth_uses_azure_service_principal(
         self, mock_config, mock_azure_provider
     ):
@@ -751,10 +759,8 @@ class TestResolveDatabricksOauthTransform(TestCase):
         call_kwargs = mock_config.call_args.kwargs
         self.assertEqual("tid", call_kwargs["azure_tenant_id"])
 
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_oauth.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_oauth.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_databricks_managed_config_uses_client_id_client_secret(
         self, mock_config, mock_provider
     ):

--- a/tests/test_databricks_rest_client.py
+++ b/tests/test_databricks_rest_client.py
@@ -11,6 +11,7 @@ from apollo.common.agent.constants import (
     ATTRIBUTE_NAME_ERROR_TYPE,
     ATTRIBUTE_NAME_RESULT,
 )
+from apollo.integrations.ctp.transforms import _oauth_cache as _oauth_cache_mod
 
 _WORKSPACE_URL = "https://adb-123.azuredatabricks.net"
 _PAT = "dapi-test-token"
@@ -56,6 +57,9 @@ class TestDatabricksRestProxyClientRequests(TestCase):
     """Integration-style tests that exercise the full agent → proxy client path."""
 
     def setUp(self) -> None:
+        # Clear the OAuth HeaderFactory cache so each test exercises a fresh
+        # cache miss against its own mocks (the cache is module-scoped).
+        _oauth_cache_mod._reset_for_tests()
         self._agent = Agent(LoggingUtils())
 
     def _mock_http_success(self, mock_request, result: dict):
@@ -106,10 +110,8 @@ class TestDatabricksRestProxyClientRequests(TestCase):
     # ------------------------------------------------------------------
 
     @patch("requests.request")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.oauth_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.oauth_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_do_request_with_databricks_oauth(
         self, mock_config_cls, mock_oauth_provider, mock_request
     ):
@@ -141,10 +143,8 @@ class TestDatabricksRestProxyClientRequests(TestCase):
     # ------------------------------------------------------------------
 
     @patch("requests.request")
-    @patch(
-        "apollo.integrations.ctp.transforms.resolve_databricks_token.azure_service_principal"
-    )
-    @patch("apollo.integrations.ctp.transforms.resolve_databricks_token.Config")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.azure_service_principal")
+    @patch("apollo.integrations.ctp.transforms._oauth_cache.Config")
     def test_do_request_with_azure_oauth(
         self, mock_config_cls, mock_azure_provider, mock_request
     ):


### PR DESCRIPTION
## Summary

Caches the Databricks SDK's `HeaderFactory` across operations in the CTP pipeline so the SDK's per-`Config` TokenSource cache survives across calls. Hypothesis under test: the per-operation OAuth IdP round-trip dominates per-op cost on self-hosted (egress-agent) customers' worker pools. The change also adds per-resolution duration/cache-stat logging so we can confirm or refute that hypothesis post-deployment.

## Problem

For customers on the egress-agent path (self-hosted Databricks credentials), per-op agent worker time has been observed clustering at 28–30s, pegging the worker pool at 100% utilization at sustained moderate throughput. Bumping the thread count to 40 unmasked the issue but didn't address the cost itself.

What's **measured** (Datadog logs on the affected customer's agent):
- Worker phase (`Running operation` → `OperationsRunner: completed operation`) averages 26s and clusters tightly between 20–30s.
- Fast operations (non-Databricks paths — storage, Fivetran, agent health) all complete in <1s.
- The only differentiator between slow and fast ops is whether they invoke the Databricks OAuth path.

What's **hypothesized but not yet directly measured**:
- That the OAuth IdP round-trip itself is the dominant cost inside those ~26 seconds. We can't currently see sub-step timing on the agent because the CTP transforms emit no internal markers.
- Indirect evidence supporting the hypothesis: on a healthy network the same `oauth_service_principal(config)` + `header_factory()` chain takes ~1.3s per call (measured locally), and the affected customer's agent rebuilds the factory on every operation (defeating the SDK's TokenSource cache); the 20–30s tight clustering looks like a single fixed wait rather than natural variance.
- We do **not** know why OAuth is so much slower on the customer's network. Firewall TLS inspection, IdP-side latency, or tenant config are all candidates. That's an orthogonal investigation.

Root cause of the *defeated-cache* part (which this PR addresses regardless of what the per-op wall-clock turns out to be): `resolve_databricks_token` (REST path) and `resolve_databricks_oauth` (SQL path) each built a fresh `Config` + `HeaderFactory` per invocation. The SDK's TokenSource cache lives **inside** the `HeaderFactory`; throwing the factory away after each call defeats the cache and forces an IdP round-trip every time. The proxy-client-level cache (`proxy_client_factory.py`) doesn't help because `skip_cache=True` is set for all callers (load-bearing for safety reasons).

## Change

- **New `apollo/integrations/ctp/transforms/_oauth_cache.py`** — shared module owning a process-wide cache for `HeaderFactory` objects keyed by `sha256(workspace_url | client_id | client_secret | azure_tenant_id | azure_workspace_resource_id)`. The raw `client_secret` never lands in the cache key (only the digest does). Uses `cachetools.cached` with `info=True` for built-in LRU eviction (`maxsize=128`) and accurate hit/miss stats.
- **`resolve_databricks_token.py`** (REST) — calls `cached_header_factory(...)` then invokes `header_factory()` for the token string. Logs `duration_s` of the actual `header_factory()` call plus cache stats per resolution.
- **`resolve_databricks_oauth.py`** (SQL) — calls `cached_header_factory(...)` and stores `lambda: header_factory` in `connect_args["credentials_provider"]`. The lambda always returns the *same* cached factory each invocation, so the SDK's TokenSource cache survives across `sql.connect()` calls.
- **Logs are inlined as f-string message bodies** — the agent-to-orchestrator forwarding strips `extra` fields, so structured data lives in the message text as `duration_s=... cache_hits=... cache_misses=... cache_size=...`. Two log lines per resolution:
  - `Built Databricks OAuth header factory (cache miss), duration_s=..., is_azure=...` — fires only on cache misses; the duration is the cost of the SDK setup itself (typically fast).
  - `Resolved Databricks OAuth token, duration_s=..., cache_hits=..., cache_misses=..., cache_size=...` — fires every resolution; `duration_s` is the `header_factory()` invocation time, which is where the actual IdP round-trip happens (on first call against a fresh factory) or where the SDK's TokenSource cache hit lives (on subsequent calls).

Together those two log lines let us confirm-or-refute the OAuth-cost hypothesis directly from production after deployment: if `Resolved Databricks OAuth token duration_s` is multi-second on cache misses and sub-millisecond on cache hits, OAuth was the dominant cost and the fix lands the predicted impact. If it isn't, we know where to look next.

## Empirical validation (local, on a healthy network)

Ran a side-script (`oauth_timing_test.py`) against a real Databricks workspace with four scenarios. Key findings:

| Scenario | First call | Subsequent calls | Notes |
|---|---|---|---|
| FRESH (today's behaviour) | ~1.3s avg | ~1.3s every time | rebuilds factory per call |
| CACHED (REST fix) | ~600ms once | **~0.0ms** | SDK TokenSource hit |
| SQL simulation | ~600ms once | **~0.0ms** | `lambda: header_factory` is transparent |
| SQL real queries | 2.8s (incl. handshake) | **~1.1s steady-state** | `provider_calls=1, factory_calls=1` per `sql.connect()` |

For the real-queries scenario against the warehouse: 5 distinct `sql.connect()` calls, each running `SELECT 1`. The connector invoked our `credentials_provider` exactly once per connection and the `HeaderFactory` exactly once per connection. **Zero additional OAuth network round-trips** after the first call — the SDK's TokenSource cache served every subsequent token request.

This validates the *caching mechanism* end-to-end. What it doesn't validate is the size of the win on the affected customer's environment, since the OAuth round-trip cost there is much higher than locally — the post-deployment logs are the empirical confirmation step.

## Implementation notes

- **Thread-safety** is handled by `cachetools.cached`'s `lock=` parameter (a stdlib `threading.Lock`). No manual locking in our code.
- **Token refresh** is handled inside the SDK's TokenSource — the cached `HeaderFactory` knows when to refresh proactively. We don't need a TTL on the CTP-level cache; tokens stay valid as long as the credentials don't change.
- **Credential rotation** changes the sha256 key naturally, so a rotated `client_secret` produces a new cache entry; the old entry ages out via LRU.

## Test plan

- [x] `black --check` on all modified files
- [x] `pyright` on the three source files (0 errors, 0 warnings)
- [x] `pytest tests/ctp/test_databricks_ctp.py tests/test_databricks_rest_client.py` (44 passed)
- [x] Empirical validation via `oauth_timing_test.py` (4 scenarios against a real warehouse, mechanism confirmed)
- [na] Manual smoke-test in apollo-agent local mode — covered by the real-warehouse `oauth_timing_test.py` run
- [ ] CI green
- [ ] Manual verification on the affected customer's agent after pin bump (look at `Resolved Databricks OAuth token` log lines: `duration_s` on cache hits should be sub-ms; `cache_hits` should climb while `cache_misses` stays small)

## Follow-ups

- **Customer rollout:** once merged, bump apollo-agent pin in hermes-agent, ship to the affected customer, and verify via Datadog by querying `Resolved Databricks OAuth token` over time. Two things to confirm:
  1. `duration_s` on cache hits drops to sub-ms (proves the cache is working)
  2. Per-op agent worker time (`Running operation` → `Running results push`) drops materially (proves OAuth was indeed the dominant cost — confirms the underlying hypothesis)
- **If the per-op time doesn't drop after this lands**, the `Resolved Databricks OAuth token` log lines will tell us OAuth is fast but something else inside the worker is slow, and we'll know where to look next (Databricks REST/SQL call latency, JSON serialization, etc.).
- **Worker-thread count rollback (optional):** after the cache lands the recent 40-thread bump on this customer's agent can likely be rolled back to 18; not urgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)