### PR TITLE
chore(databricks): add per-step timing logs to bisect slow operations

### DIFF
--- a/apollo/agent/evaluation_utils.py
+++ b/apollo/agent/evaluation_utils.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Any, Callable, Optional, Dict, List, cast
 
 from apollo.agent.annotate_logger import annotate_logger
@@ -150,14 +151,25 @@ class AgentEvaluationUtils:
             target = cls._resolve_context_variable(context, target_name)
         method = cls._resolve_method(target, command.method)
         if isinstance(method, Callable):
+            t0 = time.monotonic()
             try:
                 result = method(
                     *cls._resolve_args(command.args, context),
                     **cls._resolve_kwargs(command.kwargs, context),
                 )
             except Exception as ex:
-                logger.info(f"Error calling method {command.method}: {ex}")
+                duration_s = time.monotonic() - t0
+                logger.info(
+                    f"Command failed, method={command.method}, "
+                    f"target={type(target).__name__}, duration_s={duration_s:.3f}, "
+                    f"error={ex}"
+                )
                 raise
+            duration_s = time.monotonic() - t0
+            logger.info(
+                f"Command executed, method={command.method}, "
+                f"target={type(target).__name__}, duration_s={duration_s:.3f}"
+            )
         else:
             result = method  # assume it is a property
         if store := command.store:

--- a/apollo/integrations/ctp/transforms/resolve_databricks_token.py
+++ b/apollo/integrations/ctp/transforms/resolve_databricks_token.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from typing import Optional
 
 from databricks.sdk.core import Config, azure_service_principal, oauth_service_principal
@@ -7,6 +9,8 @@ from apollo.integrations.ctp.models import PipelineState, TransformStep
 from apollo.integrations.ctp.template import TemplateEngine
 from apollo.integrations.ctp.transforms.base import Transform
 from apollo.integrations.ctp.transforms.registry import TransformRegistry
+
+logger = logging.getLogger(__name__)
 
 
 class ResolveDatabricksTokenTransform(Transform):
@@ -117,9 +121,19 @@ class ResolveDatabricksTokenTransform(Transform):
                 )
                 provider = oauth_service_principal
 
+            t_build = time.monotonic()
             header_factory = provider(config)
+            build_s = time.monotonic() - t_build
+
+            t_fetch = time.monotonic()
             auth_header = header_factory().get("Authorization", "")
+            fetch_s = time.monotonic() - t_fetch
+
             token = auth_header.removeprefix("Bearer ").strip()
+            logger.info(
+                f"Resolved Databricks OAuth token (REST), "
+                f"build_s={build_s:.3f}, fetch_s={fetch_s:.3f}, is_azure={is_azure}"
+            )
             if not token:
                 raise CtpPipelineError(
                     stage="transform_execute",

--- a/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
+++ b/apollo/integrations/databricks/databricks_sql_warehouse_proxy_client.py
@@ -1,8 +1,12 @@
+import logging
+import time
 from typing import Dict, Optional
 
 from databricks import sql
 
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient
+
+logger = logging.getLogger(__name__)
 
 _ATTR_CONNECT_ARGS = "connect_args"
 
@@ -21,7 +25,10 @@ class DatabricksSqlWarehouseProxyClient(BaseDbProxyClient):
             raise ValueError(
                 f"Databricks agent client requires {_ATTR_CONNECT_ARGS} in credentials"
             )
+        t0 = time.monotonic()
         self._connection = sql.connect(**credentials[_ATTR_CONNECT_ARGS])
+        connect_s = time.monotonic() - t0
+        logger.info(f"Databricks sql.connect() completed, duration_s={connect_s:.3f}")
 
     @property
     def wrapped_client(self):


### PR DESCRIPTION
## Summary

Pure observability change. Adds diagnostic timing logs at three points inside a Databricks operation's worker phase so we can bisect where the per-op wall-clock is actually going on the affected customer's agent — where we've measured ~27 s per op clustering tightly at 20–30 s across **every** Databricks code path (REST `_do_request`, SQL `_execute_and_fetch_all`, `validate_connection`), with non-Databricks ops landing sub-second.

No behavior changes. No new code paths. Just timing logs at info level.

## What it adds

| Log line | Where | What it measures |
|---|---|---|
| `Resolved Databricks OAuth token (REST), build_s=…, fetch_s=…, is_azure=…` | `resolve_databricks_token._resolve_token` | `build_s` = `oauth_service_principal(config)` / `azure_service_principal(config)` (typically fast). `fetch_s` = first call to `header_factory()` — the actual IdP network round-trip. |
| `Databricks sql.connect() completed, duration_s=…` | `DatabricksSqlWarehouseProxyClient.__init__` | Thrift session establishment + auth + warehouse handshake. Fires on every fresh proxy client construction (every cache miss). |
| `Command executed, method=…, target=…, duration_s=…` (or `Command failed, …` with the error) | `AgentEvaluationUtils._execute_single_command` | Every method dispatched by the agent's command pipeline. Captures actual query work — cursor.execute, fetchall, do_request, etc. — universally across all proxy clients. |

## Why these three points

The data we have so far localized the cost to the agent worker phase (`Running operation` → `OperationsRunner: completed operation` = ~26.7 s) but couldn't go deeper because there are no sub-step markers in the agent. The three points above bracket the most expensive things a Databricks operation can do, in a way that's mutually exclusive:

- If the slowness is **OAuth IdP**: `Resolved Databricks OAuth token` will show `fetch_s` in the seconds.
- If it's **Thrift / sql.connect()**: `Databricks sql.connect() completed` will show multi-second `duration_s` on every fresh proxy client.
- If it's **the query itself or REST call**: the per-`Command executed` logs around `execute`/`fetchall`/`do_request` will show where the time goes.
- If all three are fast individually but ops still take 27 s, the cost is elsewhere (orchestrator dispatch latency, log forwarding back-pressure, agent runtime overhead) — that absence-of-evidence is itself useful.

## Why this is a separate PR

This is independent of #296 (the OAuth HeaderFactory cache). After enabling `skip_cache=False` on the affected DC, per-op time stayed at ~27 s — which rules out OAuth/Config being the dominant cost on that customer. The cache PR is still worth landing for code correctness (the SDK's TokenSource cache really is defeated by the current code), but it's not the fix for this customer's specific issue. This instrumentation will tell us what *is*.

## Test plan

- [x] `black --check` on all three modified files
- [x] `pyright` on all three modified files (0 errors, 0 warnings)
- [x] `pytest tests` (1035 passed)
- [ ] CI green
- [ ] Deploy to the affected customer's agent and read the new log lines from Datadog to identify the slow sub-step

## How to use the logs after deployment

In Datadog, on the affected customer's agent (`@mcd.agent_id:<id>`):

```
"Command executed" @duration_s:>5
```

shows commands taking >5s — should reveal the slow step(s). Combined with:

```
"Databricks sql.connect() completed" @duration_s:>1
"Resolved Databricks OAuth token (REST)" @fetch_s:>1
```

we can rule each potential bottleneck in or out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)