### PR TITLE
chore(security): bump gunicorn 23.0.0 -> 26.0.0 (SEC-1746)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,7 @@ flask-compress==1.14
 google-api-python-client==2.176.0  # Upgraded in VULN-620
 google-cloud-secret-manager==2.25.0
 google-cloud-storage==2.10.0
-gunicorn==23.0.0
+gunicorn==26.0.0  # CWE-444 HTTP request smuggling / CWE-113 in 23.0.0 (Aikido group 28678334, SEC-1746)
 hdbcli==2.18.27
 ibm-db==3.2.7
 jinja2>=3.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -151,7 +151,7 @@ grpcio==1.76.0
     #   grpcio-status
 grpcio-status==1.71.2
     # via google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements.in
 hdbcli==2.18.27
     # via -r requirements.in


### PR DESCRIPTION
## Summary

Bumps `gunicorn` from `23.0.0` to `26.0.0` in `requirements.in` + `requirements.txt`. Closes the open Aikido HIGH finding (group `28678334`) tracked in [SEC-1746](https://linear.app/montecarloai/issue/SEC-1746).

## Why this matters

`gunicorn` is the HTTP server fronting the agent — `Dockerfile` runs:
```
CMD gunicorn --bind :$PORT --workers $GUNICORN_WORKERS \
    apollo.interfaces.{aws,generic,cloudrun}.main:app
```

23.0.0 is affected by HTTP request smuggling (CWE-444) and CRLF injection (CWE-113); the fix landed in upstream gunicorn 26.0.0. Because gunicorn terminates HTTP traffic on the customer-facing surface of the agent, this is on the directly exposed attack path — not a transitive/internal-only issue.

The same CVE was confirmed against the GA `montecarlodata/agent` image (not just `pre-release-agent`) via wizcli first-party scan and Aikido cross-check.

## Lockfile note

`gunicorn` 26.0.0 only requires `packaging` (already in the lockfile). No transitive graph changes. The manual one-line lockfile edit matches what `pip-compile --output-file=requirements.txt --strip-extras requirements.in` would produce — verified against PyPI metadata for 26.0.0. If CI regenerates the lockfile differently, please push the regenerated `requirements.txt` over this change.

## Test plan

- [ ] CI green (existing apollo-agent test suite)
- [ ] Local build of the agent container succeeds (`docker build`)
- [ ] Smoke test: container starts, `GET /api/v1/test/health` returns 200
- [ ] Aikido group `28678334` closes on next scan after the GA image is re-published

## Out of scope (separate tickets / next round)

These were also flagged in the same investigation but left for the agent team's normal cadence:
- `PyMySQL` 1.1.1 -> 1.1.3 (Aikido group `26517697`) — LOW exploitability (outbound only)
- `duckdb` 1.1.0 -> 1.3.0 — LOW
- `apache/thrift` 0.22.0 -> 0.23.0 (vendored in teradatasql binaries) — transitive, upstream
- Debian 13 `libgnutls30t64` (2 CRIT TLS CVEs) — base image rebuild

## References

- Linear: [SEC-1746](https://linear.app/montecarloai/issue/SEC-1746)
- Aikido issue group: https://app.aikido.dev/queue?sidebarIssue=28678334
- gunicorn 26.0.0 release: https://pypi.org/project/gunicorn/26.0.0/

🤖 Generated with [Claude Code](https://claude.com/claude-code)