### PR TITLE
ci(lambda): disable BuildKit provenance attestation on ECR push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,23 +151,33 @@ jobs:
       - checkout
       - docker/check:
           use-docker-credentials-store: true
+      # Docker Hub copy: keep BuildKit's default provenance attestation
+      # (improves Docker Scout health scores; Docker Hub handles the OCI
+      # image index correctly).
       - docker/build:
-          step-name: Build lambda image
+          step-name: Build lambda image (Docker Hub)
           use-buildkit: true # to build only the required stages
           extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
-      - run:
-          name: Tag lambda image
-          command: |
-            docker tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
-            docker tag montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:latest
-      - verify-version-in-docker-image:
-          image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
-          version: << parameters.code_version >>,<< pipeline.number >>
       - docker/push:
           image: montecarlodata/<< parameters.docker_hub_repository >>
           tag: latest-lambda,<< parameters.code_version >>-lambda
+      # ECR copy: rebuild with --provenance=false. AWS Lambda / CloudFormation
+      # reject the OCI image index that BuildKit emits when attestations are
+      # attached ("image manifest, config or layer media type ... is not
+      # supported"), so the ECR image must be a plain single-arch manifest.
+      # BuildKit cache means the second build is nearly free.
+      - docker/build:
+          step-name: Build lambda image (ECR, no attestations)
+          use-buildkit: true
+          extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >> --provenance=false
+          registry: ${AWS_ECR_ACCOUNT_URL}
+          image: << parameters.aws_ecr_repository >>
+          tag: latest,<< parameters.code_version >>
+      - verify-version-in-docker-image:
+          image: ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
+          version: << parameters.code_version >>,<< pipeline.number >>
       - aws-cli/setup:
           role_arn: "${AWS_ROLE_ARN}"
       - aws-ecr/ecr_login
@@ -186,13 +196,18 @@ jobs:
         type: string
     steps:
       - checkout
-      - docker/pull:
-          images: montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda,montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda
-      - run:
-          name: Tag lambda image
-          command: |
-            docker tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:<< parameters.code_version >>
-            docker tag montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda ${AWS_ECR_ACCOUNT_URL}/<< parameters.aws_ecr_repository >>:latest
+      # Build a fresh lambda image with --provenance=false for the legacy ECR.
+      # Previously this job pulled the Docker Hub image and re-pushed, but
+      # that image now ships as an OCI index with a provenance attestation
+      # manifest that AWS Lambda / CloudFormation reject. Rebuilding here
+      # keeps the ECR copy as a plain single-arch manifest.
+      - docker/build:
+          step-name: Build lambda image (legacy ECR, no attestations)
+          use-buildkit: true
+          extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >> --provenance=false
+          registry: ${AWS_ECR_ACCOUNT_URL}
+          image: << parameters.aws_ecr_repository >>
+          tag: latest,<< parameters.code_version >>
       - aws-ecr/ecr_login
       - aws-ecr/push_image:
           repo: << parameters.aws_ecr_repository >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,8 +188,6 @@ jobs:
     machine:
       image: ubuntu-2204:current
     parameters:
-      docker_hub_repository:
-        type: string
       aws_ecr_repository:
         type: string
       code_version:
@@ -467,7 +465,6 @@ workflows:
                 - /.*\/pr-.*/
       - push-lambda-legacy-repo:
           name: push-lambda-aws-dev
-          docker_hub_repository: pre-release-agent
           aws_ecr_repository: mcd-pre-release-agent
           code_version: ${NEXT_VERSION}
           pre-steps:
@@ -556,7 +553,6 @@ workflows:
             - build-and-push-lambda-prod
       - push-lambda-legacy-repo:
           name: push-lambda-aws-prod
-          docker_hub_repository: agent
           aws_ecr_repository: mcd-agent
           code_version: ${VERSION_TAG}
           pre-steps:


### PR DESCRIPTION
## Summary

- Fixes CloudFormation stack update failure: `The image manifest, config or layer media type for the source image 637423407294.dkr.ecr.ca-central-1.amazonaws.com/mcd-pre-release-agent:1.6.6rc<N> is not supported`, started this morning on the first dev build.
- Root cause is upstream: CircleCI's `ubuntu-2204:current` machine image rolled forward to a Docker/BuildKit version whose default builder now emits an OCI image index that wraps the image alongside a 0-byte provenance attestation manifest, even for single-arch builds. AWS Lambda / CloudFormation can't pull that manifest shape, while Docker Hub accepts it fine and Docker Scout uses the attestation for health-score scoring.
- Keeps Docker Hub copies attested (per the same intent as hermes-agent's `--sbom=true --provenance=mode=max` setup) and rebuilds a clean copy for ECR with `--provenance=false`. BuildKit cache means the ECR rebuild in `build-and-push-lambda` is essentially free.
- The `push-lambda-legacy-repo` job previously pulled from Docker Hub and re-pushed; that path is also broken now (the pulled image is the OCI index). Switched it to a clean rebuild with `--provenance=false`, matching the new pattern.

Same shape as the historical [`KIL-3259` fix in data-collector](https://github.com/monte-carlo-data/data-collector/commit/601cac7a8a2054f56807e580dc5d0a39c26d9614).

Note: PR #298 mistakenly targeted `dev` and was already merged there, so the dev validation pipeline is running with this same commit (cherry-picked from there). This PR is the proper landing path to `main`.

## Test plan

- [ ] Dev pipeline runs successfully end-to-end (in progress via the dev-merged copy of this commit).
- [ ] New `mcd-pre-release-agent` image in ECR (ca-central-1, account 637423407294) shows as a plain "Image" entry (no Image Index, no 0-byte secondary manifest).
- [ ] `aws-dev-update-and-validate-golden-agent` job succeeds — CloudFormation stack update against the new rc tag completes, agent health check reports the expected version.
- [ ] Docker Hub `montecarlodata/pre-release-agent:<ver>-lambda` still shows the attested OCI image index (Docker Scout still picks it up).
- [ ] Legacy ECR (`aws-dev` context) push completes successfully and produces a plain image manifest as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)