### PR TITLE
ci: add BuildKit SBOM + SLSA provenance attestations to Docker Hub images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,48 +94,127 @@ jobs:
       - checkout
       - docker/check:
           use-docker-credentials-store: true
+      # Attestations (SBOM + SLSA provenance) require the docker-container
+      # buildx driver — the default docker driver writes single manifests, not
+      # the OCI image index that holds attestation manifests alongside the
+      # platform image. Set up once; reused by every buildx call below.
+      - run:
+          name: Set up buildx (docker-container driver)
+          command: |
+            docker buildx create --use --name apollo-builder --driver docker-container
+            docker buildx inspect --bootstrap
+      # Each target is built TWICE per the BuildKit-attestations workflow:
+      #   1. --load into the local daemon so verify-version-in-docker-image
+      #      can `docker run` against the image before anything is published.
+      #   2. --push with --sbom=true --provenance=mode=max so the registry
+      #      copy carries the supply-chain attestations Docker Scout reads.
+      # BuildKit cache makes the second build cheap — only SBOM/provenance
+      # generation is new work. --load and --push are mutually exclusive when
+      # attestations are involved (the daemon can't load an OCI image index),
+      # which is why two passes are necessary.
+      #
       # Publish the `system-base` stage (apt-only, no venv, no apollo source) as
       # `<version>-system-base`. Downstream consumers (e.g. hermes-agent) build
       # their own venv on top against the same native libs without inheriting
-      # apollo's pip-installed Python deps. Replaces the previous `generic-base`
-      # tag, which bundled the venv and caused image bloat for downstream repos
-      # whose pinned versions diverged from apollo's resolved set.
-      - docker/build:
-          step-name: Build system base image
-          use-buildkit: true # to build only the required stages
-          extra_build_args: --target system-base --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-system-base,<< parameters.code_version >>-system-base
-      - docker/build:
-          step-name: Build AWS generic image
-          use-buildkit: true  # to build only the required stages
-          extra_build_args: --target aws_proxied --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-aws-generic,<< parameters.code_version >>-aws-generic,latest-aws-proxied,<< parameters.code_version >>-aws-proxied
-      - docker/build:
-          step-name: Build cloudrun image
-          use-buildkit: true # to build only the required stages
-          extra_build_args: --target cloudrun --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-cloudrun,<< parameters.code_version >>-cloudrun
-      - docker/build:
-          step-name: Build azure image
-          use-buildkit: true # to build only the required stages
-          extra_build_args: --target azure --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-azure,<< parameters.code_version >>-azure
-      - verify-version-in-docker-image:
-          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun
-          version: << parameters.code_version >>,<< pipeline.number >>
-      - verify-version-in-docker-image:
-          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-azure
-          version: << parameters.code_version >>,<< pipeline.number >>
+      # apollo's pip-installed Python deps. No version check — system-base has
+      # no apollo/agent/version file, so it goes straight to push.
+      - run:
+          name: Build and push system-base with SBOM + SLSA provenance
+          command: |
+            docker buildx build \
+              --target system-base \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-system-base \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-system-base \
+              --sbom=true \
+              --provenance=mode=max \
+              --push \
+              .
+      # AWS proxied/generic — same image, four tags (aws-proxied is the
+      # current name, aws-generic is the legacy alias kept for back-compat).
+      - run:
+          name: Build aws_proxied image (local) for version verification
+          command: |
+            docker buildx build \
+              --target aws_proxied \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-aws-proxied \
+              --load \
+              .
       - verify-version-in-docker-image:
           image: montecarlodata/<< parameters.docker_hub_repository >>:latest-aws-proxied
           version: << parameters.code_version >>,<< pipeline.number >>
-      - docker/push:
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-system-base,<< parameters.code_version >>-system-base,latest-cloudrun,<< parameters.code_version >>-cloudrun,latest-azure,<< parameters.code_version >>-azure,latest-aws-generic,<< parameters.code_version >>-aws-generic,latest-aws-proxied,<< parameters.code_version >>-aws-proxied
+      - run:
+          name: Build and push aws_proxied with SBOM + SLSA provenance
+          command: |
+            docker buildx build \
+              --target aws_proxied \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-aws-proxied \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-aws-proxied \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-aws-generic \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-aws-generic \
+              --sbom=true \
+              --provenance=mode=max \
+              --push \
+              .
+      # cloudrun
+      - run:
+          name: Build cloudrun image (local) for version verification
+          command: |
+            docker buildx build \
+              --target cloudrun \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun \
+              --load \
+              .
+      - verify-version-in-docker-image:
+          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun
+          version: << parameters.code_version >>,<< pipeline.number >>
+      - run:
+          name: Build and push cloudrun with SBOM + SLSA provenance
+          command: |
+            docker buildx build \
+              --target cloudrun \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-cloudrun \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-cloudrun \
+              --sbom=true \
+              --provenance=mode=max \
+              --push \
+              .
+      # azure
+      - run:
+          name: Build azure image (local) for version verification
+          command: |
+            docker buildx build \
+              --target azure \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-azure \
+              --load \
+              .
+      - verify-version-in-docker-image:
+          image: montecarlodata/<< parameters.docker_hub_repository >>:latest-azure
+          version: << parameters.code_version >>,<< pipeline.number >>
+      - run:
+          name: Build and push azure with SBOM + SLSA provenance
+          command: |
+            docker buildx build \
+              --target azure \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-azure \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-azure \
+              --sbom=true \
+              --provenance=mode=max \
+              --push \
+              .
 
   build-and-push-lambda:
     machine:
@@ -151,18 +230,32 @@ jobs:
       - checkout
       - docker/check:
           use-docker-credentials-store: true
-      # Docker Hub copy: keep BuildKit's default provenance attestation
-      # (improves Docker Scout health scores; Docker Hub handles the OCI
-      # image index correctly).
-      - docker/build:
-          step-name: Build lambda image (Docker Hub)
-          use-buildkit: true # to build only the required stages
-          extra_build_args: --target lambda --build-arg code_version=<< parameters.code_version >> --build-arg build_number=<< pipeline.number >>
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-lambda,<< parameters.code_version >>-lambda
-      - docker/push:
-          image: montecarlodata/<< parameters.docker_hub_repository >>
-          tag: latest-lambda,<< parameters.code_version >>-lambda
+      # Docker Hub copy: build and push with SBOM + SLSA provenance (mode=max)
+      # attestations attached. The ECR step below uses the classic docker/build
+      # orb, so we create the buildx builder WITHOUT --use and pass --builder
+      # apollo-builder explicitly on this command. That leaves the default
+      # builder in place so the classic `docker build` the orb runs for the
+      # ECR step continues to use the daemon's docker driver and produces a
+      # single-manifest image (which AWS Lambda / CloudFormation require).
+      - run:
+          name: Set up buildx (docker-container driver) for the Docker Hub build
+          command: |
+            docker buildx create --name apollo-builder --driver docker-container
+            docker buildx inspect --builder apollo-builder --bootstrap
+      - run:
+          name: Build and push lambda (Docker Hub) with SBOM + SLSA provenance
+          command: |
+            docker buildx build \
+              --builder apollo-builder \
+              --target lambda \
+              --build-arg code_version=<< parameters.code_version >> \
+              --build-arg build_number=<< pipeline.number >> \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:latest-lambda \
+              --tag montecarlodata/<< parameters.docker_hub_repository >>:<< parameters.code_version >>-lambda \
+              --sbom=true \
+              --provenance=mode=max \
+              --push \
+              .
       # ECR copy: rebuild with --provenance=false. AWS Lambda / CloudFormation
       # reject the OCI image index that BuildKit emits when attestations are
       # attached ("image manifest, config or layer media type ... is not


### PR DESCRIPTION
## Summary

Add SBOM (SPDX) and SLSA provenance (mode=max) attestations to every apollo agent image we publish to Docker Hub. Clears Docker Scout's "missing supply chain attestations" warning and gives downstream scanners (Trivy, Grype, Prisma, Scout itself) an authoritative package manifest.

**Verified on dev: Docker Scout health score jumped from E → B** on `system-base`, `aws_proxied`/`aws_generic`, `cloudrun`, `azure` after the first run carrying full attestations. Lambda included on the second iteration.

**Stacked on top of #306** (non-root user). Base is `mrostan/agent-as-non-root` so the diff stays focused on the CI change. Will rebase to `main` once #306 merges.

**Targets that gain attestations** (Docker Hub):
- `system-base` → `latest-system-base`, `<ver>-system-base`
- `aws_proxied` → `latest-aws-proxied`, `<ver>-aws-proxied`, `latest-aws-generic`, `<ver>-aws-generic`
- `cloudrun` → `latest-cloudrun`, `<ver>-cloudrun`
- `azure` → `latest-azure`, `<ver>-azure`
- `lambda` (Docker Hub copy) → `latest-lambda`, `<ver>-lambda`

**Targets that intentionally stay unattested:**
- `lambda` (ECR copy in `build-and-push-lambda`, plus `push-lambda-legacy-repo`) — AWS Lambda / CloudFormation reject the OCI image index that BuildKit emits when attestations are attached. ECR copies are rebuilt with `--provenance=false` so they stay plain single-arch manifests.

## Implementation notes

- Replaces `docker/build` + `docker/push` orb pairs (for Docker Hub destinations) with explicit `docker buildx build` calls. The docker daemon's default driver can't store the OCI image index that holds attestation manifests alongside the platform image, so we use the `docker-container` driver via a buildx builder named `apollo-builder`.
- Per Docker Hub target the flow is **load → verify → push**:
  1. `buildx --load` into the local daemon, then run `verify-version-in-docker-image` before anything is published.
  2. `buildx --push` with `--sbom=true --provenance=mode=max`. BuildKit cache means this second build adds only SBOM/provenance generation time (~30s per image), not a full rebuild.
- `--load` and `--push` are mutually exclusive when attestations are involved (the daemon can't load an OCI image index), which is why two passes are necessary.
- `system-base` skips the verify pass — no `apollo/agent/version` file inside.
- `lambda` Docker Hub copy also skips inline verify; the existing ECR build that follows produces a single-manifest image which `verify-version-in-docker-image` already covers.

**Two builder-setup conventions in this PR**, because the two jobs have different surrounding shapes:

- `build-and-push` contains only buildx calls, so the builder is created with `--use` (default for the job) and each buildx call needs no `--builder` flag — matches hermes-agent's style.
- `build-and-push-lambda` mixes the buildx Docker Hub step with the classic `docker/build` orb for the ECR step (which must stay on the daemon's docker driver to produce a single-manifest image AWS Lambda accepts). The builder is created **without** `--use` and the buildx call passes `--builder apollo-builder` explicitly, so the orb step's classic `docker build` keeps routing through the daemon's docker driver.

## Safety

- **`provenance=mode=max` is safe for this repo.** Build args are only public version metadata (`code_version`, `build_number`). No `--secret` mounts, no private package indices, source repo is public.
- **No behavior change for the runtime images.** Attestations live in a separate manifest entry in the OCI image index; `docker pull` resolves to the platform image and ignores them. Image SHA, layers, size, runtime user — all unchanged.
- **ECR images unchanged.** Both Lambda ECR jobs continue through the existing `docker/build` orb path with `--provenance=false`, producing plain single-manifest images.

## Verified on dev (pipeline 2815)

SBOM + provenance present on every Docker Hub target:

| Target | SBOM packages | mode=max signals |
|---|---|---|
| `system-base` | 167 | ✅ |
| `aws_proxied` / `aws_generic` | 574 | ✅ |
| `cloudrun` | 583 | ✅ |
| `azure` | 1,517 | ✅ |
| `lambda` | 520 | ✅ (21 internal digestMappings) |

Spot-check command:
```
docker buildx imagetools inspect montecarlodata/pre-release-agent:<ver>-<target> \
  --format '{{json .SBOM.SPDX}}' | jq '{name, packages: (.packages | length)}'
```

## Test plan

- [x] CircleCI green on this PR (run-linter, run-test-docker, build-ok)
- [x] `build-and-push-dev` succeeded on dev; SBOM + mode=max provenance on system-base/aws/cloudrun/azure
- [x] `build-and-push-lambda-dev` succeeded with new buildx Docker Hub flow; lambda image gains SBOM + mode=max provenance
- [x] Docker Scout health score E → B (verified on first iteration; lambda expected to follow on next Scout refresh)
- [x] ECR lambda image confirmed as plain single-manifest in ECR console — only one "Image" row per tag, no additional attestation-manifest rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
