### PR TITLE
chore(security): bump pyarrow 17→23.0.1, teradatasql 20.0.0.57→20.0.0.59

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,7 @@ presto-python-client==0.8.3
 trino==0.336.0
 protobuf==5.29.6
 psycopg2-binary==2.9.9
-pyarrow==17.0.0  # CVE-2024-52338
+pyarrow==23.0.1  # CVE-2026-25087 (Python bindings unaffected per GHSA-rgxp-2hwp-jwgg, but Trivy/Scout flag <23.0.1)
 pyasn1>=0.6.3  # CVE-2026-30922 (uncontrolled recursion), CVE-2026-23490
 pycryptodome>=3.21.0
 pyjwt>=2.12.0  # CVE-2026-32597
@@ -49,7 +49,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 tableauserverclient==0.38 ; python_version >= "3.10"
 urllib3~=2.7  # CVE-2026-44431, CVE-2026-44432
 
-teradatasql>=20.0.0.57  # earlier versions ship a vulnerable Go 1.25.5 stdlib (CVE-2025-68121 + 5 highs)
+teradatasql>=20.0.0.59  # 20.0.0.59 bumps embedded Go stdlib to 1.26.3 (closes CVE-2026-33811, -39820, -39836, -42499); golang.org/x/net 0.49.0 + thrift 0.22.0 still bundled (33814, 41602 pending upstream)
 oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 impyla==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -218,7 +218,6 @@ numpy==1.26.4
     #   -r requirements.in
     #   databricks-sql-connector
     #   pandas
-    #   pyarrow
 oauthlib==3.2.2
     # via databricks-sql-connector
 openpyxl==3.1.5
@@ -266,7 +265,7 @@ psycopg2-binary==2.9.9
     # via -r requirements.in
 pure-sasl==0.6.2
     # via thrift-sasl
-pyarrow==17.0.0
+pyarrow==23.0.1
     # via
     #   -r requirements.in
     #   salesforce-cdp-connector
@@ -362,7 +361,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tableauserverclient==0.38 ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.57
+teradatasql==20.0.0.59
     # via -r requirements.in
 thrift==0.16.0
     # via


### PR DESCRIPTION
## Summary

Close fixable HIGH-severity CVEs flagged by today's Scout scan.

### pyarrow 17.0.0 → 23.0.1
- Clears Trivy/Scout finding for **CVE-2026-25087**.
- Python bindings are **not actually vulnerable** per [GHSA-rgxp-2hwp-jwgg](https://github.com/advisories/GHSA-rgxp-2hwp-jwgg) — the bug is in Apache Arrow C++'s `RecordBatchFileReader::PreBufferMetadata`, not exposed via Python — but the scanner doesn't differentiate and flags all `<23.0.1`.
- APIs used by `dremio_proxy_client.py` (and `data-collector`'s `plugin_dremio.py` / `custom_mapping.py`) are stable across 17→23: `flight.connect`, `FlightDescriptor`, `FlightCallOptions`, `Schema`, `types.*`, `pyarrow.parquet.read_table`.
- `salesforce-cdp-connector==1.0.19` declares `pyarrow>=17.0.0` — compatible.

### teradatasql 20.0.0.57 → 20.0.0.59
- 20.0.0.59 (released 2026-05-20) bumps the embedded **Go stdlib from 1.26.2 → 1.26.3** in all bundled `.so` files (verified by extracting the wheel and inspecting `teradatasql.so` / `teradatasql.arm.fips.so` / `teradatasql.fips.so` with `strings`).
- Closes **4 of 6** teradata-attributed HIGHs:
  - CVE-2026-33811 (stdlib)
  - CVE-2026-39820 (stdlib)
  - CVE-2026-39836 (stdlib)
  - CVE-2026-42499 (stdlib)
- **Still bundled at vulnerable versions** — pending upstream Teradata to refresh:
  - `golang.org/x/net 0.49.0` → CVE-2026-33814
  - `github.com/apache/thrift 0.22.0` → CVE-2026-41602

## Validation against `pre-release-agent` dev images (Scout, --only-fixed)

| Image | HIGH before | HIGH after | Remaining |
|---|---|---|---|
| `latest-aws-proxied` | 7 | **2** ✅ | x/net, thrift (teradata-bundled) |
| `latest-cloudrun` | 7 | **2** ✅ | same |
| `latest-aws-generic` | 7 | **2** ✅ | same |
| `latest-lambda` | 7 | **2** ✅ | same |
| `latest-azure` | 7 | **7** ⚠️ | same 2 + 5 stdlib 1.26.2 CVEs from a *tombstoned* MS Go binary at `/opt/startupcmdgen/` (see caveat below) |

### Azure caveat (follow-up)

The 5 stdlib-1.26.2 findings on `latest-azure` are a **Docker layer artifact**, not a real runtime exposure. The Dockerfile already runs `rm -rf /opt/startupcmdgen/`, so the Microsoft-supplied Go binary is gone from the merged filesystem. But Scout indexes *every layer in the image manifest*, so the lower MS-base layer still surfaces it. Verified: `grep -ra "go1.26.2" /tmp/azure-extract` returns zero hits; every Go binary that *does* exist in the final FS (all teradata `.so` files) is at 1.26.3.

Pre-bump these were masked because teradata also shipped 1.26.2 — so they showed as one combined finding. Now that teradata is at 1.26.3, the layer-cached binary is exposed.

Follow-up options (not in this PR): squash the azure stage via `COPY --from=` into a fresh azure base, or add a Scout policy exception for tombstoned-file findings.

## Test plan
- [x] `pip-compile` regenerates all 5 lockfiles cleanly
- [x] Local pytest passes (1014/1014; 7 collection errors are macOS-local pyodbc/ODBC/cloud-cred env issues unrelated to the bump)
- [x] CircleCI build green on feature branch
- [x] Dev pipeline green (linter, test-docker, build-and-push-{dev,lambda-dev,docs-dev}, push-lambda-aws-dev, all 3 golden-agent validations)
- [x] Scout validation: 4/5 pre-release images dropped from 7→2 HIGHs as predicted; azure caveat documented above
- [x] **Teradata** smoke-tested in dev (driver was the one updated)
- [x] **Salesforce Data Cloud** smoke-tested in dev (indirect pyarrow consumer via salesforce-cdp-connector)
- [na] **Dremio** — skipped, low risk and priority (only stable `flight.connect` / `FlightDescriptor` / `Schema` / `types.*` APIs in use)
- [na] Data Lake parquet query-log ingestion — skipped, low risk and priority (only `pyarrow.parquet.read_table` + `to_pylist` which are stable APIs)

## Context
- Scout scan thread: https://montecarloai.slack.com/archives/C0B3Q59NKQX/p1779441210738429
- Teradata 20.0.0.59 release (2026-05-20): https://pypi.org/project/teradatasql/20.0.0.59/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
