### PR TITLE
feat(credentials): cache externally-fetched secrets across operations

### DIFF
--- a/apollo/credentials/akv.py
+++ b/apollo/credentials/akv.py
@@ -14,6 +14,9 @@ class AzureKeyVaultCredentialsService(BaseCredentialsService):
     Credentials service that fetches credentials from a secret in Azure Key Vault.
     """
 
+    def __init__(self):
+        super().__init__(provider_name="azure_key_vault")
+
     def _load_external_credentials(self, credentials: dict) -> dict:
         secret_name = credentials.get(SECRET_NAME)
         if not secret_name:

--- a/apollo/credentials/asm.py
+++ b/apollo/credentials/asm.py
@@ -11,6 +11,9 @@ class AwsSecretsManagerCredentialsService(BaseCredentialsService):
     Credentials service that fetches credentials from AWS Secrets Manager.
     """
 
+    def __init__(self):
+        super().__init__(provider_name="aws_secrets_manager")
+
     def _load_external_credentials(self, credentials: dict) -> dict:
         secret_name = credentials.get(SECRET_NAME)
         if not secret_name:

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -1,14 +1,42 @@
+from apollo.credentials.external_credentials_cache import load_cached
+
+
 class BaseCredentialsService:
     """
     Base class for credentials services, provides default behavior of
     expecting warehouse credentials to be included in the request.
+
+    Subclasses pass a short ``provider_name`` identifier to ``__init__``
+    (e.g. ``aws_secrets_manager``, ``azure_key_vault``). The name appears in
+    the cache log lines emitted by :func:`load_cached` and is purely for
+    observability — it doesn't affect routing. Making it a required
+    constructor argument means a new subclass that forgets to supply it
+    fails loudly at instantiation rather than silently logging a generic
+    label.
     """
 
+    def __init__(self, provider_name: str):
+        self.provider_name = provider_name
+
     def get_credentials(self, credentials: dict) -> dict:
-        external_credentials = self._load_external_credentials(credentials)
+        external_credentials = self._load_external_credentials_cached(credentials)
         return self._merge_connect_args(
             incoming_credentials=credentials,
             external_credentials=external_credentials,
+        )
+
+    def _load_external_credentials_cached(self, credentials: dict) -> dict:
+        """Cache the result of ``_load_external_credentials`` across operations.
+
+        The default ``BaseCredentialsService`` implementation is a passthrough
+        that does no network I/O — caching it adds no value and would pin
+        request-specific dicts in memory, so we short-circuit it. Subclasses
+        that talk to ASM / AKV / GSM benefit from the cache.
+        """
+        if type(self) is BaseCredentialsService:
+            return self._load_external_credentials(credentials)
+        return load_cached(
+            credentials, self._load_external_credentials, self.provider_name
         )
 
     def _load_external_credentials(self, credentials: dict) -> dict:

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -12,11 +12,13 @@ class BaseCredentialsService:
     observability — it doesn't affect routing. Making it a required
     constructor argument means a new subclass that forgets to supply it
     fails loudly at instantiation rather than silently logging a generic
-    label.
+    label. The attribute is stored as ``_provider_name`` because it is an
+    implementation detail of the cache logging path, not part of the
+    service's public contract.
     """
 
     def __init__(self, provider_name: str):
-        self.provider_name = provider_name
+        self._provider_name = provider_name
 
     def get_credentials(self, credentials: dict) -> dict:
         external_credentials = self._load_external_credentials_cached(credentials)
@@ -45,7 +47,7 @@ class BaseCredentialsService:
         if type(self) is BaseCredentialsService:
             return self._load_external_credentials(credentials)
         return load_cached(
-            credentials, self._load_external_credentials, self.provider_name
+            credentials, self._load_external_credentials, self._provider_name
         )
 
     def _load_external_credentials(self, credentials: dict) -> dict:

--- a/apollo/credentials/base.py
+++ b/apollo/credentials/base.py
@@ -32,6 +32,15 @@ class BaseCredentialsService:
         that does no network I/O — caching it adds no value and would pin
         request-specific dicts in memory, so we short-circuit it. Subclasses
         that talk to ASM / AKV / GSM benefit from the cache.
+
+        ``type(self) is BaseCredentialsService`` (not ``isinstance``) is
+        deliberate: it bypasses the cache only for *direct* uses of the
+        passthrough base class. Every existing subclass overrides
+        ``_load_external_credentials`` to actually fetch a secret, so they
+        all benefit from caching. A future subclass that forgets to override
+        ``_load_external_credentials`` would inherit the passthrough and
+        cache request-specific dicts; that is a subclass authoring bug, not
+        a defect in this gate.
         """
         if type(self) is BaseCredentialsService:
             return self._load_external_credentials(credentials)

--- a/apollo/credentials/env_var.py
+++ b/apollo/credentials/env_var.py
@@ -12,6 +12,9 @@ class EnvVarCredentialsService(BaseCredentialsService):
     and decrypts them if necessary.
     """
 
+    def __init__(self):
+        super().__init__(provider_name="env_var")
+
     def _load_external_credentials(self, credentials: dict) -> dict:
         env_var_name = credentials.get(ENV_VAR_NAME)
         if not env_var_name:

--- a/apollo/credentials/external_credentials_cache.py
+++ b/apollo/credentials/external_credentials_cache.py
@@ -12,7 +12,18 @@ everything else (provider type, secret name, region, vault url, assumable
 role, …) is what identifies the secret source.
 
 TTL is configurable via ``MCD_EXTERNAL_CREDENTIALS_CACHE_TTL_SECONDS``.
-Set to ``0`` to disable the cache entirely.
+Set to ``0`` to disable the cache entirely. The value is read once at module
+import — changing the env var on a running process has no effect; restart the
+process for the new TTL to take effect.
+
+Caveat on concurrency: ``cachetools.cached`` releases the lock between the
+cache lookup and the loader call, so N threads that miss the cache for the
+same key simultaneously will all invoke the loader (the last write wins).
+In practice the egress agent's traffic pattern is "one first call, then
+concurrent calls hit the warm cache", so the herd is small and the
+correctness cost is zero (all loaders return the same value). The fix would
+be per-key locking, but the added complexity is not justified by observed
+load.
 
 Each call to :func:`load_cached` emits an INFO-level log line with the
 provider class name, whether the call was a cache hit or miss, and the
@@ -36,6 +47,10 @@ logger = logging.getLogger(__name__)
 
 _CACHE_TTL_ENV_VAR = "MCD_EXTERNAL_CREDENTIALS_CACHE_TTL_SECONDS"
 _DEFAULT_CACHE_TTL_SECONDS = 300
+# Sized for the number of distinct credential identifiers a single agent
+# process might hold — one entry per (provider type, secret name, region,
+# assumable role) tuple. A typical customer has a handful of integrations;
+# 128 leaves plenty of headroom and the per-entry memory cost is negligible.
 _CACHE_MAX_SIZE = 128
 _CONNECT_ARGS_KEY = "connect_args"
 

--- a/apollo/credentials/external_credentials_cache.py
+++ b/apollo/credentials/external_credentials_cache.py
@@ -102,7 +102,9 @@ def _cache_key(credentials: Dict[str, Any], _loader: Loader) -> str:
 @cached(_CACHE, key=_cache_key, lock=_CACHE_LOCK)
 def _load_and_cache(credentials: Dict[str, Any], loader: Loader) -> Dict[str, Any]:
     """Cached load. The ``@cached`` decorator stores the loader's return value
-    keyed by ``_cache_key(credentials, loader)``."""
+    keyed by ``_cache_key(credentials, loader)`` — which by design ignores the
+    ``loader`` argument, so the same credentials always map to the same cache
+    entry regardless of which (potentially wrapped) loader was supplied."""
     return loader(credentials)
 
 
@@ -121,9 +123,14 @@ def load_cached(
 
     Emits one INFO log per call describing ``provider_name``, hit/miss, and
     duration. ``provider_name`` is supplied by the caller (typically the
-    ``BaseCredentialsService.provider_name`` class attribute) rather than
+    ``BaseCredentialsService._provider_name`` instance attribute) rather than
     inferred from the loader, so the log label stays stable regardless of
     how the loader is plumbed.
+
+    Five log states are possible: ``cache=hit``, ``cache=miss``,
+    ``cache=disabled``, ``cache=miss-failed`` (loader was invoked and
+    raised), ``cache=error`` (the cache machinery itself — key hash, lock,
+    deepcopy — raised before/after the loader ran).
     """
     if _CACHE_TTL_SECONDS == 0:
         t0 = time.monotonic()
@@ -144,31 +151,24 @@ def load_cached(
         return loader(c)
 
     t_total = time.monotonic()
+    state = "error"
     try:
         cached_value = _load_and_cache(credentials, timed_loader)
+        result = copy.deepcopy(cached_value)
+        state = "miss" if miss_started_at else "hit"
+        return result
     except Exception:
-        if miss_started_at:
-            logger.info(
-                f"Loaded external credentials, provider={provider_name}, "
-                f"cache=miss-failed, "
-                f"duration_s={time.monotonic() - miss_started_at[0]:.3f}"
-            )
+        state = "miss-failed" if miss_started_at else "error"
         raise
-
-    if miss_started_at:
-        duration_s = time.monotonic() - miss_started_at[0]
+    finally:
+        if miss_started_at:
+            duration_s = time.monotonic() - miss_started_at[0]
+        else:
+            duration_s = time.monotonic() - t_total
         logger.info(
             f"Loaded external credentials, provider={provider_name}, "
-            f"cache=miss, duration_s={duration_s:.3f}"
+            f"cache={state}, duration_s={duration_s:.3f}"
         )
-    else:
-        duration_s = time.monotonic() - t_total
-        logger.info(
-            f"Loaded external credentials, provider={provider_name}, "
-            f"cache=hit, duration_s={duration_s:.3f}"
-        )
-
-    return copy.deepcopy(cached_value)
 
 
 def clear_external_credentials_cache() -> None:

--- a/apollo/credentials/external_credentials_cache.py
+++ b/apollo/credentials/external_credentials_cache.py
@@ -1,0 +1,162 @@
+"""In-memory TTL cache for externally fetched self-hosted credentials.
+
+Network-backed credentials providers (ASM, AKV, GSM) make a fresh API call on
+every operation, which has been observed to add seconds of latency per op when
+the provider is intermittently slow. Caching the resolved external credentials
+collapses those calls to roughly one per TTL window per distinct identifier.
+
+The cache key is a sha256 of the credentials request with ``connect_args``
+removed — ``connect_args`` carries request-specific values (warehouse id,
+http_path, etc.) that should not affect which secret is fetched, while
+everything else (provider type, secret name, region, vault url, assumable
+role, …) is what identifies the secret source.
+
+TTL is configurable via ``MCD_EXTERNAL_CREDENTIALS_CACHE_TTL_SECONDS``.
+Set to ``0`` to disable the cache entirely.
+
+Each call to :func:`load_cached` emits an INFO-level log line with the
+provider class name, whether the call was a cache hit or miss, and the
+elapsed time. This lets us verify in production whether the cache is doing
+its job and, when ops are still slow, whether the time is spent inside the
+loader or somewhere else in the request path.
+"""
+
+import copy
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Dict, List
+
+from cachetools import TTLCache, cached
+
+logger = logging.getLogger(__name__)
+
+_CACHE_TTL_ENV_VAR = "MCD_EXTERNAL_CREDENTIALS_CACHE_TTL_SECONDS"
+_DEFAULT_CACHE_TTL_SECONDS = 300
+_CACHE_MAX_SIZE = 128
+_CONNECT_ARGS_KEY = "connect_args"
+
+Loader = Callable[[Dict[str, Any]], Dict[str, Any]]
+
+
+def _resolve_ttl_seconds() -> int:
+    raw = os.getenv(_CACHE_TTL_ENV_VAR)
+    if raw is None or raw == "":
+        return _DEFAULT_CACHE_TTL_SECONDS
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            f"Invalid {_CACHE_TTL_ENV_VAR}={raw!r}, falling back to "
+            f"{_DEFAULT_CACHE_TTL_SECONDS}s"
+        )
+        return _DEFAULT_CACHE_TTL_SECONDS
+    if value < 0:
+        logger.warning(
+            f"Negative {_CACHE_TTL_ENV_VAR}={value}, falling back to "
+            f"{_DEFAULT_CACHE_TTL_SECONDS}s"
+        )
+        return _DEFAULT_CACHE_TTL_SECONDS
+    return value
+
+
+_CACHE_TTL_SECONDS: int = _resolve_ttl_seconds()
+# TTLCache requires ttl > 0; the load_cached() short-circuit handles ttl=0.
+_CACHE: TTLCache = TTLCache(maxsize=_CACHE_MAX_SIZE, ttl=max(_CACHE_TTL_SECONDS, 1))
+_CACHE_LOCK = threading.RLock()
+
+
+def _cache_key(credentials: Dict[str, Any], _loader: Loader) -> str:
+    """Stable sha256 of the secret-identifying portion of the credentials dict.
+
+    ``connect_args`` is excluded because it is request-specific and does not
+    influence which secret should be fetched. The ``loader`` argument is
+    ignored — the same credentials should always resolve to the same cached
+    value regardless of which bound method produced it. ``default=str``
+    protects against non-JSON-serialisable values appearing in the dict by
+    stringifying them rather than raising.
+    """
+    cacheable = {k: v for k, v in credentials.items() if k != _CONNECT_ARGS_KEY}
+    serialized = json.dumps(cacheable, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+@cached(_CACHE, key=_cache_key, lock=_CACHE_LOCK)
+def _load_and_cache(credentials: Dict[str, Any], loader: Loader) -> Dict[str, Any]:
+    """Cached load. The ``@cached`` decorator stores the loader's return value
+    keyed by ``_cache_key(credentials, loader)``."""
+    return loader(credentials)
+
+
+def load_cached(
+    credentials: Dict[str, Any], loader: Loader, provider_name: str
+) -> Dict[str, Any]:
+    """Return the loader's result for ``credentials``, using the process-wide
+    TTL cache.
+
+    A deep copy is returned so callers can mutate the result (the existing
+    ``_merge_connect_args`` implementation mutates the external credentials
+    dict in place) without corrupting the cached value for subsequent callers.
+
+    When the TTL is configured to ``0`` the cache is bypassed entirely and the
+    loader is invoked on every call.
+
+    Emits one INFO log per call describing ``provider_name``, hit/miss, and
+    duration. ``provider_name`` is supplied by the caller (typically the
+    ``BaseCredentialsService.provider_name`` class attribute) rather than
+    inferred from the loader, so the log label stays stable regardless of
+    how the loader is plumbed.
+    """
+    if _CACHE_TTL_SECONDS == 0:
+        t0 = time.monotonic()
+        try:
+            return loader(credentials)
+        finally:
+            logger.info(
+                f"Loaded external credentials, provider={provider_name}, "
+                f"cache=disabled, duration_s={time.monotonic() - t0:.3f}"
+            )
+
+    # Wrap the loader so we know whether it actually ran (cache miss) without
+    # having to peek into the cache ourselves and racing against other threads.
+    miss_started_at: List[float] = []
+
+    def timed_loader(c: Dict[str, Any]) -> Dict[str, Any]:
+        miss_started_at.append(time.monotonic())
+        return loader(c)
+
+    t_total = time.monotonic()
+    try:
+        cached_value = _load_and_cache(credentials, timed_loader)
+    except Exception:
+        if miss_started_at:
+            logger.info(
+                f"Loaded external credentials, provider={provider_name}, "
+                f"cache=miss-failed, "
+                f"duration_s={time.monotonic() - miss_started_at[0]:.3f}"
+            )
+        raise
+
+    if miss_started_at:
+        duration_s = time.monotonic() - miss_started_at[0]
+        logger.info(
+            f"Loaded external credentials, provider={provider_name}, "
+            f"cache=miss, duration_s={duration_s:.3f}"
+        )
+    else:
+        duration_s = time.monotonic() - t_total
+        logger.info(
+            f"Loaded external credentials, provider={provider_name}, "
+            f"cache=hit, duration_s={duration_s:.3f}"
+        )
+
+    return copy.deepcopy(cached_value)
+
+
+def clear_external_credentials_cache() -> None:
+    """Drop every cached entry. Intended for tests."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/apollo/credentials/factory.py
+++ b/apollo/credentials/factory.py
@@ -40,4 +40,4 @@ class CredentialsFactory:
             raise ValueError(
                 f"Invalid self hosted credentials type: {self_hosted_credentials_type}. Supported types: {SELF_HOSTED_CREDENTIALS_TYPES.keys()}"
             )
-        return BaseCredentialsService()
+        return BaseCredentialsService(provider_name="passthrough")

--- a/apollo/credentials/file.py
+++ b/apollo/credentials/file.py
@@ -11,6 +11,9 @@ class FileCredentialsService(BaseCredentialsService):
     Credentials service that fetches credentials from a file.
     """
 
+    def __init__(self):
+        super().__init__(provider_name="file")
+
     def _load_external_credentials(self, credentials: dict) -> dict:
         file_path = credentials.get("file_path")
         if not file_path:

--- a/apollo/credentials/gsm.py
+++ b/apollo/credentials/gsm.py
@@ -11,6 +11,9 @@ class GoogleSecretManagerCredentialsService(BaseCredentialsService):
     Credentials service that fetches credentials from GCP Secret Manager.
     """
 
+    def __init__(self):
+        super().__init__(provider_name="gcp_secret_manager")
+
     def _load_external_credentials(self, credentials: dict) -> dict:
         secret_name = credentials.get(SECRET_NAME)
         if not secret_name:

--- a/requirements.in
+++ b/requirements.in
@@ -6,6 +6,7 @@ azure-keyvault-secrets==4.10.0
 azure-mgmt-storage==21.2.1
 azure-storage-blob==12.23.0
 brotli==1.2.0  # Upgrade transient dependency of flask-compress to address SEC-1143 (CVE-2025-6176)
+cachetools==5.3.3  # Runtime dep for apollo/credentials/external_credentials_cache.py; pinned here so it shows up in install_requires for downstream consumers
 clickhouse-connect==0.8.18
 cryptography>=46.0.5  # CVE-2026-26007
 databricks-sql-connector==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,9 @@ brotli==1.2.0
     #   -r requirements.in
     #   flask-compress
 cachetools==5.3.3
-    # via google-auth
+    # via
+    #   -r requirements.in
+    #   google-auth
 cattrs==23.2.3
     # via looker-sdk
 certifi==2024.8.30

--- a/tests/credentials/conftest.py
+++ b/tests/credentials/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from apollo.credentials.external_credentials_cache import (
+    clear_external_credentials_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_external_credentials_cache():
+    """Drop the process-wide cache before and after every credentials test.
+
+    The cache lives at module scope and persists across tests; without this
+    fixture, provider tests that ``assert_called_once_with`` on a mocked
+    client would flake whenever a prior test populated the cache for the
+    same key.
+    """
+    clear_external_credentials_cache()
+    yield
+    clear_external_credentials_cache()

--- a/tests/credentials/test_env_var.py
+++ b/tests/credentials/test_env_var.py
@@ -61,34 +61,30 @@ class TestEnvVarCredentialsService(TestCase):
 
             self.assertEqual({"key": "decrypted_value"}, credentials)
 
-    def test_get_credentials_merge_connect_args(self):
-        with patch.dict(
-            os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'}
-        ):
-            credentials = self.service.get_credentials(
-                {"env_var_name": "TEST_CREDS", "connect_args": {"username": "test"}}
-            )
-            self.assertEqual(
-                {"connect_args": {"username": "test", "password": "secret"}},
-                credentials,
-            )
-        # test merge credentials when connect_args is a string
-        with patch.dict(
-            os.environ, {"TEST_CREDS": '{"connect_args": "external connect args"}'}
-        ):
-            credentials = self.service.get_credentials(
-                {"env_var_name": "TEST_CREDS", "connect_args": "incoming connect args"}
-            )
-            self.assertEqual(
-                {"connect_args": "external connect args"},
-                credentials,
-            )
-        # test merge credentials when internal connect_args is not provided
-        with patch.dict(
-            os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'}
-        ):
-            credentials = self.service.get_credentials({"env_var_name": "TEST_CREDS"})
-            self.assertEqual(
-                {"connect_args": {"password": "secret"}},
-                credentials,
-            )
+    @patch.dict(os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'})
+    def test_get_credentials_merge_connect_args_dict(self):
+        credentials = self.service.get_credentials(
+            {"env_var_name": "TEST_CREDS", "connect_args": {"username": "test"}}
+        )
+        self.assertEqual(
+            {"connect_args": {"username": "test", "password": "secret"}},
+            credentials,
+        )
+
+    @patch.dict(os.environ, {"TEST_CREDS": '{"connect_args": "external connect args"}'})
+    def test_get_credentials_merge_connect_args_string_external_wins(self):
+        credentials = self.service.get_credentials(
+            {"env_var_name": "TEST_CREDS", "connect_args": "incoming connect args"}
+        )
+        self.assertEqual(
+            {"connect_args": "external connect args"},
+            credentials,
+        )
+
+    @patch.dict(os.environ, {"TEST_CREDS": '{"connect_args": {"password": "secret"}}'})
+    def test_get_credentials_no_incoming_connect_args(self):
+        credentials = self.service.get_credentials({"env_var_name": "TEST_CREDS"})
+        self.assertEqual(
+            {"connect_args": {"password": "secret"}},
+            credentials,
+        )

--- a/tests/credentials/test_external_credentials_cache.py
+++ b/tests/credentials/test_external_credentials_cache.py
@@ -1,0 +1,237 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from apollo.credentials import external_credentials_cache as cache_module
+from apollo.credentials.base import BaseCredentialsService
+from apollo.credentials.external_credentials_cache import (
+    _cache_key,
+    clear_external_credentials_cache,
+    load_cached,
+)
+
+
+class _RecordingCredentialsService(BaseCredentialsService):
+    """Subclass that counts calls and returns a fresh dict each time."""
+
+    def __init__(self):
+        super().__init__(provider_name="recording")
+        self.calls = 0
+
+    def _load_external_credentials(self, credentials: dict) -> dict:
+        self.calls += 1
+        return {"resolved": True, "call_number": self.calls}
+
+
+class _FailingCredentialsService(BaseCredentialsService):
+    def __init__(self):
+        super().__init__(provider_name="failing")
+        self.calls = 0
+
+    def _load_external_credentials(self, credentials: dict) -> dict:
+        self.calls += 1
+        raise ValueError("boom")
+
+
+def _noop_loader(credentials: dict) -> dict:
+    return {}
+
+
+class TestCredentialsCacheKey(TestCase):
+    def test_connect_args_do_not_affect_key(self):
+        a = {"aws_secret": "s1", "aws_region": "us-east-1", "connect_args": {"x": 1}}
+        b = {"aws_secret": "s1", "aws_region": "us-east-1", "connect_args": {"x": 2}}
+        c = {"aws_secret": "s1", "aws_region": "us-east-1"}
+        self.assertEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+        self.assertEqual(_cache_key(a, _noop_loader), _cache_key(c, _noop_loader))
+
+    def test_loader_does_not_affect_key(self):
+        creds = {"aws_secret": "s1"}
+
+        def loader_a(c):
+            return {}
+
+        def loader_b(c):
+            return {}
+
+        self.assertEqual(_cache_key(creds, loader_a), _cache_key(creds, loader_b))
+
+    def test_different_secret_name_yields_different_key(self):
+        a = {"aws_secret": "s1", "aws_region": "us-east-1"}
+        b = {"aws_secret": "s2", "aws_region": "us-east-1"}
+        self.assertNotEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+
+    def test_different_region_yields_different_key(self):
+        a = {"aws_secret": "s1", "aws_region": "us-east-1"}
+        b = {"aws_secret": "s1", "aws_region": "us-west-2"}
+        self.assertNotEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+
+    def test_different_assumable_role_yields_different_key(self):
+        a = {"aws_secret": "s1", "assumable_role": "arn:aws:iam::111:role/a"}
+        b = {"aws_secret": "s1", "assumable_role": "arn:aws:iam::222:role/b"}
+        self.assertNotEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+
+    def test_different_provider_yields_different_key(self):
+        a = {"self_hosted_credentials_type": "aws_secrets_manager", "secret": "s"}
+        b = {"self_hosted_credentials_type": "azure_key_vault", "secret": "s"}
+        self.assertNotEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+
+    def test_key_is_stable_across_key_order(self):
+        a = {"aws_region": "us-east-1", "aws_secret": "s1"}
+        b = {"aws_secret": "s1", "aws_region": "us-east-1"}
+        self.assertEqual(_cache_key(a, _noop_loader), _cache_key(b, _noop_loader))
+
+
+class TestCacheBehavior(TestCase):
+    def setUp(self):
+        clear_external_credentials_cache()
+
+    def tearDown(self):
+        clear_external_credentials_cache()
+
+    def test_cache_hit_skips_load(self):
+        svc = _RecordingCredentialsService()
+        creds = {"aws_secret": "s1"}
+        first = svc.get_credentials(creds)
+        second = svc.get_credentials(creds)
+        self.assertEqual(1, svc.calls)
+        self.assertEqual({"resolved": True, "call_number": 1}, first)
+        # second hit also returns call_number=1 (the cached value), not a new fetch
+        self.assertEqual({"resolved": True, "call_number": 1}, second)
+
+    def test_different_keys_do_not_share_cache(self):
+        svc = _RecordingCredentialsService()
+        svc.get_credentials({"aws_secret": "s1"})
+        svc.get_credentials({"aws_secret": "s2"})
+        self.assertEqual(2, svc.calls)
+
+    def test_connect_args_only_difference_is_a_cache_hit(self):
+        svc = _RecordingCredentialsService()
+        svc.get_credentials({"aws_secret": "s1", "connect_args": {"warehouse": "a"}})
+        svc.get_credentials({"aws_secret": "s1", "connect_args": {"warehouse": "b"}})
+        self.assertEqual(1, svc.calls)
+
+    def test_connect_args_still_merge_on_cache_hit(self):
+        svc = _RecordingCredentialsService()
+        svc._load_external_credentials = (  # type: ignore[method-assign]
+            lambda credentials: {"connect_args": {"password": "secret"}}
+        )
+        # First call populates the cache
+        first = svc.get_credentials(
+            {"aws_secret": "s1", "connect_args": {"username": "alice"}}
+        )
+        self.assertEqual(
+            {"connect_args": {"username": "alice", "password": "secret"}}, first
+        )
+        # Second call uses different incoming connect_args; merge must still apply
+        second = svc.get_credentials(
+            {"aws_secret": "s1", "connect_args": {"username": "bob"}}
+        )
+        self.assertEqual(
+            {"connect_args": {"username": "bob", "password": "secret"}}, second
+        )
+
+    def test_failed_load_is_not_cached(self):
+        svc = _FailingCredentialsService()
+        creds = {"aws_secret": "s1"}
+        with self.assertRaises(ValueError):
+            svc.get_credentials(creds)
+        with self.assertRaises(ValueError):
+            svc.get_credentials(creds)
+        self.assertEqual(2, svc.calls)
+
+    def test_passthrough_base_service_bypasses_cache(self):
+        # Default BaseCredentialsService is a passthrough — caching it would
+        # pin request-specific dicts. Confirm we don't.
+        svc = BaseCredentialsService(provider_name="passthrough")
+        svc.get_credentials({"aws_secret": "s1", "connect_args": {"x": 1}})
+        # Nothing should have been written to the shared cache
+        self.assertEqual(0, len(cache_module._CACHE))
+
+    def test_returned_dict_can_be_mutated_without_corrupting_cache(self):
+        svc = _RecordingCredentialsService()
+        creds = {"aws_secret": "s1"}
+        first = svc.get_credentials(creds)
+        first["resolved"] = "MUTATED"  # type: ignore[assignment]
+        second = svc.get_credentials(creds)
+        self.assertEqual(True, second["resolved"])  # cached value unchanged
+        self.assertEqual(1, svc.calls)
+
+    def test_disabling_via_ttl_zero_calls_loader_every_time(self):
+        with patch.object(cache_module, "_CACHE_TTL_SECONDS", 0):
+            svc = _RecordingCredentialsService()
+            creds = {"aws_secret": "s1"}
+            svc.get_credentials(creds)
+            svc.get_credentials(creds)
+        self.assertEqual(2, svc.calls)
+
+    def test_load_cached_with_ttl_zero_bypasses_cache_directly(self):
+        with patch.object(cache_module, "_CACHE_TTL_SECONDS", 0):
+            calls = []
+
+            def loader(c):
+                calls.append(c)
+                return {"resolved": True}
+
+            load_cached({"aws_secret": "s1"}, loader, "test_provider")
+            load_cached({"aws_secret": "s1"}, loader, "test_provider")
+        self.assertEqual(2, len(calls))
+
+
+class TestLoadCachedLogging(TestCase):
+    """The duration logs are how we'll verify the cache is doing its job in
+    production. Pin the shape of the message so we don't accidentally break
+    downstream parsing."""
+
+    def setUp(self):
+        clear_external_credentials_cache()
+
+    def tearDown(self):
+        clear_external_credentials_cache()
+
+    def test_cache_miss_log_includes_provider_and_duration(self):
+        svc = _RecordingCredentialsService()
+        with self.assertLogs(
+            "apollo.credentials.external_credentials_cache", level="INFO"
+        ) as cm:
+            svc.get_credentials({"aws_secret": "s1"})
+        miss_logs = [m for m in cm.output if "cache=miss" in m]
+        self.assertEqual(1, len(miss_logs), cm.output)
+        self.assertIn("provider=recording", miss_logs[0])
+        self.assertRegex(miss_logs[0], r"duration_s=\d+\.\d{3}")
+
+    def test_cache_hit_log_emitted_on_second_call(self):
+        svc = _RecordingCredentialsService()
+        creds = {"aws_secret": "s1"}
+        svc.get_credentials(creds)  # populate cache
+        with self.assertLogs(
+            "apollo.credentials.external_credentials_cache", level="INFO"
+        ) as cm:
+            svc.get_credentials(creds)
+        hit_logs = [m for m in cm.output if "cache=hit" in m]
+        self.assertEqual(1, len(hit_logs), cm.output)
+        self.assertIn("provider=recording", hit_logs[0])
+        self.assertRegex(hit_logs[0], r"duration_s=\d+\.\d{3}")
+
+    def test_cache_disabled_log_emitted_when_ttl_zero(self):
+        svc = _RecordingCredentialsService()
+        with patch.object(cache_module, "_CACHE_TTL_SECONDS", 0):
+            with self.assertLogs(
+                "apollo.credentials.external_credentials_cache", level="INFO"
+            ) as cm:
+                svc.get_credentials({"aws_secret": "s1"})
+        disabled_logs = [m for m in cm.output if "cache=disabled" in m]
+        self.assertEqual(1, len(disabled_logs), cm.output)
+        self.assertIn("provider=recording", disabled_logs[0])
+        self.assertRegex(disabled_logs[0], r"duration_s=\d+\.\d{3}")
+
+    def test_cache_miss_failed_log_emitted_when_loader_raises(self):
+        svc = _FailingCredentialsService()
+        with self.assertLogs(
+            "apollo.credentials.external_credentials_cache", level="INFO"
+        ) as cm:
+            with self.assertRaises(ValueError):
+                svc.get_credentials({"aws_secret": "s1"})
+        failed_logs = [m for m in cm.output if "cache=miss-failed" in m]
+        self.assertEqual(1, len(failed_logs), cm.output)
+        self.assertIn("provider=failing", failed_logs[0])
+        self.assertRegex(failed_logs[0], r"duration_s=\d+\.\d{3}")

--- a/tests/credentials/test_external_credentials_cache.py
+++ b/tests/credentials/test_external_credentials_cache.py
@@ -156,6 +156,29 @@ class TestCacheBehavior(TestCase):
         self.assertEqual(True, second["resolved"])  # cached value unchanged
         self.assertEqual(1, svc.calls)
 
+    def test_nested_mutation_does_not_corrupt_cached_value(self):
+        """A shallow copy would also pass the top-level mutation test above.
+        This one specifically pins the deep-copy semantics: mutating a
+        nested dict in the returned value must not propagate to subsequent
+        cache reads."""
+
+        class _NestedReturningService(BaseCredentialsService):
+            def __init__(self):
+                super().__init__(provider_name="nested")
+                self.calls = 0
+
+            def _load_external_credentials(self, credentials: dict) -> dict:
+                self.calls += 1
+                return {"outer": {"inner": {"value": "original"}}}
+
+        svc = _NestedReturningService()
+        creds = {"aws_secret": "s1"}
+        first = svc.get_credentials(creds)
+        first["outer"]["inner"]["value"] = "MUTATED"
+        second = svc.get_credentials(creds)
+        self.assertEqual("original", second["outer"]["inner"]["value"])
+        self.assertEqual(1, svc.calls)
+
     def test_disabling_via_ttl_zero_calls_loader_every_time(self):
         with patch.object(cache_module, "_CACHE_TTL_SECONDS", 0):
             svc = _RecordingCredentialsService()
@@ -235,3 +258,26 @@ class TestLoadCachedLogging(TestCase):
         self.assertEqual(1, len(failed_logs), cm.output)
         self.assertIn("provider=failing", failed_logs[0])
         self.assertRegex(failed_logs[0], r"duration_s=\d+\.\d{3}")
+
+    def test_cache_error_log_emitted_when_machinery_raises_before_loader(self):
+        """Exceptions raised before the loader is invoked — e.g. inside the
+        cache key hash, the lock acquisition, or the @cached decorator
+        itself — must still produce a log line so a silent failure can't
+        sneak past the diagnostics."""
+        svc = _RecordingCredentialsService()
+        # Force the cached wrapper to raise before the inner timed_loader
+        # has a chance to run.
+        with patch.object(
+            cache_module, "_load_and_cache", side_effect=RuntimeError("machinery boom")
+        ):
+            with self.assertLogs(
+                "apollo.credentials.external_credentials_cache", level="INFO"
+            ) as cm:
+                with self.assertRaises(RuntimeError):
+                    svc.get_credentials({"aws_secret": "s1"})
+        error_logs = [m for m in cm.output if "cache=error" in m]
+        self.assertEqual(1, len(error_logs), cm.output)
+        self.assertIn("provider=recording", error_logs[0])
+        self.assertRegex(error_logs[0], r"duration_s=\d+\.\d{3}")
+        # Loader was never called
+        self.assertEqual(0, svc.calls)

--- a/tests/test_base_credentials_service.py
+++ b/tests/test_base_credentials_service.py
@@ -8,7 +8,7 @@ from apollo.integrations.ctp.registry import CtpRegistry
 
 class TestMergeConnectArgs(TestCase):
     def setUp(self):
-        self.svc = BaseCredentialsService()
+        self.svc = BaseCredentialsService(provider_name="passthrough")
 
     def test_plain_credentials_returned_unchanged(self):
         creds = {"connect_args": {"host": "h", "port": 5432}}


### PR DESCRIPTION
## Summary

Cache the resolved external credentials (ASM / AKV / GSM / etc.) in a process-wide TTL cache so we make at most one network round-trip per credential identifier per TTL window, instead of one per operation.

## Motivation

While investigating a customer agent we observed Databricks ops taking 15–24s end-to-end, with the time spent entirely between credentials fetch start and completion. The same agent's Tableau ops, backed by file-based credentials, were sub-second. ASM was being hit on every op (fresh `boto3.Session` + fresh `secretsmanager` client per call).

## What changes

- New module `apollo/credentials/external_credentials_cache.py`
  - `TTLCache(maxsize=128, ttl=300s)` keyed by sha256 of the credentials dict with `connect_args` removed — request-specific values like warehouse id / http_path don't change which secret to fetch
  - Returns a deep copy on every get so the in-place mutation in `_merge_connect_args` doesn't corrupt the cached value
  - TTL configurable via `MCD_EXTERNAL_CREDENTIALS_CACHE_TTL_SECONDS` (`0` disables caching but keeps the diagnostic log). Value is read once at module import; restart required to change.
  - Documented caveat: `cachetools.@cached` releases the lock between lookup and loader, so concurrent first-misses for the same key all invoke the loader. In practice the egress agent's pattern is "one first call, then concurrent warm hits", so the herd is small and the correctness cost is zero (last write wins).
- `BaseCredentialsService`
  - Routes through `_load_external_credentials_cached` in `get_credentials`
  - `__init__(provider_name: str)` — required, no default. Forgetting the arg in a new subclass fails loudly at instantiation.
  - Passthrough `BaseCredentialsService` bypasses the cache (no network I/O, no benefit, would pin request-specific dicts)
- All five providers (`asm`, `akv`, `gsm`, `env_var`, `file`) declare their `provider_name` via `super().__init__(...)`
- Each `load_cached()` call emits one INFO log so we can verify the cache in production and triage residual slowness:

  ```
  Loaded external credentials, provider=aws_secrets_manager, cache=hit, duration_s=0.000
  Loaded external credentials, provider=aws_secrets_manager, cache=miss, duration_s=0.412
  Loaded external credentials, provider=aws_secrets_manager, cache=disabled, duration_s=0.411
  Loaded external credentials, provider=aws_secrets_manager, cache=miss-failed, duration_s=15.012
  ```

## Test plan

- [x] 24 new unit tests covering cache key stability/separation, hit/miss, failure not cached, deep-copy semantics, log shape, TTL=0 disable
- [x] All existing credentials tests still pass (split a multi-scenario env_var test that used the same key for 3 different env values in one method)
- [x] `pytest tests/` — **1057 passed**
- [x] `black --check`, `pyright` — clean
- [x] Smoke tested on dev EC2 agent (`977f5159-4bcd-4370-9e59-2f3d195d0afc`): 1 `cache=miss` (duration_s=0.172) followed by 27 `cache=hit` (duration_s=0.000) on subsequent ops, 96.4% hit rate — `Found credentials from IAM Role` events dropped from ~130 in 2 min on the old image to 1 in the same window on the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)