### PR TITLE
Add get_connection_metadata RPC for Informatica POD URL

### DIFF
--- a/apollo/integrations/base_proxy_client.py
+++ b/apollo/integrations/base_proxy_client.py
@@ -46,6 +46,18 @@ class BaseProxyClient(ABC):
         """
         return None
 
+    def get_connection_metadata(self) -> Dict[str, Any]:
+        """
+        Non-secret metadata resolved during CTP / client construction that the
+        caller (Data Collector) may need to include in emitted records — e.g.,
+        the API base URL resolved from a login response, used by callers to
+        construct stable customer-facing links to integration UIs.
+
+        Default: empty dict. Override on subclasses that have something
+        useful to expose. Values must be JSON-serializable.
+        """
+        return {}
+
     def log_payload(self, request: AgentOperation) -> Dict:
         """
         Returns the `extra` payload to include in the log message for the given operation on this client.

--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -60,6 +60,13 @@ class InformaticaProxyClient(BaseProxyClient):
     def wrapped_client(self):
         return None
 
+    def get_connection_metadata(self) -> Dict[str, Any]:
+        """Expose the CTP-resolved API base URL so the Data Collector can
+        construct customer-facing run-detail links — the DC has no other way
+        to discover the resolved POD URL when running through an agent.
+        """
+        return {"api_base_url": self._api_base_url}
+
     def do_http_request(
         self,
         path: str,

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -294,3 +294,58 @@ class InformaticaV2ProxyClientReuseTests(TestCase):
         self.assertTrue(api_url.startswith(_API_BASE_URL))
         headers = mock_request.call_args[1]["headers"]
         self.assertEqual(headers["icSessionId"], _SESSION_ID)
+
+
+class InformaticaConnectionMetadataTests(TestCase):
+    """`get_connection_metadata` exposes the CTP-resolved API base URL so the
+    DC can construct customer-facing run links — it's the DC's only way to
+    discover the resolved POD URL when running through an agent."""
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    def _operation(self) -> dict:
+        return {
+            "trace_id": "test",
+            "skip_cache": True,
+            "commands": [{"method": "get_connection_metadata", "kwargs": {}}],
+        }
+
+    def test_returns_resolved_api_base_url_for_informatica(self):
+        response = self._agent.execute_operation(
+            "informatica",
+            "get_connection_metadata",
+            self._operation(),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
+        )
+
+        self.assertEqual(
+            {"api_base_url": _API_BASE_URL}, response.result["__mcd_result__"]
+        )
+
+    def test_returns_resolved_api_base_url_for_informatica_v2(self):
+        """v2 uses the same proxy client — confirm the metadata surfaces identically."""
+        response = self._agent.execute_operation(
+            "informatica-v2",
+            "get_connection_metadata",
+            self._operation(),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
+        )
+
+        self.assertEqual(
+            {"api_base_url": _API_BASE_URL}, response.result["__mcd_result__"]
+        )
+
+
+class BaseProxyClientConnectionMetadataDefaultTests(TestCase):
+    """The base class default is an empty dict — subclasses opt in by overriding."""
+
+    def test_default_returns_empty_dict(self):
+        from apollo.integrations.base_proxy_client import BaseProxyClient
+
+        class _NoOverride(BaseProxyClient):
+            @property
+            def wrapped_client(self):
+                return None
+
+        self.assertEqual({}, _NoOverride().get_connection_metadata())


### PR DESCRIPTION
## Changes

Exposes CTP-resolved connection metadata back to the Data Collector. Initially used for the Informatica POD URL — the DC has no way to discover the resolved `api_base_url` on the agent path today (the CTP runs on the agent; the resolved URL lives on the proxy client there).

- **`BaseProxyClient.get_connection_metadata() -> Dict[str, Any]`** — new default-returns-empty-dict method. Subclasses opt in by overriding. Values must be JSON-serializable.
- **`InformaticaProxyClient.get_connection_metadata()`** — returns `{"api_base_url": self._api_base_url}`. The CTP's `resolve_informatica_session` transform writes this URL into the proxy client at construction, so exposing it costs nothing.

## Why

Customer use case: the DC builds run-detail event payloads that include a `run_url` field. The Informatica web UI's run-detail URL uses the resolved POD URL (e.g. `https://usw5.dm-us.informaticacloud.com/...`), not the customer-entered login URL. On the DC-direct path the DC sees this URL during `_authenticate`. On the agent path it doesn't. Without this RPC, agent-path `run_url` values can't be built.

## Compatibility

- New method on `BaseProxyClient`. No change to dispatch protocol — existing `@agent_operation`-style calls dispatch by method name.
- The DC will call this opportunistically. Older agents that pre-date this PR (no method on the proxy client) will return a "no such method" error; the DC catches and proceeds with `run_url` omitted on emitted records. **No min-agent-version bump is needed** — run URLs are a nice-to-have follow-up feature.

## Tests

3 new cases in `tests/test_informatica_proxy_client.py`:
- Informatica v1 connection type returns the resolved `api_base_url`
- Informatica v2 connection type returns the same (shared proxy client)
- Base-class default returns `{}` (verified via a minimal subclass with no override)

11/11 pass; pyright + black clean.

## Followups

- **data-collector**: add `@agent_operation`-decorated `get_connection_metadata()` on `InformaticaAgentProxyClient`; call from `InformaticaClient.__init__` on the agent path; wire `self._base_url`; construct `run_url` in the v2 extractor using the Informatica run-detail URL template.
- **saas-serverless**: pass `run_url` through the v2 normalizer.