### PR TITLE
feat(security): block cloud metadata services and other non-routable IPs

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,3 +1,9 @@
 export MCD_DEBUG=true
-export MCD_STORAGE_BUCKET_NAME=agent-bucket 
+export MCD_STORAGE_BUCKET_NAME=agent-bucket
 export MCD_STORAGE=GCS
+
+# SSRF guard — additional CIDRs to block (comma-separated IPv4/IPv6, extends the default block list)
+# export MCD_HTTP_BLOCKED_CIDRS=100.64.0.0/10,10.50.0.0/16
+
+# SSRF guard — require HTTPS in the default tier (true/false, default false)
+# export MCD_HTTP_REQUIRE_HTTPS=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
       types_or: [python, pyi]
 
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.337
+    rev: v1.1.407
     hooks:
     - id: pyright

--- a/README.md
+++ b/README.md
@@ -187,6 +187,22 @@ See [LICENSE](https://github.com/monte-carlo-data/apollo-agent/blob/main/LICENSE
 
 See [SECURITY](https://github.com/monte-carlo-data/apollo-agent/blob/main/SECURITY.md) for more information.
 
+### SSRF protection
+
+The agent's HTTP integrations include a built-in SSRF guard that blocks requests to link-local and
+loopback addresses (including cloud metadata endpoints such as `169.254.169.254`). Two environment
+variables allow operators to tune this behaviour:
+
+- **`MCD_HTTP_BLOCKED_CIDRS`** — comma-separated list of additional CIDRs (IPv4 or IPv6) the agent
+  should refuse to connect to, extending the default block list. Invalid entries are logged and
+  skipped. The value is read once at module import time. Example:
+  `MCD_HTTP_BLOCKED_CIDRS=100.64.0.0/10,10.50.0.0/16`
+
+- **`MCD_HTTP_REQUIRE_HTTPS`** — boolean (`true`/`false`). When `true`, the default SSRF-guard tier
+  rejects plain HTTP URLs, allowing only HTTPS. Defaults to `false` (both HTTP and HTTPS are
+  permitted in the default tier). The strict download tier always requires HTTPS regardless of this
+  setting.
+
 ## Advanced deployment
 This section is intended only for troubleshooting and advanced scenarios, using templates (Terraform or CloudFormation)
 is the preferred way to deploy agents (even test agents as you can customize the image to use).

--- a/apollo/integrations/http/CLAUDE.md
+++ b/apollo/integrations/http/CLAUDE.md
@@ -31,7 +31,7 @@ the connection.
 
 | Tier | Activated by | What it allows |
 |---|---|---|
-| **Default** | `safe_request(method, url, **kwargs)` | RFC 1918 allowed; metadata service ranges and loopback blocked |
+| **Default** | `safe_request(method, url, **kwargs)` | RFC 1918 allowed; metadata service ranges and loopback blocked. HTTP allowed by default; set `MCD_HTTP_REQUIRE_HTTPS=true` to require HTTPS. |
 | **Strict** | `safety_policy(url, strict_ip_policy=True, https_only=True)` | Public IPs only + HTTPS required; used for pre-signed URL downloads |
 
 ### Redirect handling
@@ -70,6 +70,8 @@ import requests
 with safety_policy(url, strict_ip_policy=True, https_only=True):
     response = requests.get(url, allow_redirects=False)
 ```
+
+**Subclasses of `HttpProxyClient`** get the guard automatically — `do_request` already routes through `safe_request`. New request paths that bypass `do_request` (or new clients that don't subclass `HttpProxyClient`) must wrap with `safe_request` explicitly.
 
 **Do not use `requests.request` directly** — the URL-layer scheme and host
 pre-flight checks in `safety_policy` will be skipped (the IP-level hook still

--- a/apollo/integrations/http/CLAUDE.md
+++ b/apollo/integrations/http/CLAUDE.md
@@ -1,0 +1,92 @@
+# HTTP — Generic HTTP Proxy Client and SSRF Guard
+
+Generic HTTP client infrastructure used by HTTP-based integrations, plus a
+server-side request forgery (SSRF) guard that blocks requests to cloud metadata
+services, RFC 1918 ranges (where not expected), and other sensitive targets.
+
+## Key files
+
+- **`http_proxy_client.py`** — `HttpProxyClient`: generic HTTP proxy client with
+  `do_request`, `download_bytes`, and `download_to_storage` methods used by all
+  HTTP-based integrations.
+- **`url_safety.py`** — SSRF guard: a `urllib3` connection hook plus the
+  `safety_policy` context manager that activates it per-thread.
+- **`informatica_proxy_client.py`** — `InformaticaProxyClient`: `HttpProxyClient`
+  subclass for Informatica Intelligent Data Management Cloud.
+- **`mulesoft_proxy_client.py`** — `MuleSoftProxyClient`: `HttpProxyClient`
+  subclass for MuleSoft Anypoint.
+
+## SSRF guard architecture
+
+The guard wraps `urllib3.util.connection.create_connection` **once at module
+import time**. The wrapper is transparent by default: if no policy is active on
+the current thread, every call passes straight through, so Snowflake, GCS,
+Azure, and other SDK-managed connections are completely unaffected.
+
+When a `safety_policy` context manager is active, the wrapper resolves the
+destination IP and runs it against the configured block list before allowing
+the connection.
+
+### Two tiers
+
+| Tier | Activated by | What it allows |
+|---|---|---|
+| **Default** | `safe_request(method, url, **kwargs)` | RFC 1918 allowed; metadata service ranges and loopback blocked |
+| **Strict** | `safety_policy(url, strict_ip_policy=True, https_only=True)` | Public IPs only + HTTPS required; used for pre-signed URL downloads |
+
+### Redirect handling
+
+Every TCP connection attempt goes through `create_connection`, so each redirect
+hop is independently checked. There is no need to subclass `requests.Session` or
+intercept the redirect chain at a higher level.
+
+### Operator extension points
+
+| Env var | Default | Effect |
+|---|---|---|
+| `MCD_HTTP_BLOCKED_CIDRS` | _(empty)_ | Comma-separated extra CIDRs to block |
+| `MCD_HTTP_REQUIRE_HTTPS` | `false` | Require HTTPS on the default tier |
+
+Both are read once at import time. Changing them requires a process restart.
+
+## Call-site guidance
+
+**General HTTP requests** — use `safe_request`:
+
+```python
+from apollo.integrations.http.url_safety import safe_request
+
+response = safe_request("GET", "https://api.example.com/data", headers={...})
+```
+
+**Strict downloads** (pre-signed URLs received from upstream systems) — enter
+`safety_policy` explicitly and disable automatic redirects so each hop is
+evaluated:
+
+```python
+from apollo.integrations.http.url_safety import safety_policy
+import requests
+
+with safety_policy(url, strict_ip_policy=True, https_only=True):
+    response = requests.get(url, allow_redirects=False)
+```
+
+**Do not use `requests.request` directly** — the URL-layer scheme and host
+pre-flight checks in `safety_policy` will be skipped (the IP-level hook still
+fires at connection time, but the earlier URL validation won't run).
+
+## Threading note
+
+The policy is stored in `threading.local`, so it is scoped to the thread that
+entered the context manager. If HTTP work is dispatched to a worker thread
+(e.g. `ThreadPoolExecutor`, `asyncio.run_in_executor`), re-enter `safety_policy`
+on that worker thread — it does not propagate automatically.
+
+## Out of scope
+
+- **`apollo/integrations/db/`** — DB clients speak DB-specific wire protocols
+  (TDS, MySQL binary protocol, etc.) with their own connection security model;
+  the HTTP SSRF guard does not apply.
+- **`apollo/integrations/ctp/transforms/`** — CTP transforms build credentials
+  and resolve OAuth tokens before a connection is opened; they intentionally
+  do not route through the guard.

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -12,7 +12,7 @@ from apollo.common.agent.models import AgentOperation
 from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
 from apollo.integrations.http.url_safety import (
-    HttpClientError,
+    HttpClientError as HttpClientError,
     safe_request,
     safety_policy,
 )

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -1,10 +1,8 @@
-import ipaddress
 import logging
 import os
 import tempfile
 from contextlib import contextmanager
 from typing import Dict, Iterator, List, Optional, Tuple, Union
-from urllib.parse import urlsplit
 
 import requests
 from requests import HTTPError
@@ -13,6 +11,11 @@ from retry.api import retry_call
 from apollo.common.agent.models import AgentOperation
 from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.http.url_safety import (
+    HttpClientError,
+    safe_request,
+    safety_policy,
+)
 from apollo.integrations.storage.base_storage_client import BaseStorageClient
 
 # Hoisted to module scope: a late import inside `download_to_storage` would
@@ -38,10 +41,6 @@ _RRI = dict(
     backoff=2,
     max_delay=10,
 )
-
-
-class HttpClientError(Exception):
-    pass
 
 
 class HttpRetryableError(Exception):
@@ -104,31 +103,6 @@ class HttpProxyClient(BaseProxyClient):
             payload, _HTTP_REDACTED_ATTRIBUTES
         )
 
-    @staticmethod
-    def _assert_safe_download_url(url: str) -> None:
-        # Phrasing is method-agnostic so the same helper can be reused by every
-        # streaming download entry point on this client (download_bytes,
-        # download_to_storage, future additions) without misnaming the caller.
-        parts = urlsplit(url)
-        if parts.scheme != "https":
-            raise HttpClientError(
-                f"download requires https scheme; got '{parts.scheme}'"
-            )
-        host = (parts.hostname or "").lower()
-        if host in ("", "localhost"):
-            raise HttpClientError(f"download refuses '{host or '<empty>'}' host")
-        try:
-            ip = ipaddress.ip_address(host)
-        except ValueError:
-            return  # not a literal IP — DNS hostname is OK
-        # Reject every IP-literal class that is not appropriate as a download
-        # target. `is_global` is False for private (RFC1918), loopback,
-        # link-local, reserved, and unspecified (0.0.0.0 / ::) — but Python's
-        # ipaddress module reports `is_global=True` for multicast (e.g.
-        # 224.0.0.0/4), so we add an explicit multicast check.
-        if not ip.is_global or ip.is_multicast:
-            raise HttpClientError(f"download refuses non-public address: {ip}")
-
     def _get_storage_client(self) -> BaseStorageClient:
         """Lazy + cached storage client for ``download_to_storage``.
 
@@ -181,14 +155,16 @@ class HttpProxyClient(BaseProxyClient):
             The ranges are expected to be specified in a list of tuples where each tuple includes two elements:
             inclusive from and exclusive to, for example: [(500, 600)] means: `500 <= status_code < 600`.
 
-        URL validation: ``do_request`` does NOT validate the destination URL — no
-        scheme check, no host allowlist, no IP-range guard. The agent trusts the
-        caller (typically the Monte Carlo DC) for URL construction. This is a
-        deliberate design choice for the MuleSoft and ``http`` connection types,
-        where the DC owns endpoint selection. Callers that need SSRF defenses
-        (e.g., for downloading from caller-supplied URLs that may originate further
-        upstream) should use ``download_bytes`` instead, which calls
-        ``_assert_safe_download_url``.
+        URL validation: the destination URL is validated against the SSRF block
+        list in ``apollo.integrations.http.url_safety`` (default-blocks cloud
+        metadata services and loopback; operator-extensible via
+        ``MCD_HTTP_BLOCKED_CIDRS``) and the underlying TCP connect is pinned to
+        the validated IP to close DNS-rebinding. RFC1918 is intentionally
+        allowed — VPC/Private-Link traffic is in scope for this client.
+        Callers needing the stricter "public-only" policy (e.g. for
+        caller-supplied URLs whose host comes from further upstream) should
+        use ``download_bytes`` instead, which wraps the request in
+        ``safety_policy(url, strict_ip_policy=True, https_only=True)``.
 
         :return: the JSON result of the request
         """
@@ -215,7 +191,7 @@ class HttpProxyClient(BaseProxyClient):
             headers["User-Agent"] = user_agent
         request_args["headers"] = headers
 
-        response = requests.request(http_method, url, **request_args)
+        response = safe_request(http_method, url, **request_args)
         try:
             response.raise_for_status()
         except HTTPError as err:
@@ -264,8 +240,6 @@ class HttpProxyClient(BaseProxyClient):
                 or 4xx response.
             HTTPError: 5xx response.
         """
-        self._assert_safe_download_url(url)
-
         headers = {**additional_headers} if additional_headers else {}
         if not no_auth:
             self._attach_auth_header(headers)
@@ -287,8 +261,13 @@ class HttpProxyClient(BaseProxyClient):
             request_func = requests.head
         else:
             request_func = requests.get
+        # Strict tier: downloads only ever target signed public HTTPS URLs;
+        # non-public IPs and non-HTTPS schemes are out-of-band. ``allow_redirects=False``
+        # is set in ``request_kwargs`` above, so the IP guard installed by
+        # ``safety_policy`` only runs for the initial connection.
         try:
-            response = request_func(url, **request_kwargs)
+            with safety_policy(url, strict_ip_policy=True, https_only=True):
+                response = request_func(url, **request_kwargs)
         except requests.RequestException as exc:
             raise HttpClientError(
                 f"{op_label} transport error: {type(exc).__name__}"

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -248,6 +248,17 @@ def assert_safe_destination(
         the block list applies uniformly — but the policy structure
         (e.g. adding a new early-exit check) must be kept in sync
         manually.
+
+        Note the two intentionally differ on mixed record sets: this
+        function is strict and rejects if *any* resolved address is
+        blocked, because it only returns a validated IP and does not
+        connect. ``_safe_create_connection`` validates lazily, in
+        ``getaddrinfo`` order, only the addresses it actually attempts —
+        a blocked address that appears *after* one it connects to
+        successfully is never reached and never checked. That is
+        deliberate (it mirrors urllib3's own fall-through-on-failure
+        behavior); don't "fix" the divergence by forcing either side to
+        match the other.
     """
     if not host:
         raise HttpClientError("destination refuses '<empty>' host")

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -35,7 +35,14 @@ Operators can extend the default block list via the
 ``MCD_HTTP_BLOCKED_CIDRS`` env var: a comma-separated list of CIDRs
 (e.g. ``"100.64.0.0/10,10.50.0.0/16"``). Invalid entries are logged
 and skipped at import time so a typo never crashes the agent. The
-env-var extension applies on top of both policy tiers.
+env-var extension applies on top of both policy tiers. Read once at
+module-import time — changes require a process restart.
+
+Operators can also enforce HTTPS in the default policy tier by setting
+``MCD_HTTP_REQUIRE_HTTPS=true``. The strict download tier (which passes
+``https_only=True`` explicitly) is unaffected — it already requires
+HTTPS unconditionally. Only the default tier picks up the env-var policy.
+Read once at module-import time — changes require a process restart.
 
 The ``create_connection`` wrapper is **always installed** at import
 time but is a passthrough whenever no policy is active on the current
@@ -86,6 +93,7 @@ class HttpClientError(Exception):
 
 
 _ENV_EXTRA_BLOCKED_CIDRS = "MCD_HTTP_BLOCKED_CIDRS"
+_ENV_REQUIRE_HTTPS = "MCD_HTTP_REQUIRE_HTTPS"
 
 _DEFAULT_BLOCKED_CIDRS: Tuple[str, ...] = (
     "169.254.0.0/16",
@@ -123,10 +131,39 @@ def _load_extra_blocked_networks() -> List[_Network]:
     return _parse_cidrs(tuple(raw.split(",")), source=_ENV_EXTRA_BLOCKED_CIDRS)
 
 
+def _load_bool_env(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if raw in ("true", "1", "yes", "on"):
+        return True
+    if raw in ("false", "0", "no", "off", ""):
+        return default if raw == "" else False
+    _logger.warning(
+        "url_safety: ignoring invalid value for %s: '%s' — using default %s",
+        name,
+        raw,
+        default,
+    )
+    return default
+
+
 _DEFAULT_NETWORKS: List[_Network] = _parse_cidrs(
     _DEFAULT_BLOCKED_CIDRS, source="defaults"
 )
 _EXTRA_NETWORKS: List[_Network] = _load_extra_blocked_networks()
+_REQUIRE_HTTPS_BY_DEFAULT: bool = _load_bool_env(_ENV_REQUIRE_HTTPS, default=False)
+
+
+def _log_startup_summary() -> None:
+    _logger.info(
+        "url_safety: SSRF guard initialized — %d default CIDR(s), %d extra CIDR(s) from %s, https_only=%s",
+        len(_DEFAULT_NETWORKS),
+        len(_EXTRA_NETWORKS),
+        _ENV_EXTRA_BLOCKED_CIDRS,
+        _REQUIRE_HTTPS_BY_DEFAULT,
+    )
+
+
+_log_startup_summary()
 
 
 def _ip_is_rejected(ip: _Address, *, strict_ip_policy: bool) -> bool:
@@ -159,7 +196,8 @@ def _assert_safe_url_scheme_and_host(url: str, *, https_only: bool) -> None:
     block) but produces a clearer error message at the URL layer.
     """
     parts = urlsplit(url)
-    allowed_schemes = ("https",) if https_only else ("http", "https")
+    effective_https_only = https_only or _REQUIRE_HTTPS_BY_DEFAULT
+    allowed_schemes = ("https",) if effective_https_only else ("http", "https")
     if parts.scheme not in allowed_schemes:
         raise HttpClientError(f"request refuses unsupported scheme '{parts.scheme}'")
     host = (parts.hostname or "").lower()
@@ -187,6 +225,13 @@ def _assert_safe_url_scheme_and_host(url: str, *, https_only: bool) -> None:
 # ``requests.Session`` subclassing.
 
 _policy = threading.local()
+# We hook urllib3.util.connection.create_connection because it is the
+# function every HTTP(S) connection ultimately calls for the TCP socket
+# create+connect step. This is internal urllib3 API; the hook has been
+# verified against urllib3 1.26.x and 2.x. If a future urllib3 version
+# reorganizes connection creation away from this function, the hook
+# will silently become a no-op — `test_hook_is_installed` is the
+# canary for that.
 _original_create_connection = _urllib3_connection.create_connection
 
 
@@ -206,6 +251,11 @@ def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any)
     if literal is not None:
         if _ip_is_rejected(literal, strict_ip_policy=strict):
             raise HttpClientError(f"request refuses blocked address: {literal}")
+        # Pass the original `address` tuple through unchanged: when the IP is
+        # not rejected, urllib3 sees exactly what it would have without the
+        # wrapper. Reconstructing here (e.g. `(str(literal), port)`) would
+        # work — but minimizing interference avoids subtle interpretation
+        # drift between the validated and pass-through paths.
         return _original_create_connection(address, *args, **kwargs)
 
     # Hostname: resolve, then validate-and-connect in a single pass.
@@ -241,7 +291,13 @@ def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any)
     raise OSError("getaddrinfo returned no usable address")
 
 
-_urllib3_connection.create_connection = _safe_create_connection
+_safe_create_connection._mc_ssrf_guard = True  # marker for idempotency check
+
+if not getattr(_urllib3_connection.create_connection, "_mc_ssrf_guard", False):
+    _urllib3_connection.create_connection = _safe_create_connection
+# else: module already imported (possibly via a different import path);
+# don't re-wrap. _original_create_connection retains the value from
+# the first import.
 
 
 @contextmanager
@@ -265,6 +321,23 @@ def safety_policy(
     callers do not need to subclass ``requests.Session`` to handle
     cross-host redirects safely.
 
+    ``https_only`` is enforced ONLY against the entry URL via the
+    URL-layer pre-flight; it is NOT re-checked on redirected hops (the
+    TCP-layer hook does not see the URL scheme). Callers that need to
+    prevent redirect-based scheme downgrade MUST also pass
+    ``allow_redirects=False`` to the underlying ``requests`` call. The
+    strict download path in ``HttpProxyClient._open_download_response``
+    already does this.
+
+    The policy is per-thread (``threading.local``). It applies only to
+    HTTP calls issued on the same thread that entered ``safety_policy``.
+    If the calling code dispatches the HTTP request to a worker thread
+    (``concurrent.futures.ThreadPoolExecutor``) or via
+    ``asyncio.get_event_loop().run_in_executor(...)``, the worker thread
+    will see no active policy and the guard will be a passthrough.
+    Callers that fan out HTTP work to other threads MUST re-enter
+    ``safety_policy`` on the worker thread.
+
     Args:
         url: optional URL whose scheme + host should be validated
             upfront against the active tier.
@@ -280,13 +353,15 @@ def safety_policy(
     """
     if url is not None:
         _assert_safe_url_scheme_and_host(url, https_only=https_only)
+    prev_active = getattr(_policy, "active", False)
+    prev_strict = getattr(_policy, "strict_ip_policy", False)
     _policy.active = True
     _policy.strict_ip_policy = strict_ip_policy
-    _policy.https_only = https_only
     try:
         yield
     finally:
-        _policy.active = False
+        _policy.active = prev_active
+        _policy.strict_ip_policy = prev_strict
 
 
 def safe_request(method: str, url: str, **kwargs: Any) -> requests.Response:

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -220,7 +220,10 @@ def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any)
 
     err: Union[BaseException, None] = None
     for info in infos:
-        ip_str = info[4][0]
+        # info[4] is the sockaddr tuple; first element is the IP literal as
+        # a string (str() is a no-op typed-narrowing here, since getaddrinfo
+        # always returns IP literals as strings for AF_INET / AF_INET6).
+        ip_str = str(info[4][0])
         try:
             ip = ipaddress.ip_address(ip_str)
         except ValueError:

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -1,0 +1,307 @@
+"""SSRF defense for the agent's HTTP integrations.
+
+The guard is enforced inside urllib3's TCP-connect path, gated by a
+per-thread policy that the caller activates around the request via
+``safety_policy``. Because urllib3 calls ``create_connection`` for every
+connection it opens — initial request, redirected request, retry — a
+single wrapper on that function covers every hop without any special
+``requests.Session`` plumbing.
+
+Two policy tiers share one implementation:
+
+  * **Default policy** (used by ``do_request`` and similar integrations
+    where the agent talks to customer-configured services): rejects
+    cloud metadata services and loopback, but allows RFC1918 so the
+    agent can reach databases and services in the customer's VPC/VNet
+    via private IP. Operator-extensible via ``MCD_HTTP_BLOCKED_CIDRS``.
+
+  * **Strict policy** (used by streaming download endpoints whose URLs
+    originate further upstream — e.g. pre-signed S3/GCS/Azure Blob URLs
+    handed to ``HttpProxyClient.download_*``): rejects every non-public
+    address (RFC1918, link-local, loopback, multicast, reserved,
+    unspecified) and refuses non-HTTPS. Enabled by passing
+    ``strict_ip_policy=True`` and ``https_only=True`` to
+    ``safety_policy``.
+
+Default-blocked CIDRs cover cloud metadata services and other
+addresses the agent never has a legitimate reason to reach:
+
+  - 169.254.0.0/16  IPv4 link-local (AWS/GCP/Azure/Oracle/etc. metadata)
+  - fe80::/10       IPv6 link-local
+  - 127.0.0.0/8     IPv4 loopback
+  - ::1/128         IPv6 loopback
+
+Operators can extend the default block list via the
+``MCD_HTTP_BLOCKED_CIDRS`` env var: a comma-separated list of CIDRs
+(e.g. ``"100.64.0.0/10,10.50.0.0/16"``). Invalid entries are logged
+and skipped at import time so a typo never crashes the agent. The
+env-var extension applies on top of both policy tiers.
+
+The ``create_connection`` wrapper is **always installed** at import
+time but is a passthrough whenever no policy is active on the current
+thread, so unrelated urllib3 users in the same process (Snowflake
+connector, GCS / Azure SDKs, OpenTelemetry exporter, etc.) see the
+original behavior.
+
+Out of scope:
+  - DB clients (Snowflake, BigQuery, Redshift, Starburst, etc.) — they
+    speak DB-specific wire protocols, so a metadata-service IP fails
+    handshake rather than serving credentials. Different threat model.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+import threading
+from contextlib import contextmanager
+from typing import Any, Iterator, List, Tuple, Union
+from urllib.parse import urlsplit
+
+import requests
+from urllib3.util import connection as _urllib3_connection
+
+_logger = logging.getLogger(__name__)
+
+
+class HttpClientError(Exception):
+    """Raised when a request URL or its resolved IP fails the SSRF
+    safety check.
+
+    Defined here (rather than in ``http_proxy_client``) so that
+    ``url_safety`` has no upward dependency on the client module.
+    ``http_proxy_client`` re-exports it under the same name to
+    preserve the existing import surface for external callers.
+
+    Note: ``HttpClientError`` deliberately does NOT inherit from
+    ``OSError``. When raised from inside ``create_connection`` it
+    propagates cleanly through urllib3's pool layer and the
+    ``HTTPAdapter`` (both of which catch ``OSError`` / urllib3-specific
+    exceptions but not arbitrary subclasses), so callers see the
+    original ``HttpClientError`` rather than a wrapped
+    ``ConnectionError``.
+    """
+
+
+_ENV_EXTRA_BLOCKED_CIDRS = "MCD_HTTP_BLOCKED_CIDRS"
+
+_DEFAULT_BLOCKED_CIDRS: Tuple[str, ...] = (
+    "169.254.0.0/16",
+    "fe80::/10",
+    "127.0.0.0/8",
+    "::1/128",
+)
+
+_Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
+_Address = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+
+def _parse_cidrs(cidrs: Tuple[str, ...], *, source: str) -> List[_Network]:
+    parsed: List[_Network] = []
+    for raw in cidrs:
+        entry = raw.strip()
+        if not entry:
+            continue
+        try:
+            parsed.append(ipaddress.ip_network(entry, strict=False))
+        except ValueError as exc:
+            _logger.warning(
+                "url_safety: ignoring invalid CIDR in %s: '%s' (%s)",
+                source,
+                entry,
+                exc,
+            )
+    return parsed
+
+
+def _load_extra_blocked_networks() -> List[_Network]:
+    raw = os.environ.get(_ENV_EXTRA_BLOCKED_CIDRS, "")
+    if not raw:
+        return []
+    return _parse_cidrs(tuple(raw.split(",")), source=_ENV_EXTRA_BLOCKED_CIDRS)
+
+
+_DEFAULT_NETWORKS: List[_Network] = _parse_cidrs(
+    _DEFAULT_BLOCKED_CIDRS, source="defaults"
+)
+_EXTRA_NETWORKS: List[_Network] = _load_extra_blocked_networks()
+
+
+def _ip_is_rejected(ip: _Address, *, strict_ip_policy: bool) -> bool:
+    """Return True if ``ip`` is disallowed by the active policy tier.
+
+    The env-var extra list applies under both tiers; the strict tier
+    adds the broader "non-public" rejection on top.
+    """
+    if any(ip in net for net in _DEFAULT_NETWORKS):
+        return True
+    if any(ip in net for net in _EXTRA_NETWORKS):
+        return True
+    if strict_ip_policy:
+        # ``is_global`` is False for private (RFC1918), loopback,
+        # link-local, reserved, and unspecified — but Python's
+        # ipaddress module reports ``is_global=True`` for multicast,
+        # so multicast gets an explicit reject.
+        if (not ip.is_global) or ip.is_multicast:
+            return True
+    return False
+
+
+def _assert_safe_url_scheme_and_host(url: str, *, https_only: bool) -> None:
+    """URL-layer pre-flight: scheme + host sanity.
+
+    ``create_connection`` only sees ``(host, port)`` — port 443 is not a
+    reliable proxy for "this is HTTPS", so the scheme check has to live
+    at the URL layer. The empty/``localhost`` check is technically
+    redundant (``localhost`` resolves to 127.0.0.1 → caught by the IP
+    block) but produces a clearer error message at the URL layer.
+    """
+    parts = urlsplit(url)
+    allowed_schemes = ("https",) if https_only else ("http", "https")
+    if parts.scheme not in allowed_schemes:
+        raise HttpClientError(f"request refuses unsupported scheme '{parts.scheme}'")
+    host = (parts.hostname or "").lower()
+    if host in ("", "localhost"):
+        raise HttpClientError(f"request refuses '{host or '<empty>'}' host")
+
+
+# --- Per-thread policy + create_connection wrapper ---------------------------
+#
+# The wrapper around ``urllib3.util.connection.create_connection`` is
+# installed once at import time. It is a passthrough whenever no policy
+# is active on the current thread, so unrelated urllib3 users in the
+# same process (Snowflake connector, GCS / Azure SDKs, OpenTelemetry
+# exporter, etc.) see the original behavior.
+#
+# When a policy IS active (set via ``safety_policy``), the wrapper:
+#   1. Validates IP literals directly against the active tier.
+#   2. For hostnames, resolves and validates every A/AAAA record —
+#      rejecting the whole hostname if any record is blocked, then
+#      iterating through the validated list trying to connect. This
+#      preserves urllib3's native multi-IP fallback semantics.
+#
+# Because the wrapper runs on every ``create_connection``, redirected
+# requests get the same guard as the initial request without any
+# ``requests.Session`` subclassing.
+
+_policy = threading.local()
+_original_create_connection = _urllib3_connection.create_connection
+
+
+def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any) -> Any:
+    if not getattr(_policy, "active", False):
+        return _original_create_connection(address, *args, **kwargs)
+
+    host, port = address
+    strict = getattr(_policy, "strict_ip_policy", False)
+
+    # IP literal: validate, then delegate to the original (which is now
+    # a cheap getaddrinfo on a literal + connect).
+    try:
+        literal = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if _ip_is_rejected(literal, strict_ip_policy=strict):
+            raise HttpClientError(f"request refuses blocked address: {literal}")
+        return _original_create_connection(address, *args, **kwargs)
+
+    # Hostname: resolve, then validate-and-connect in a single pass.
+    # If a transiently-unreachable address fails, fall back to the next
+    # (parity with the original urllib3 behavior). We only validate an
+    # address when we're about to connect to it — addresses past a
+    # successful connect are not validated, since we never reach them.
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise HttpClientError(f"DNS resolution failed: {exc}") from None
+
+    err: Union[BaseException, None] = None
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _ip_is_rejected(ip, strict_ip_policy=strict):
+            raise HttpClientError(
+                f"request refuses blocked address resolved from hostname: {ip}"
+            )
+        try:
+            return _original_create_connection((ip_str, port), *args, **kwargs)
+        except OSError as exc:
+            err = exc
+    if err is not None:
+        raise err
+    raise OSError("getaddrinfo returned no usable address")
+
+
+_urllib3_connection.create_connection = _safe_create_connection
+
+
+@contextmanager
+def safety_policy(
+    url: Union[str, None] = None,
+    *,
+    strict_ip_policy: bool = False,
+    https_only: bool = False,
+) -> Iterator[None]:
+    """Activate the SSRF policy for HTTP requests on this thread for the
+    duration of the context.
+
+    If ``url`` is provided, the URL is validated upfront (scheme + host)
+    against the active tier — this is the right entry point for code
+    that's about to issue a request and wants both the URL pre-flight
+    and the IP-level guard in one call.
+
+    The IP-level check runs automatically via the
+    ``create_connection`` wrapper for every TCP connect made inside
+    the context — initial request, redirected request, retry — so
+    callers do not need to subclass ``requests.Session`` to handle
+    cross-host redirects safely.
+
+    Args:
+        url: optional URL whose scheme + host should be validated
+            upfront against the active tier.
+        strict_ip_policy: when True, reject every non-public IP under
+            this context (used by the download tier).
+        https_only: when True, reject anything other than HTTPS under
+            this context (used by the download tier).
+
+    Raises:
+        HttpClientError: ``url`` (when given) fails the scheme/host
+            check, or any TCP connect made inside the context targets
+            a blocked address.
+    """
+    if url is not None:
+        _assert_safe_url_scheme_and_host(url, https_only=https_only)
+    _policy.active = True
+    _policy.strict_ip_policy = strict_ip_policy
+    _policy.https_only = https_only
+    try:
+        yield
+    finally:
+        _policy.active = False
+
+
+def safe_request(method: str, url: str, **kwargs: Any) -> requests.Response:
+    """Validate ``url`` and issue the request with SSRF guards active.
+
+    Drop-in for ``requests.request(method, url, **kwargs)`` — same
+    signature and same return type. Uses the default (permissive)
+    policy tier — RFC1918 allowed. For the strict download tier,
+    wrap a direct ``requests.get`` / ``requests.head`` call in
+    ``safety_policy(url, strict_ip_policy=True, https_only=True)``.
+
+    Redirects are followed safely: every hop goes through
+    ``create_connection``, every hop is validated against the same
+    policy as the initial URL.
+
+    Raises:
+        HttpClientError: URL or any resolved/redirect address rejected
+            by the active policy.
+    """
+    with safety_policy(url):
+        return requests.request(method, url, **kwargs)

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -194,6 +194,69 @@ def _ip_is_rejected(ip: _Address, *, strict_ip_policy: bool) -> bool:
     return False
 
 
+def assert_safe_destination(
+    host: str,
+    port: int,
+    *,
+    strict_ip_policy: bool = False,
+) -> None:
+    """Validate that ``(host, port)`` is a safe destination under the
+    active block list, without opening any connection.
+
+    Used by callers that issue raw socket / telnet probes (i.e. anything
+    not going through ``requests`` / ``urllib3``). The URL-layer
+    pre-flight does not apply (no scheme) — this helper only checks
+    host validity + IP block list. Hostnames are resolved via
+    ``getaddrinfo`` and the whole hostname is rejected if any A/AAAA
+    record is blocked (no fallback connect to defer to here, unlike
+    the ``create_connection`` wrapper).
+
+    Args:
+        host: destination hostname or IP literal. Empty / ``"localhost"``
+            are rejected with a clearer message than the IP-block would
+            produce.
+        port: destination port (passed to ``getaddrinfo`` for hostname
+            resolution; not otherwise inspected).
+        strict_ip_policy: when True, reject every non-public IP (RFC1918,
+            link-local, loopback, multicast, reserved, unspecified).
+            Default False — only the explicit block list applies.
+
+    Raises:
+        HttpClientError: empty/localhost host, blocked IP literal, or
+            blocked IP in the resolved record set.
+    """
+    if not host:
+        raise HttpClientError("destination refuses '<empty>' host")
+    host_lower = host.lower()
+    if host_lower == "localhost":
+        raise HttpClientError("destination refuses 'localhost' host")
+
+    try:
+        literal = ipaddress.ip_address(host_lower.strip("[]"))
+    except ValueError:
+        literal = None
+    if literal is not None:
+        if _ip_is_rejected(literal, strict_ip_policy=strict_ip_policy):
+            raise HttpClientError(f"destination refuses blocked address: {literal}")
+        return
+
+    try:
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise HttpClientError(f"DNS resolution failed: {exc}") from None
+
+    for info in infos:
+        ip_str = str(info[4][0])
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _ip_is_rejected(ip, strict_ip_policy=strict_ip_policy):
+            raise HttpClientError(
+                f"destination refuses blocked address resolved from hostname: {ip}"
+            )
+
+
 def _assert_safe_url_scheme_and_host(url: str, *, https_only: bool) -> None:
     """URL-layer pre-flight: scheme + host sanity.
 

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -95,6 +95,12 @@ class HttpClientError(Exception):
 _ENV_EXTRA_BLOCKED_CIDRS = "MCD_HTTP_BLOCKED_CIDRS"
 _ENV_REQUIRE_HTTPS = "MCD_HTTP_REQUIRE_HTTPS"
 
+# Sentinel for idempotency guard on the create_connection wrapper. Using a
+# private object() instance prevents any external code from accidentally
+# setting an attribute of the same name with a truthy value — which would
+# cause a silent SSRF regression by skipping the install.
+_MC_SSRF_GUARD_SENTINEL = object()
+
 _DEFAULT_BLOCKED_CIDRS: Tuple[str, ...] = (
     "169.254.0.0/16",
     "fe80::/10",
@@ -133,10 +139,12 @@ def _load_extra_blocked_networks() -> List[_Network]:
 
 def _load_bool_env(name: str, *, default: bool) -> bool:
     raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
     if raw in ("true", "1", "yes", "on"):
         return True
-    if raw in ("false", "0", "no", "off", ""):
-        return default if raw == "" else False
+    if raw in ("false", "0", "no", "off"):
+        return False
     _logger.warning(
         "url_safety: ignoring invalid value for %s: '%s' — using default %s",
         name,
@@ -291,13 +299,24 @@ def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any)
     raise OSError("getaddrinfo returned no usable address")
 
 
-_safe_create_connection._mc_ssrf_guard = True  # marker for idempotency check
+_safe_create_connection._mc_ssrf_guard = (
+    _MC_SSRF_GUARD_SENTINEL  # marker for idempotency check
+)
 
-if not getattr(_urllib3_connection.create_connection, "_mc_ssrf_guard", False):
+if (
+    getattr(_urllib3_connection.create_connection, "_mc_ssrf_guard", None)
+    is not _MC_SSRF_GUARD_SENTINEL
+):
     _urllib3_connection.create_connection = _safe_create_connection
 # else: module already imported (possibly via a different import path);
 # don't re-wrap. _original_create_connection retains the value from
 # the first import.
+#
+# Note: under ``importlib.reload(...)``, the captured
+# ``_original_create_connection`` would point at the already-installed
+# wrapper. The marker check correctly short-circuits installation in that
+# case, but ``reload`` is not a supported recovery path — restart the
+# process.
 
 
 @contextmanager
@@ -351,13 +370,13 @@ def safety_policy(
             check, or any TCP connect made inside the context targets
             a blocked address.
     """
-    if url is not None:
-        _assert_safe_url_scheme_and_host(url, https_only=https_only)
     prev_active = getattr(_policy, "active", False)
     prev_strict = getattr(_policy, "strict_ip_policy", False)
     _policy.active = True
     _policy.strict_ip_policy = strict_ip_policy
     try:
+        if url is not None:
+            _assert_safe_url_scheme_and_host(url, https_only=https_only)
         yield
     finally:
         _policy.active = prev_active

--- a/apollo/integrations/http/url_safety.py
+++ b/apollo/integrations/http/url_safety.py
@@ -1,11 +1,15 @@
-"""SSRF defense for the agent's HTTP integrations.
+"""SSRF defense for the agent's HTTP integrations and raw-socket callers.
 
 The guard is enforced inside urllib3's TCP-connect path, gated by a
 per-thread policy that the caller activates around the request via
 ``safety_policy``. Because urllib3 calls ``create_connection`` for every
 connection it opens — initial request, redirected request, retry — a
 single wrapper on that function covers every hop without any special
-``requests.Session`` plumbing.
+``requests.Session`` plumbing. The module also exposes
+``assert_safe_destination`` for non-HTTP raw-socket / telnet callers
+(the network troubleshooting validators in ``apollo/validators/``) that
+manage their own TCP layer and need the same block-list enforcement
+without going through ``requests``.
 
 Two policy tiers share one implementation:
 
@@ -30,6 +34,7 @@ addresses the agent never has a legitimate reason to reach:
   - fe80::/10       IPv6 link-local
   - 127.0.0.0/8     IPv4 loopback
   - ::1/128         IPv6 loopback
+  - fd00:ec2::/64   AWS IMDSv2 IPv6 endpoint (fd00:ec2::254)
 
 Operators can extend the default block list via the
 ``MCD_HTTP_BLOCKED_CIDRS`` env var: a comma-separated list of CIDRs
@@ -77,6 +82,11 @@ class HttpClientError(Exception):
     """Raised when a request URL or its resolved IP fails the SSRF
     safety check.
 
+    Despite the HTTP-flavored name (retained for backwards compatibility),
+    this is the generic "destination blocked by SSRF guard" exception for
+    this module — it is also raised by ``assert_safe_destination`` for
+    non-HTTP raw-socket / telnet callers that share the same block list.
+
     Defined here (rather than in ``http_proxy_client``) so that
     ``url_safety`` has no upward dependency on the client module.
     ``http_proxy_client`` re-exports it under the same name to
@@ -102,10 +112,11 @@ _ENV_REQUIRE_HTTPS = "MCD_HTTP_REQUIRE_HTTPS"
 _MC_SSRF_GUARD_SENTINEL = object()
 
 _DEFAULT_BLOCKED_CIDRS: Tuple[str, ...] = (
-    "169.254.0.0/16",
-    "fe80::/10",
-    "127.0.0.0/8",
-    "::1/128",
+    "169.254.0.0/16",  # IPv4 link-local (AWS / GCP / Azure / Oracle / etc. metadata)
+    "fe80::/10",  # IPv6 link-local
+    "127.0.0.0/8",  # IPv4 loopback
+    "::1/128",  # IPv6 loopback
+    "fd00:ec2::/64",  # AWS IMDSv2 IPv6 endpoint (fd00:ec2::254)
 )
 
 _Network = Union[ipaddress.IPv4Network, ipaddress.IPv6Network]
@@ -199,17 +210,16 @@ def assert_safe_destination(
     port: int,
     *,
     strict_ip_policy: bool = False,
-) -> None:
+) -> str:
     """Validate that ``(host, port)`` is a safe destination under the
-    active block list, without opening any connection.
+    active block list and return the IP literal callers should connect to.
 
-    Used by callers that issue raw socket / telnet probes (i.e. anything
-    not going through ``requests`` / ``urllib3``). The URL-layer
-    pre-flight does not apply (no scheme) — this helper only checks
-    host validity + IP block list. Hostnames are resolved via
-    ``getaddrinfo`` and the whole hostname is rejected if any A/AAAA
-    record is blocked (no fallback connect to defer to here, unlike
-    the ``create_connection`` wrapper).
+    Used by callers that own their own socket / telnet layer (the
+    ``ValidateNetwork`` troubleshooting validators). Callers MUST connect
+    to the returned IP (not the original hostname) — connecting to the
+    hostname re-triggers DNS resolution and exposes a rebinding TOCTOU
+    where an attacker can return a safe IP for the validation lookup
+    and a blocked IP for the connect.
 
     Args:
         host: destination hostname or IP literal. Empty / ``"localhost"``
@@ -221,30 +231,52 @@ def assert_safe_destination(
             link-local, loopback, multicast, reserved, unspecified).
             Default False — only the explicit block list applies.
 
+    Returns:
+        The validated IP literal as a string. For IP-literal inputs this
+        is the input itself (normalized via ``ipaddress.ip_address``). For
+        hostnames, this is the first non-rejected address from
+        ``getaddrinfo`` in OS-preference order.
+
     Raises:
-        HttpClientError: empty/localhost host, blocked IP literal, or
-            blocked IP in the resolved record set.
+        HttpClientError: empty/localhost host, blocked IP literal, blocked
+            IP in the resolved record set, or DNS resolution failure.
+
+    See also:
+        ``_safe_create_connection`` — the connection-time sibling that
+        applies the same block list inside urllib3's TCP-connect path.
+        These two functions share ``_ip_is_rejected``, so any change to
+        the block list applies uniformly — but the policy structure
+        (e.g. adding a new early-exit check) must be kept in sync
+        manually.
     """
     if not host:
         raise HttpClientError("destination refuses '<empty>' host")
     host_lower = host.lower()
-    if host_lower == "localhost":
+    # Normalize a trailing dot (valid FQDN form) so the fast-path catches
+    # both `localhost` and `localhost.` with the same clearer-message check.
+    if host_lower.rstrip(".") == "localhost":
         raise HttpClientError("destination refuses 'localhost' host")
 
+    # Strip IPv6 zone IDs (e.g. `fe80::1%eth0`) before parsing — `ip_address`
+    # raises ValueError on `%`. The DNS path would catch zone-IDed link-locals
+    # via the `fe80::/10` CIDR anyway, but normalizing here keeps the
+    # fast-path comment accurate.
+    literal_candidate = host_lower.strip("[]").split("%", 1)[0]
     try:
-        literal = ipaddress.ip_address(host_lower.strip("[]"))
+        literal = ipaddress.ip_address(literal_candidate)
     except ValueError:
         literal = None
     if literal is not None:
         if _ip_is_rejected(literal, strict_ip_policy=strict_ip_policy):
             raise HttpClientError(f"destination refuses blocked address: {literal}")
-        return
+        return str(literal)
 
     try:
         infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
     except socket.gaierror as exc:
         raise HttpClientError(f"DNS resolution failed: {exc}") from None
 
+    validated_ip: Union[str, None] = None
     for info in infos:
         ip_str = str(info[4][0])
         try:
@@ -255,6 +287,12 @@ def assert_safe_destination(
             raise HttpClientError(
                 f"destination refuses blocked address resolved from hostname: {ip}"
             )
+        if validated_ip is None:
+            validated_ip = ip_str
+
+    if validated_ip is None:
+        raise HttpClientError("DNS resolution returned no usable address")
+    return validated_ip
 
 
 def _assert_safe_url_scheme_and_host(url: str, *, https_only: bool) -> None:
@@ -306,6 +344,10 @@ _policy = threading.local()
 _original_create_connection = _urllib3_connection.create_connection
 
 
+# See `assert_safe_destination` for the no-connection sibling used by raw
+# socket / telnet callers — both share `_ip_is_rejected`, so block-list
+# changes propagate uniformly, but the check-sequence structure must be
+# kept in sync manually.
 def _safe_create_connection(address: Tuple[str, int], *args: Any, **kwargs: Any) -> Any:
     if not getattr(_policy, "active", False):
         return _original_create_connection(address, *args, **kwargs)

--- a/apollo/integrations/tableau/tableau_proxy_client.py
+++ b/apollo/integrations/tableau/tableau_proxy_client.py
@@ -9,11 +9,11 @@ from typing import (
 )
 
 import jwt
-import requests
 from tableauserverclient.models.tableau_auth import Credentials
 from tableauserverclient.server.server import Server
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.http.url_safety import safe_request
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ class TableauProxyClient(BaseProxyClient):
             url = f"{self._server.baseurl}{path}"
         else:
             url = f"{self._server.baseurl}/sites/{self._server.site_id}/{path}"
-        response = requests.request(
+        response = safe_request(
             method=request_method,
             url=url,
             data=data,

--- a/apollo/validators/validate_network.py
+++ b/apollo/validators/validate_network.py
@@ -2,10 +2,13 @@ import socket
 from telnetlib import Telnet
 from typing import Optional, Callable, Dict, Tuple, Union
 
-import requests
-
 from apollo.agent.utils import AgentUtils
 from apollo.common.interfaces.agent_response import AgentResponse
+from apollo.integrations.http.url_safety import (
+    HttpClientError,
+    assert_safe_destination,
+    safe_request,
+)
 
 _DEFAULT_TIMEOUT_SECS = 5
 _DEFAULT_HTTP_TIMEOUT_SECS = 10
@@ -156,6 +159,14 @@ class ValidateNetwork:
             host, port_str, timeout_str
         )
 
+        # SSRF guard: refuse to probe blocked destinations (cloud metadata
+        # services, loopback) — the troubleshooting endpoint should not
+        # be a reconnaissance vector even for Monte Carlo operators.
+        try:
+            assert_safe_destination(host, port)  # type: ignore[arg-type]
+        except HttpClientError as err:
+            raise ConnectionFailedError(str(err)) from err
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(timeout_in_seconds)
 
@@ -179,6 +190,12 @@ class ValidateNetwork:
             host, port_str, timeout_str
         )
         friendly_name = f"{host}:{port}"
+
+        # SSRF guard: see _internal_validate_tcp_open_connection for rationale.
+        try:
+            assert_safe_destination(host, port)  # type: ignore[arg-type]
+        except HttpClientError as err:
+            raise ConnectionFailedError(str(err)) from err
 
         try:
             with Telnet(host, port, timeout_in_seconds) as session:
@@ -240,8 +257,12 @@ class ValidateNetwork:
             int(timeout_str) if timeout_str else _DEFAULT_HTTP_TIMEOUT_SECS
         )
 
+        # Route through the SSRF guard so the troubleshooting endpoint can't
+        # be used to reach cloud metadata services or other blocked targets.
+        # safe_request applies the default policy tier (RFC1918 allowed for
+        # legitimate VPC troubleshooting; metadata/loopback blocked).
         try:
-            response = requests.get(url, timeout=timeout_in_seconds)
+            response = safe_request("GET", url, timeout=timeout_in_seconds)
             message = f"URL {url} responded with status: {response.status_code} ({response.reason})"
             if include_response:
                 content_str = response.content.decode("utf-8")

--- a/apollo/validators/validate_network.py
+++ b/apollo/validators/validate_network.py
@@ -159,18 +159,18 @@ class ValidateNetwork:
             host, port_str, timeout_str
         )
 
-        # SSRF guard: refuse to probe blocked destinations (cloud metadata
-        # services, loopback) — the troubleshooting endpoint should not
-        # be a reconnaissance vector even for Monte Carlo operators.
+        # SSRF guard: resolve and validate ONCE here, then connect by IP. Connecting
+        # to the original hostname would re-trigger DNS and expose a rebinding
+        # TOCTOU where the second lookup could return a blocked address.
         try:
-            assert_safe_destination(host, port)  # type: ignore[arg-type]
+            validated_ip = assert_safe_destination(host, port)  # type: ignore[arg-type]
         except HttpClientError as err:
             raise ConnectionFailedError(str(err)) from err
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(timeout_in_seconds)
 
-        if sock.connect_ex((host, port)) == 0:
+        if sock.connect_ex((validated_ip, port)) == 0:
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()
             return {
@@ -191,14 +191,38 @@ class ValidateNetwork:
         )
         friendly_name = f"{host}:{port}"
 
-        # SSRF guard: see _internal_validate_tcp_open_connection for rationale.
+        # SSRF guard: resolve and validate ONCE, then create the socket ourselves
+        # and hand it to Telnet. Telnet(host, port, ...) does its own internal
+        # socket.create_connection which re-resolves DNS and would expose a
+        # rebinding TOCTOU.
         try:
-            assert_safe_destination(host, port)  # type: ignore[arg-type]
+            validated_ip = assert_safe_destination(host, port)  # type: ignore[arg-type]
         except HttpClientError as err:
             raise ConnectionFailedError(str(err)) from err
 
         try:
-            with Telnet(host, port, timeout_in_seconds) as session:
+            sock = socket.create_connection(
+                (validated_ip, port), timeout=timeout_in_seconds
+            )
+        except socket.timeout as err:
+            raise ConnectionFailedError(
+                f"Socket timeout for {friendly_name}. Connection unusable."
+            ) from err
+        except socket.gaierror as err:
+            # validated_ip is an IP literal, so getaddrinfo on it shouldn't fail
+            # under normal conditions — but the original code caught gaierror, so
+            # keep the handler for parity.
+            raise ConnectionFailedError(
+                f"Invalid hostname {host} ({err}). Connection unusable."
+            ) from err
+
+        try:
+            session = Telnet()
+            session.sock = sock
+            # Telnet().host / .port are not in telnetlib's type stubs (they're
+            # set inside .open()), but read_very_eager() only uses .sock — so
+            # we just hand over the pre-created socket and skip the rest.
+            try:
                 try:
                     session.read_very_eager()
                     return {
@@ -208,14 +232,17 @@ class ValidateNetwork:
                     raise ConnectionFailedError(
                         f"Telnet connection for {friendly_name} is unusable."
                     ) from err
-        except socket.timeout as err:
-            raise ConnectionFailedError(
-                f"Socket timeout for {friendly_name}. Connection unusable."
-            ) from err
-        except socket.gaierror as err:
-            raise ConnectionFailedError(
-                f"Invalid hostname {host} ({err}). Connection unusable."
-            ) from err
+            finally:
+                session.close()
+        except ConnectionFailedError:
+            raise
+        except Exception:
+            # ensure socket is closed if Telnet setup itself fails
+            try:
+                sock.close()
+            except Exception:
+                pass
+            raise
 
     @classmethod
     def _internal_perform_dns_lookup(
@@ -263,15 +290,20 @@ class ValidateNetwork:
         # legitimate VPC troubleshooting; metadata/loopback blocked).
         try:
             response = safe_request("GET", url, timeout=timeout_in_seconds)
-            message = f"URL {url} responded with status: {response.status_code} ({response.reason})"
-            if include_response:
-                content_str = response.content.decode("utf-8")
-                message += f" and content: {content_str}"
-            return {"message": message}
+        except HttpClientError as err:
+            # SSRF guard rejected the URL — surface as ConnectionFailedError to
+            # match the TCP/Telnet sibling validators' error shape.
+            raise ConnectionFailedError(str(err)) from err
         except Exception as err:
             raise ConnectionFailedError(
                 f"HTTP request failed for {url}: {err}."
             ) from err
+
+        message = f"URL {url} responded with status: {response.status_code} ({response.reason})"
+        if include_response:
+            content_str = response.content.decode("utf-8")
+            message += f" and content: {content_str}"
+        return {"message": message}
 
     @staticmethod
     def _internal_validate_network_parameters(

--- a/tests/test_health_network.py
+++ b/tests/test_health_network.py
@@ -82,17 +82,21 @@ class HealthNetworkTests(TestCase):
             response.result.get(ATTRIBUTE_NAME_ERROR),
         )
 
+    # Tests use a public IP literal so assert_safe_destination short-circuits
+    # without hitting DNS. `localhost` is now rejected by the SSRF guard —
+    # covered by dedicated regression tests further down.
+
     @patch("socket.socket")
     def test_tcp_open_success(self, mock_socket):
         mock_socket = mock_socket.return_value
         mock_socket.connect_ex.return_value = 0
         response = self._agent.validate_tcp_open_connection(
-            "localhost", "123", None, trace_id="1234"
+            "93.184.216.34", "123", None, trace_id="1234"
         )
         self.assertEqual("1234", response.result.get(ATTRIBUTE_NAME_TRACE_ID))
         self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
         self.assertEqual(
-            "Port 123 is open on localhost",
+            "Port 123 is open on 93.184.216.34",
             response.result.get(ATTRIBUTE_NAME_RESULT).get("message"),
         )
 
@@ -100,18 +104,20 @@ class HealthNetworkTests(TestCase):
     def test_tcp_open_failure(self, mock_socket):
         mock_socket = mock_socket.return_value
         mock_socket.connect_ex.return_value = 1
-        response = self._agent.validate_tcp_open_connection("localhost", "123", None)
+        response = self._agent.validate_tcp_open_connection(
+            "93.184.216.34", "123", None
+        )
         self.assertEqual(
-            "Port 123 is closed on localhost.",
+            "Port 123 is closed on 93.184.216.34.",
             response.result.get(ATTRIBUTE_NAME_ERROR),
         )
 
     @patch("apollo.validators.validate_network.Telnet")
     def test_telnet_success(self, mock_telnet):
-        response = self._agent.validate_telnet_connection("localhost", "123", None)
+        response = self._agent.validate_telnet_connection("93.184.216.34", "123", None)
         self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
         self.assertEqual(
-            "Telnet connection for localhost:123 is usable.",
+            "Telnet connection for 93.184.216.34:123 is usable.",
             response.result.get(ATTRIBUTE_NAME_RESULT).get("message"),
         )
 
@@ -119,10 +125,10 @@ class HealthNetworkTests(TestCase):
     def test_telnet_timeout(self, mock_telnet):
         mock_telnet.side_effect = socket.timeout
 
-        response = self._agent.validate_telnet_connection("localhost", "123", "11")
-        mock_telnet.assert_called_with("localhost", 123, 11)
+        response = self._agent.validate_telnet_connection("93.184.216.34", "123", "11")
+        mock_telnet.assert_called_with("93.184.216.34", 123, 11)
         self.assertEqual(
-            "Socket timeout for localhost:123. Connection unusable.",
+            "Socket timeout for 93.184.216.34:123. Connection unusable.",
             response.result.get(ATTRIBUTE_NAME_ERROR),
         )
 
@@ -132,11 +138,50 @@ class HealthNetworkTests(TestCase):
         mock_telnet.return_value.__enter__.return_value = mock_session
         mock_session.read_very_eager.side_effect = EOFError
 
-        response = self._agent.validate_telnet_connection("localhost", "123", None)
-        mock_telnet.assert_called_with("localhost", 123, _DEFAULT_TIMEOUT_SECS)
+        response = self._agent.validate_telnet_connection("93.184.216.34", "123", None)
+        mock_telnet.assert_called_with("93.184.216.34", 123, _DEFAULT_TIMEOUT_SECS)
         self.assertEqual(
-            "Telnet connection for localhost:123 is unusable.",
+            "Telnet connection for 93.184.216.34:123 is unusable.",
             response.result.get(ATTRIBUTE_NAME_ERROR),
+        )
+
+    # --- SSRF guard regression tests --------------------------------------
+
+    def test_tcp_open_rejects_metadata_ip(self):
+        """The SSRF guard refuses to probe cloud metadata services even via
+        the troubleshooting endpoint."""
+        response = self._agent.validate_tcp_open_connection(
+            "169.254.169.254", "80", None
+        )
+        self.assertIn(
+            "blocked address",
+            response.result.get(ATTRIBUTE_NAME_ERROR) or "",
+        )
+
+    def test_tcp_open_rejects_localhost(self):
+        response = self._agent.validate_tcp_open_connection("localhost", "80", None)
+        self.assertIn(
+            "localhost",
+            response.result.get(ATTRIBUTE_NAME_ERROR) or "",
+        )
+
+    def test_telnet_rejects_metadata_ip(self):
+        response = self._agent.validate_telnet_connection("169.254.169.254", "80", None)
+        self.assertIn(
+            "blocked address",
+            response.result.get(ATTRIBUTE_NAME_ERROR) or "",
+        )
+
+    def test_http_rejects_metadata_ip(self):
+        """The HTTP troubleshooting endpoint must not be a way to fetch
+        IMDS credentials. The SSRF guard fires at the TCP layer and the
+        error is surfaced as a ConnectionFailedError."""
+        response = self._agent.validate_http_connection(
+            "http://169.254.169.254/latest/meta-data/", "true", None, trace_id=None
+        )
+        self.assertIn(
+            "blocked address",
+            response.result.get(ATTRIBUTE_NAME_ERROR) or "",
         )
 
     @patch("apollo.validators.validate_network.socket.getaddrinfo")
@@ -152,13 +197,13 @@ class HealthNetworkTests(TestCase):
             response.result.get(ATTRIBUTE_NAME_RESULT).get("message"),
         )
 
-    @patch("requests.get")
-    def test_http_connection(self, get_mock):
+    @patch("apollo.validators.validate_network.safe_request")
+    def test_http_connection(self, safe_request_mock):
         response_mock = Mock()
         response_mock.status_code = 200
         response_mock.reason = "OK"
         response_mock.content = b"foo"
-        get_mock.return_value = response_mock
+        safe_request_mock.return_value = response_mock
         response = self._agent.validate_http_connection(
             "https://foo.bar", "true", None, trace_id=None
         )

--- a/tests/test_health_network.py
+++ b/tests/test_health_network.py
@@ -113,8 +113,16 @@ class HealthNetworkTests(TestCase):
         )
 
     @patch("apollo.validators.validate_network.Telnet")
-    def test_telnet_success(self, mock_telnet):
+    @patch("apollo.validators.validate_network.socket.create_connection")
+    def test_telnet_success(self, mock_create_conn, mock_telnet):
+        mock_sock = mock_create_conn.return_value
+        mock_telnet_inst = mock_telnet.return_value
+        mock_telnet_inst.read_very_eager.return_value = None
+
         response = self._agent.validate_telnet_connection("93.184.216.34", "123", None)
+
+        mock_telnet.assert_called_once_with()
+        self.assertIs(mock_telnet_inst.sock, mock_sock)
         self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
         self.assertEqual(
             "Telnet connection for 93.184.216.34:123 is usable.",
@@ -122,28 +130,82 @@ class HealthNetworkTests(TestCase):
         )
 
     @patch("apollo.validators.validate_network.Telnet")
-    def test_telnet_timeout(self, mock_telnet):
-        mock_telnet.side_effect = socket.timeout
+    @patch("apollo.validators.validate_network.socket.create_connection")
+    def test_telnet_timeout(self, mock_create_conn, mock_telnet):
+        mock_create_conn.side_effect = socket.timeout
 
         response = self._agent.validate_telnet_connection("93.184.216.34", "123", "11")
-        mock_telnet.assert_called_with("93.184.216.34", 123, 11)
+        mock_telnet.assert_not_called()
         self.assertEqual(
             "Socket timeout for 93.184.216.34:123. Connection unusable.",
             response.result.get(ATTRIBUTE_NAME_ERROR),
         )
 
     @patch("apollo.validators.validate_network.Telnet")
-    def test_telnet_read_failed(self, mock_telnet):
-        mock_session = create_autospec(Telnet)
-        mock_telnet.return_value.__enter__.return_value = mock_session
-        mock_session.read_very_eager.side_effect = EOFError
+    @patch("apollo.validators.validate_network.socket.create_connection")
+    def test_telnet_read_failed(self, mock_create_conn, mock_telnet):
+        mock_telnet_inst = mock_telnet.return_value
+        mock_telnet_inst.read_very_eager.side_effect = EOFError
 
         response = self._agent.validate_telnet_connection("93.184.216.34", "123", None)
-        mock_telnet.assert_called_with("93.184.216.34", 123, _DEFAULT_TIMEOUT_SECS)
+        mock_telnet.assert_called_once_with()
         self.assertEqual(
             "Telnet connection for 93.184.216.34:123 is unusable.",
             response.result.get(ATTRIBUTE_NAME_ERROR),
         )
+
+    # --- TOCTOU regression tests ------------------------------------------
+
+    @patch("apollo.validators.validate_network.socket.socket")
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_tcp_open_resolves_once_no_toctou(self, mock_gai, mock_socket_cls):
+        """Regression: TCP validator must resolve DNS once (via assert_safe_destination)
+        and connect by IP, not re-resolve. Mock getaddrinfo to return a public IP;
+        assert connect_ex was called with that IP, not with the hostname."""
+        mock_gai.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 80)),
+        ]
+        mock_sock = mock_socket_cls.return_value
+        mock_sock.connect_ex.return_value = 0
+
+        response = self._agent.validate_tcp_open_connection(
+            "example.com", "80", None, trace_id=None
+        )
+
+        # getaddrinfo called once (by assert_safe_destination); connect_ex called
+        # with the resolved IP literal, not the hostname.
+        self.assertEqual(mock_gai.call_count, 1)
+        mock_sock.connect_ex.assert_called_once_with(("93.184.216.34", 80))
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
+
+    @patch("apollo.validators.validate_network.Telnet")
+    @patch("apollo.validators.validate_network.socket.create_connection")
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_telnet_resolves_once_no_toctou(
+        self, mock_gai, mock_create_conn, mock_telnet
+    ):
+        """Regression: Telnet validator must resolve DNS once (via assert_safe_destination)
+        and connect by IP via socket.create_connection. Mock getaddrinfo to return a
+        public IP; assert socket.create_connection was called with that IP."""
+        mock_gai.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", 23)),
+        ]
+        mock_sock = mock_create_conn.return_value
+        mock_telnet_inst = mock_telnet.return_value
+        mock_telnet_inst.read_very_eager.return_value = None
+
+        response = self._agent.validate_telnet_connection(
+            "example.com", "23", None, trace_id=None
+        )
+
+        self.assertEqual(mock_gai.call_count, 1)
+        mock_create_conn.assert_called_once_with(
+            ("93.184.216.34", 23), timeout=_DEFAULT_TIMEOUT_SECS
+        )
+        # Telnet() called with no args; .sock set to the mock socket.
+        mock_telnet.assert_called_once_with()
+        self.assertIs(mock_telnet_inst.sock, mock_sock)
+        self.assertIsNone(response.result.get(ATTRIBUTE_NAME_ERROR))
 
     # --- SSRF guard regression tests --------------------------------------
 
@@ -169,6 +231,14 @@ class HealthNetworkTests(TestCase):
         response = self._agent.validate_telnet_connection("169.254.169.254", "80", None)
         self.assertIn(
             "blocked address",
+            response.result.get(ATTRIBUTE_NAME_ERROR) or "",
+        )
+
+    def test_telnet_rejects_localhost(self):
+        """F4: SSRF guard symmetry — Telnet mirrors TCP's localhost rejection."""
+        response = self._agent.validate_telnet_connection("localhost", "80", None)
+        self.assertIn(
+            "localhost",
             response.result.get(ATTRIBUTE_NAME_ERROR) or "",
         )
 

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -486,7 +486,7 @@ class TestHttpClientSsrfGuard(TestCase):
             )
 
     @patch("requests.request")
-    def test_do_request_with_rfc1918_url_is_allowed(self, mock_request):
+    def test_do_request_rfc1918_passes_default_tier(self, mock_request):
         """T-F4 (companion): RFC1918 addresses are intentionally allowed by the
         default policy tier so the agent can reach databases and services in
         the customer's VPC/VNet. do_request must succeed and delegate to

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -669,9 +669,11 @@ class TestDownloadBytes(TestCase):
 
 
 class TestDownloadBytesUrlSafety(TestCase):
-    """SSRF defense-in-depth: verify _assert_safe_download_url rejects every
-    non-public IP-literal class (not just RFC1918 / loopback / link-local) and
-    that download_bytes itself refuses to follow redirects."""
+    """SSRF defense-in-depth: verify the strict-tier guard (applied via
+    ``safety_policy(url, strict_ip_policy=True, https_only=True)`` in
+    ``_open_download_response``) rejects every non-public IP-literal class
+    (not just RFC1918 / loopback / link-local) and that download_bytes
+    itself refuses to follow redirects."""
 
     def _make_response(
         self,
@@ -700,41 +702,41 @@ class TestDownloadBytesUrlSafety(TestCase):
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://0.0.0.0/file")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     def test_rejects_unspecified_ipv6(self):
         # IPv6 :: — not private/loopback/link-local, but not global either.
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://[::]/file")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     def test_rejects_multicast_ipv4(self):
         # 224.0.0.0/4 is multicast — is_global is False.
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://224.0.0.1/file")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     def test_rejects_reserved_ipv4(self):
         # 240.0.0.0/4 is reserved — is_global is False.
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://240.0.0.1/file")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     def test_rejects_imds_link_local(self):
         # 169.254.169.254 — AWS IMDS, the canonical SSRF target.
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://169.254.169.254/latest/meta-data/")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     def test_rejects_rfc1918(self):
         client = HttpProxyClient(credentials={"connect_args": {}})
         with self.assertRaises(HttpClientError) as ctx:
             client.download_bytes("https://10.0.0.1/file")
-        self.assertIn("non-public", str(ctx.exception))
+        self.assertIn("blocked address", str(ctx.exception))
 
     @patch("requests.get")
     def test_dns_hostname_passes_url_safety_check(self, mock_get):

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -467,6 +467,45 @@ class TestHttpClient(TestCase):
         )
 
 
+class TestHttpClientSsrfGuard(TestCase):
+    """T-F4: Verify the do_request → safe_request → safety_policy chain
+    rejects SSRF-dangerous URLs. IP rejection happens at the urllib3
+    create_connection hook (not the URL pre-flight), so this test must NOT
+    mock requests.request — it lets the call flow through to urllib3 where
+    the hook short-circuits with HttpClientError before any TCP attempt."""
+
+    def test_do_request_rejects_metadata_ip_literal(self):
+        """T-F4: Calling do_request with the AWS IMDS URL must raise
+        HttpClientError. The urllib3 create_connection hook fires before any
+        real TCP connect, so no network access is needed for this test."""
+        client = HttpProxyClient(credentials={})
+        with self.assertRaises(HttpClientError):
+            client.do_request(
+                url="http://169.254.169.254/latest/meta-data/",
+                http_method="GET",
+            )
+
+    @patch("requests.request")
+    def test_do_request_with_rfc1918_url_is_allowed(self, mock_request):
+        """T-F4 (companion): RFC1918 addresses are intentionally allowed by the
+        default policy tier so the agent can reach databases and services in
+        the customer's VPC/VNet. do_request must succeed and delegate to
+        requests.request."""
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"ok": True}
+        mock_request.return_value = mock_resp
+
+        client = HttpProxyClient(credentials={})
+        result = client.do_request(
+            url="http://10.0.0.20/api",
+            http_method="GET",
+        )
+
+        mock_request.assert_called_once()
+        self.assertEqual({"ok": True}, result)
+
+
 class TestDownloadBytes(TestCase):
     """Tests for HttpProxyClient.download_bytes — streaming binary fetches with
     optional auth-skip and size cap."""

--- a/tests/test_tableau_client.py
+++ b/tests/test_tableau_client.py
@@ -139,8 +139,8 @@ class TableauTests(TestCase):
         self.assertEqual((expected_result, 200), response)
         self._mock_client.auth.sign_in.assert_called_once_with(self._mock_creds)
         mock_request.assert_called_once_with(
-            method="GET",
-            url="https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
+            "GET",
+            "https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
             data=None,
             headers={
                 "X-Tableau-Auth": "fizz|buzz|sample_site_id",
@@ -199,8 +199,8 @@ class TableauTests(TestCase):
         self.assertEqual((expected_result, 200), response)
         self._mock_client.auth.sign_in.assert_called_once_with(self._mock_creds)
         mock_request.assert_called_once_with(
-            method="GET",
-            url="https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
+            "GET",
+            "https://example.com/sites/sample_site_id/views?includeUsageStatistics=true",
             data=None,
             headers={
                 "X-Tableau-Auth": "fizz|buzz|sample_site_id",

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -738,11 +738,11 @@ class TestAssertSafeDestination(TestCase):
             assert_safe_destination("10.0.0.5", 80, strict_ip_policy=True)
 
     def test_default_policy_allows_rfc1918(self):
-        # Returns None on success (no exception).
-        self.assertIsNone(assert_safe_destination("10.0.0.5", 80))
+        # Returns the validated IP string on success (no exception).
+        self.assertEqual(assert_safe_destination("10.0.0.5", 80), "10.0.0.5")
 
     def test_allows_public_ip_literal(self):
-        self.assertIsNone(assert_safe_destination("93.184.216.34", 80))
+        self.assertEqual(assert_safe_destination("93.184.216.34", 80), "93.184.216.34")
 
     @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
     def test_rejects_hostname_resolving_to_blocked_ip(self, mock_gai):
@@ -754,7 +754,7 @@ class TestAssertSafeDestination(TestCase):
     @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
     def test_allows_hostname_resolving_to_public_ip(self, mock_gai):
         mock_gai.return_value = [_addrinfo("93.184.216.34", port=80)]
-        self.assertIsNone(assert_safe_destination("example.com", 80))
+        self.assertEqual(assert_safe_destination("example.com", 80), "93.184.216.34")
 
     @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
     def test_wraps_dns_failure(self, mock_gai):
@@ -762,3 +762,37 @@ class TestAssertSafeDestination(TestCase):
         with self.assertRaises(HttpClientError) as ctx:
             assert_safe_destination("nonexistent.invalid", 80)
         self.assertIn("DNS resolution failed", str(ctx.exception))
+
+    def test_rejects_aws_imds_ipv6(self):
+        """F3: fd00:ec2::/64 (AWS IMDSv2 IPv6) is blocked."""
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("fd00:ec2::254", 80)
+        self.assertIn("blocked address", str(ctx.exception))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_rejects_hostname_resolving_to_aws_imds_ipv6(self, mock_gai):
+        """F3: hostname that resolves to the IMDSv2 IPv6 address is blocked."""
+        mock_gai.return_value = [
+            _addrinfo("fd00:ec2::254", port=80, family=socket.AF_INET6)
+        ]
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("imds.internal.example.com", 80)
+        self.assertIn("blocked address", str(ctx.exception))
+
+    def test_rejects_loopback_ipv6_bracketed(self):
+        """F9: bracket-stripped `[::1]` is caught as a blocked loopback address."""
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("[::1]", 80)
+
+    def test_rejects_localhost_trailing_dot(self):
+        """F6 regression: `localhost.` (trailing dot, valid FQDN) is caught by
+        the fast-path before DNS is attempted, same as plain `localhost`."""
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("localhost.", 80)
+        self.assertIn("localhost", str(ctx.exception))
+
+    def test_strips_ipv6_zone_id(self):
+        """F7 regression: `fe80::1%eth0` has its zone ID stripped then is
+        rejected by the fe80::/10 IP-literal fast-path — no DNS call needed."""
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("fe80::1%eth0", 80)

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -11,6 +11,7 @@ from apollo.integrations.http.url_safety import (
     HttpClientError,
     _policy,
     _safe_create_connection,
+    assert_safe_destination,
     safe_request,
     safety_policy,
 )
@@ -702,3 +703,62 @@ class TestLoadBoolEnv(TestCase):
                 result = url_safety._load_bool_env("MCD_TEST", default=False)
             self.assertFalse(result)
             self.assertTrue(any("invalid value" in msg for msg in cm.output))
+
+
+class TestAssertSafeDestination(TestCase):
+    """`assert_safe_destination(host, port)` is a no-connection variant of
+    the SSRF guard for callers that own their own socket / telnet layer
+    (the troubleshooting validators). It must reject empty / localhost,
+    blocked IP literals, and hostnames that resolve to a blocked IP."""
+
+    def test_rejects_empty_host(self):
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("", 80)
+
+    def test_rejects_localhost(self):
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("localhost", 80)
+        self.assertIn("localhost", str(ctx.exception))
+
+    def test_rejects_metadata_ip_literal(self):
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("169.254.169.254", 80)
+        self.assertIn("blocked address", str(ctx.exception))
+
+    def test_rejects_loopback_ipv4(self):
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("127.0.0.1", 80)
+
+    def test_rejects_loopback_ipv6(self):
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("::1", 80)
+
+    def test_strict_policy_rejects_rfc1918(self):
+        with self.assertRaises(HttpClientError):
+            assert_safe_destination("10.0.0.5", 80, strict_ip_policy=True)
+
+    def test_default_policy_allows_rfc1918(self):
+        # Returns None on success (no exception).
+        self.assertIsNone(assert_safe_destination("10.0.0.5", 80))
+
+    def test_allows_public_ip_literal(self):
+        self.assertIsNone(assert_safe_destination("93.184.216.34", 80))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_rejects_hostname_resolving_to_blocked_ip(self, mock_gai):
+        mock_gai.return_value = [_addrinfo("169.254.169.254", port=80)]
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("attacker.example.com", 80)
+        self.assertIn("blocked address resolved from hostname", str(ctx.exception))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_allows_hostname_resolving_to_public_ip(self, mock_gai):
+        mock_gai.return_value = [_addrinfo("93.184.216.34", port=80)]
+        self.assertIsNone(assert_safe_destination("example.com", 80))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_wraps_dns_failure(self, mock_gai):
+        mock_gai.side_effect = socket.gaierror("Name or service not known")
+        with self.assertRaises(HttpClientError) as ctx:
+            assert_safe_destination("nonexistent.invalid", 80)
+        self.assertIn("DNS resolution failed", str(ctx.exception))

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import ipaddress
+import os
 import socket
 import threading
 from unittest import TestCase
@@ -27,6 +28,7 @@ class TestSafeCreateConnection(TestCase):
     def tearDown(self):
         # Belt-and-suspenders: never leave the policy active across tests.
         _policy.active = False
+        _policy.strict_ip_policy = False
 
     def test_hook_is_installed(self):
         from urllib3.util import connection as urllib3_connection
@@ -271,31 +273,29 @@ class TestSafeCreateConnection(TestCase):
         worker_results: list = []
         worker_errors: list = []
 
-        def worker():
-            try:
-                # RFC1918 — would be blocked under strict_ip_policy on main
-                # thread but must be a passthrough on the worker (no policy).
-                with patch.object(
-                    url_safety,
-                    "_original_create_connection",
-                    return_value=sentinel_sock,
-                ) as called:
+        with patch.object(
+            url_safety,
+            "_original_create_connection",
+            return_value=sentinel_sock,
+        ) as called:
+
+            def worker_task():
+                try:
+                    # RFC1918 — would be blocked under strict_ip_policy on main
+                    # thread but must be a passthrough on the worker (no policy).
                     result = _safe_create_connection(("10.0.0.5", 443))
-                worker_results.append((result, called.call_count))
-            except Exception as exc:  # pragma: no cover
-                worker_errors.append(exc)
+                    worker_results.append(result)
+                except Exception as exc:  # pragma: no cover
+                    worker_errors.append(exc)
 
-        url = "https://93.184.216.34/"
-        with safety_policy(url, strict_ip_policy=True):
-            t = threading.Thread(target=worker)
-            t.start()
-            t.join()
-
-        self.assertEqual([], worker_errors, f"worker raised: {worker_errors}")
-        self.assertEqual(1, len(worker_results))
-        result, call_count = worker_results[0]
-        self.assertIs(sentinel_sock, result)
-        self.assertEqual(1, call_count)
+            with safety_policy("https://93.184.216.34/", strict_ip_policy=True):
+                t = threading.Thread(target=worker_task)
+                t.start()
+                t.join()
+            # Now we can inspect `called` — patch is still active in this with block
+            self.assertEqual([], worker_errors, f"worker raised: {worker_errors}")
+            self.assertEqual([sentinel_sock], worker_results)
+            self.assertEqual(called.call_count, 1)
 
     # --- T-F6: ThreadPoolExecutor does not propagate policy ---
 
@@ -310,21 +310,22 @@ class TestSafeCreateConnection(TestCase):
         called from a pool worker — confirming the policy was not inherited."""
         sentinel_sock = MagicMock(name="socket")
 
-        def worker_task():
-            # Under the main thread's strict policy this would raise. On the
-            # worker thread there is no policy — so it must be a passthrough.
-            with patch.object(
-                url_safety,
-                "_original_create_connection",
-                return_value=sentinel_sock,
-            ):
+        with patch.object(
+            url_safety,
+            "_original_create_connection",
+            return_value=sentinel_sock,
+        ):
+
+            def worker_task():
+                # Under the main thread's strict policy this would raise. On the
+                # worker thread there is no policy — so it must be a passthrough.
                 return _safe_create_connection(("10.0.0.5", 443))
 
-        url = "https://93.184.216.34/"
-        with safety_policy(url, strict_ip_policy=True):
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                future = pool.submit(worker_task)
-                result = future.result()  # raises if worker raised
+            url = "https://93.184.216.34/"
+            with safety_policy(url, strict_ip_policy=True):
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    future = pool.submit(worker_task)
+                    result = future.result()  # raises if worker raised
 
         self.assertIs(sentinel_sock, result)
 
@@ -492,6 +493,27 @@ class TestSafetyPolicyContext(TestCase):
                 "_policy.strict_ip_policy was False after inner context exited",
             )
 
+    def test_nested_inner_exception_restores_outer_state(self):
+        """The F1 fix's central guarantee: if an inner safety_policy
+        raises mid-body, the outer context's prev_active and
+        prev_strict are still restored on inner exit, and the outer
+        body continues with its own state intact."""
+        with safety_policy("https://93.184.216.34/", strict_ip_policy=False):
+            outer_active_before = _policy.active
+            outer_strict_before = _policy.strict_ip_policy
+            with self.assertRaises(RuntimeError):
+                with safety_policy("https://93.184.216.34/", strict_ip_policy=True):
+                    # inner is now active with strict=True
+                    self.assertTrue(_policy.active)
+                    self.assertTrue(_policy.strict_ip_policy)
+                    raise RuntimeError("boom")
+            # after inner exits via exception, outer state must be intact
+            self.assertEqual(_policy.active, outer_active_before)
+            self.assertEqual(_policy.strict_ip_policy, outer_strict_before)
+        # after outer exits, both back to baseline
+        self.assertFalse(getattr(_policy, "active", False))
+        self.assertFalse(getattr(_policy, "strict_ip_policy", False))
+
 
 class TestRedirectGuard(TestCase):
     """T-F3: The create_connection hook guards every hop — including redirected
@@ -507,6 +529,7 @@ class TestRedirectGuard(TestCase):
 
     def tearDown(self):
         _policy.active = False
+        _policy.strict_ip_policy = False
 
     @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
     def test_blocked_redirect_target_raises_on_connect(self, mock_gai):
@@ -568,6 +591,7 @@ class TestRequireHttpsEnvVar(TestCase):
 
     def tearDown(self):
         _policy.active = False
+        _policy.strict_ip_policy = False
 
     def test_default_tier_allows_http_when_env_var_false(self):
         """T-F14: When _REQUIRE_HTTPS_BY_DEFAULT is False (the default), the
@@ -630,3 +654,51 @@ class TestSafeRequest(TestCase):
         with self.assertRaises(RuntimeError):
             safe_request("GET", "https://93.184.216.34/")
         self.assertFalse(getattr(_policy, "active", False))
+
+
+class TestLoadBoolEnv(TestCase):
+    """Direct unit tests for the env-var → bool parser used by
+    _REQUIRE_HTTPS_BY_DEFAULT. The integration tests patch
+    _REQUIRE_HTTPS_BY_DEFAULT directly so this parsing logic was
+    previously untested."""
+
+    def test_truthy_aliases_return_true(self):
+        for value in ("true", "1", "yes", "on", "TRUE", "YeS", "  true  "):
+            with patch.dict(os.environ, {"MCD_TEST": value}):
+                self.assertTrue(
+                    url_safety._load_bool_env("MCD_TEST", default=False),
+                    f"expected True for {value!r}",
+                )
+
+    def test_falsy_aliases_return_false(self):
+        for value in ("false", "0", "no", "off", "FALSE", "Off"):
+            with patch.dict(os.environ, {"MCD_TEST": value}):
+                self.assertFalse(
+                    url_safety._load_bool_env("MCD_TEST", default=True),
+                    f"expected False for {value!r}",
+                )
+
+    def test_empty_string_returns_default(self):
+        with patch.dict(os.environ, {"MCD_TEST": ""}):
+            self.assertTrue(url_safety._load_bool_env("MCD_TEST", default=True))
+            self.assertFalse(url_safety._load_bool_env("MCD_TEST", default=False))
+
+    def test_whitespace_only_returns_default(self):
+        with patch.dict(os.environ, {"MCD_TEST": "   "}):
+            self.assertTrue(url_safety._load_bool_env("MCD_TEST", default=True))
+            self.assertFalse(url_safety._load_bool_env("MCD_TEST", default=False))
+
+    def test_missing_env_var_returns_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MCD_TEST", None)
+            self.assertTrue(url_safety._load_bool_env("MCD_TEST", default=True))
+            self.assertFalse(url_safety._load_bool_env("MCD_TEST", default=False))
+
+    def test_invalid_value_logs_warning_and_returns_default(self):
+        with patch.dict(os.environ, {"MCD_TEST": "maybe"}):
+            with self.assertLogs(
+                "apollo.integrations.http.url_safety", level="WARNING"
+            ) as cm:
+                result = url_safety._load_bool_env("MCD_TEST", default=False)
+            self.assertFalse(result)
+            self.assertTrue(any("invalid value" in msg for msg in cm.output))

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,5 +1,7 @@
+import concurrent.futures
 import ipaddress
 import socket
+import threading
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -230,6 +232,102 @@ class TestSafeCreateConnection(TestCase):
         self.assertEqual(first_args[0], ("93.184.216.34", 443))
         self.assertEqual(second_args[0], ("93.184.216.35", 443))
 
+    # --- T-F10: Cross-thread isolation ---
+
+    def test_policy_is_per_thread(self):
+        """T-F10: A policy active on the main thread must not be visible on a
+        worker thread. threading.local ensures each thread starts with no
+        policy."""
+        worker_observations = []
+        worker_error: list = []
+
+        def worker():
+            try:
+                active = getattr(_policy, "active", False)
+                worker_observations.append(active)
+            except Exception as exc:  # pragma: no cover
+                worker_error.append(exc)
+
+        url = "https://93.184.216.34/"
+        with safety_policy(url, strict_ip_policy=True):
+            self.assertTrue(_policy.active)
+            self.assertTrue(_policy.strict_ip_policy)
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+        # Main thread: policy deactivated after context exits.
+        self.assertFalse(_policy.active)
+        # Worker thread: never saw the main thread's policy.
+        self.assertEqual([], worker_error)
+        self.assertEqual([False], worker_observations)
+
+    def test_active_policy_on_one_thread_does_not_block_another(self):
+        """T-F10 (additional): When the main thread has strict_ip_policy active,
+        a worker thread that calls _safe_create_connection directly sees no
+        active policy (passthrough), so RFC1918 addresses are allowed on the
+        worker even though they'd be blocked on the main thread."""
+        sentinel_sock = MagicMock(name="socket")
+        worker_results: list = []
+        worker_errors: list = []
+
+        def worker():
+            try:
+                # RFC1918 — would be blocked under strict_ip_policy on main
+                # thread but must be a passthrough on the worker (no policy).
+                with patch.object(
+                    url_safety,
+                    "_original_create_connection",
+                    return_value=sentinel_sock,
+                ) as called:
+                    result = _safe_create_connection(("10.0.0.5", 443))
+                worker_results.append((result, called.call_count))
+            except Exception as exc:  # pragma: no cover
+                worker_errors.append(exc)
+
+        url = "https://93.184.216.34/"
+        with safety_policy(url, strict_ip_policy=True):
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+        self.assertEqual([], worker_errors, f"worker raised: {worker_errors}")
+        self.assertEqual(1, len(worker_results))
+        result, call_count = worker_results[0]
+        self.assertIs(sentinel_sock, result)
+        self.assertEqual(1, call_count)
+
+    # --- T-F6: ThreadPoolExecutor does not propagate policy ---
+
+    def test_threadpool_executor_does_not_propagate_policy(self):
+        """T-F6 / T-F10 (docs contract): A policy active on the submitting
+        thread does NOT propagate into a ThreadPoolExecutor worker. Callers
+        that fan out HTTP work to a thread pool MUST re-enter safety_policy on
+        the worker thread — the threading.local semantics make this explicit.
+
+        This test locks the contract by asserting that an RFC1918 address
+        (blocked under strict_ip_policy) does NOT raise HttpClientError when
+        called from a pool worker — confirming the policy was not inherited."""
+        sentinel_sock = MagicMock(name="socket")
+
+        def worker_task():
+            # Under the main thread's strict policy this would raise. On the
+            # worker thread there is no policy — so it must be a passthrough.
+            with patch.object(
+                url_safety,
+                "_original_create_connection",
+                return_value=sentinel_sock,
+            ):
+                return _safe_create_connection(("10.0.0.5", 443))
+
+        url = "https://93.184.216.34/"
+        with safety_policy(url, strict_ip_policy=True):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(worker_task)
+                result = future.result()  # raises if worker raised
+
+        self.assertIs(sentinel_sock, result)
+
 
 class TestExtraBlockedCidrs(TestCase):
     """``MCD_HTTP_BLOCKED_CIDRS`` env var feeds the ``_EXTRA_NETWORKS``
@@ -344,6 +442,161 @@ class TestSafetyPolicyContext(TestCase):
             self.assertTrue(_policy.active)
             self.assertTrue(_policy.strict_ip_policy)
         self.assertFalse(_policy.active)
+
+    # --- T-F1: Nested safety_policy save/restore ---
+
+    def test_nested_safety_policy_restores_strict_flag(self):
+        """T-F1: After an inner safety_policy (default tier) exits inside an
+        outer safety_policy (strict tier), the outer's strict_ip_policy flag
+        must be restored on the current thread."""
+        url = "https://93.184.216.34/"
+        with safety_policy(url, strict_ip_policy=True):
+            self.assertTrue(_policy.strict_ip_policy)
+            with safety_policy(url):  # inner: default tier (strict=False)
+                self.assertFalse(_policy.strict_ip_policy)
+            # Inner has exited — outer's strict flag must be back.
+            self.assertTrue(
+                _policy.strict_ip_policy,
+                "outer strict_ip_policy was not restored after inner context exited",
+            )
+
+    def test_nested_safety_policy_restores_active_flag(self):
+        """T-F1: After an inner safety_policy exits inside an outer
+        safety_policy, the outer's active flag must still be True."""
+        url = "https://93.184.216.34/"
+        with safety_policy(url):
+            self.assertTrue(_policy.active)
+            with safety_policy(url):
+                self.assertTrue(_policy.active)
+            # Inner exited — outer is still active.
+            self.assertTrue(
+                _policy.active,
+                "outer active flag was cleared when inner context exited",
+            )
+
+    def test_outer_safety_policy_stays_active_after_inner_exits(self):
+        """T-F1 (regression): Both active and strict_ip_policy are correctly
+        restored when a default-tier inner context exits inside a strict-tier
+        outer context."""
+        url = "https://93.184.216.34/"
+        with safety_policy(url, strict_ip_policy=True):
+            with safety_policy(url):  # inner: default tier
+                pass
+            # After inner exits, outer's full state must be intact.
+            self.assertTrue(
+                _policy.active,
+                "_policy.active was False after inner context exited",
+            )
+            self.assertTrue(
+                _policy.strict_ip_policy,
+                "_policy.strict_ip_policy was False after inner context exited",
+            )
+
+
+class TestRedirectGuard(TestCase):
+    """T-F3: The create_connection hook guards every hop — including redirected
+    connections — because it runs on every TCP connect, not just the first.
+
+    Since requests_mock is not a dependency, these tests exercise the hook
+    directly: call _safe_create_connection for an allowed host (simulating the
+    initial connect) then for a blocked host (simulating the redirect connect).
+    This is a direct proxy for the per-hop guarantee: if the hook runs on every
+    create_connection call, it will block the redirect's TCP connect the same
+    way it blocks the test's second direct call.
+    """
+
+    def tearDown(self):
+        _policy.active = False
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_blocked_redirect_target_raises_on_connect(self, mock_gai):
+        """T-F3: Simulates the initial connect succeeding (public IP) then the
+        redirect connect being blocked (metadata IP literal). The hook must
+        raise HttpClientError on the second call without ever delegating to
+        the original create_connection."""
+        url = "https://safe-source.example.com/"
+        with safety_policy(url):
+            # --- hop 1: initial request to a public host (hostname path) ---
+            mock_gai.return_value = [_addrinfo("93.184.216.34")]
+            sentinel = MagicMock(name="socket")
+            with patch.object(
+                url_safety, "_original_create_connection", return_value=sentinel
+            ) as called_first:
+                result = _safe_create_connection(("safe-source.example.com", 443))
+            self.assertIs(sentinel, result)
+            called_first.assert_called_once()
+
+            # --- hop 2: redirect to cloud metadata (IP literal path) ---
+            with patch.object(
+                url_safety, "_original_create_connection"
+            ) as called_second:
+                with self.assertRaises(HttpClientError) as ctx:
+                    _safe_create_connection(("169.254.169.254", 80))
+            self.assertIn("blocked address", str(ctx.exception))
+            called_second.assert_not_called()
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_safe_redirect_target_is_allowed(self, mock_gai):
+        """T-F3 (complement): A redirect to a safe public IP must succeed — the
+        guard must not over-block legitimate redirects."""
+        url = "https://safe-source.example.com/"
+        sentinel = MagicMock(name="socket")
+
+        with safety_policy(url):
+            # hop 1
+            mock_gai.return_value = [_addrinfo("93.184.216.34")]
+            with patch.object(
+                url_safety, "_original_create_connection", return_value=sentinel
+            ):
+                _safe_create_connection(("safe-source.example.com", 443))
+
+            # hop 2: redirect to another safe public host
+            mock_gai.return_value = [_addrinfo("93.184.216.35")]
+            with patch.object(
+                url_safety, "_original_create_connection", return_value=sentinel
+            ) as called:
+                result = _safe_create_connection(("safe-redirect.example.com", 443))
+            self.assertIs(sentinel, result)
+            called.assert_called_once()
+
+
+class TestRequireHttpsEnvVar(TestCase):
+    """T-F14: MCD_HTTP_REQUIRE_HTTPS env-var feeds _REQUIRE_HTTPS_BY_DEFAULT.
+    Tests use patch.object on the module attribute rather than reloading the
+    module (which would create new _policy / _safe_create_connection objects
+    and break other tests that hold references to the originals)."""
+
+    def tearDown(self):
+        _policy.active = False
+
+    def test_default_tier_allows_http_when_env_var_false(self):
+        """T-F14: When _REQUIRE_HTTPS_BY_DEFAULT is False (the default), the
+        default policy tier must accept HTTP URLs."""
+        with patch.object(url_safety, "_REQUIRE_HTTPS_BY_DEFAULT", False):
+            # Must not raise — HTTP is allowed in the default tier.
+            with safety_policy("http://93.184.216.34/"):
+                self.assertTrue(_policy.active)
+
+    def test_default_tier_rejects_http_when_env_var_true(self):
+        """T-F14: When _REQUIRE_HTTPS_BY_DEFAULT is True (operator opt-in),
+        the default policy tier must reject HTTP URLs the same way the strict
+        tier does."""
+        with patch.object(url_safety, "_REQUIRE_HTTPS_BY_DEFAULT", True):
+            with self.assertRaises(HttpClientError) as ctx:
+                with safety_policy("http://93.184.216.34/"):
+                    self.fail("body must not run when env-var HTTPS enforcement is on")
+        self.assertIn("scheme", str(ctx.exception))
+
+    def test_strict_tier_rejects_http_regardless_of_env_var(self):
+        """T-F14 (OR semantics): even with _REQUIRE_HTTPS_BY_DEFAULT=False, the
+        strict tier (https_only=True) still rejects HTTP — the env-var default
+        is OR'd into the explicit https_only flag, so both paths lead to
+        rejection."""
+        with patch.object(url_safety, "_REQUIRE_HTTPS_BY_DEFAULT", False):
+            with self.assertRaises(HttpClientError) as ctx:
+                with safety_policy("http://93.184.216.34/", https_only=True):
+                    self.fail("strict tier must reject HTTP regardless of env-var")
+        self.assertIn("scheme", str(ctx.exception))
 
 
 class TestSafeRequest(TestCase):

--- a/tests/test_url_safety.py
+++ b/tests/test_url_safety.py
@@ -1,0 +1,379 @@
+import ipaddress
+import socket
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from apollo.integrations.http import url_safety
+from apollo.integrations.http.url_safety import (
+    HttpClientError,
+    _policy,
+    _safe_create_connection,
+    safe_request,
+    safety_policy,
+)
+
+
+def _addrinfo(ip: str, *, port: int = 443, family: int = socket.AF_INET):
+    return (family, socket.SOCK_STREAM, 0, "", (ip, port))
+
+
+class TestSafeCreateConnection(TestCase):
+    """The urllib3 hook is the live enforcement point. Verify (a) it's
+    installed, (b) it passes through when no policy is active, and (c)
+    it enforces the active policy with multi-IP fallback."""
+
+    def tearDown(self):
+        # Belt-and-suspenders: never leave the policy active across tests.
+        _policy.active = False
+
+    def test_hook_is_installed(self):
+        from urllib3.util import connection as urllib3_connection
+
+        self.assertIs(urllib3_connection.create_connection, _safe_create_connection)
+
+    def test_passthrough_when_policy_inactive(self):
+        # Other urllib3 users (Snowflake driver etc.) must see the original
+        # function behavior when no policy is active.
+        _policy.active = False
+        original = url_safety._original_create_connection
+        with patch.object(
+            url_safety, "_original_create_connection", wraps=original
+        ) as wrapped:
+            try:
+                _safe_create_connection(("203.0.113.10", 443), timeout=1)
+            except OSError:
+                pass  # connect itself may fail; we only care it was attempted
+            wrapped.assert_called_once()
+            args, _ = wrapped.call_args
+            self.assertEqual(args[0], ("203.0.113.10", 443))
+
+    def test_active_default_policy_blocks_metadata_ip_literal(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError) as ctx:
+                _safe_create_connection(("169.254.169.254", 80), timeout=1)
+        self.assertIn("blocked address", str(ctx.exception))
+        called.assert_not_called()
+
+    def test_active_default_policy_blocks_loopback_ipv4(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("127.0.0.1", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_active_default_policy_blocks_loopback_ipv6(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("::1", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_active_default_policy_blocks_link_local_ipv6(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("fe80::1", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_active_default_policy_allows_rfc1918(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(
+            url_safety, "_original_create_connection", return_value="sock"
+        ) as called:
+            result = _safe_create_connection(("10.0.0.20", 443), timeout=1)
+        self.assertEqual(result, "sock")
+        called.assert_called_once()
+
+    def test_active_default_policy_allows_public(self):
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(
+            url_safety, "_original_create_connection", return_value="sock"
+        ) as called:
+            _safe_create_connection(("93.184.216.34", 443), timeout=1)
+        called.assert_called_once()
+
+    def test_strict_policy_blocks_rfc1918(self):
+        _policy.active = True
+        _policy.strict_ip_policy = True
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("10.0.0.5", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_strict_policy_blocks_multicast(self):
+        _policy.active = True
+        _policy.strict_ip_policy = True
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("224.0.0.1", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_strict_policy_blocks_unspecified(self):
+        _policy.active = True
+        _policy.strict_ip_policy = True
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("0.0.0.0", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_strict_policy_blocks_reserved(self):
+        _policy.active = True
+        _policy.strict_ip_policy = True
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("240.0.0.1", 443), timeout=1)
+        called.assert_not_called()
+
+    def test_strict_policy_allows_public(self):
+        _policy.active = True
+        _policy.strict_ip_policy = True
+        with patch.object(
+            url_safety, "_original_create_connection", return_value="sock"
+        ) as called:
+            _safe_create_connection(("93.184.216.34", 443), timeout=1)
+        called.assert_called_once()
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_blocks_hostname_resolving_to_metadata(self, mock_gai):
+        mock_gai.return_value = [_addrinfo("169.254.169.254")]
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_original_create_connection") as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("attacker.example.com", 443), timeout=1)
+        called.assert_not_called()
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_mixed_records_succeed_via_unblocked_first(self, mock_gai):
+        # Public address first, blocked address second. We connect to the
+        # public one and never even look at the blocked one — the security
+        # guarantee is "never connect to a blocked IP", not "reject
+        # hostnames that advertise any blocked IP".
+        mock_gai.return_value = [
+            _addrinfo("93.184.216.34"),
+            _addrinfo("169.254.169.254"),
+        ]
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        sentinel_sock = MagicMock(name="socket")
+        with patch.object(
+            url_safety, "_original_create_connection", return_value=sentinel_sock
+        ) as called:
+            result = _safe_create_connection(("mixed.example.com", 443), timeout=1)
+        self.assertIs(result, sentinel_sock)
+        called.assert_called_once()  # only the public IP was tried
+        args, _ = called.call_args
+        self.assertEqual(args[0], ("93.184.216.34", 443))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_blocked_record_after_failed_first_raises(self, mock_gai):
+        # First address is public but unreachable; second is blocked. We
+        # MUST raise HttpClientError rather than connect to the blocked
+        # address as a fallback.
+        mock_gai.return_value = [
+            _addrinfo("93.184.216.34"),
+            _addrinfo("169.254.169.254"),
+        ]
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(
+            url_safety,
+            "_original_create_connection",
+            side_effect=OSError("first unreachable"),
+        ) as called:
+            with self.assertRaises(HttpClientError):
+                _safe_create_connection(("hop.example.com", 443), timeout=1)
+        # Only the first (public, unreachable) connect was attempted; the
+        # blocked second IP triggered HttpClientError before any connect.
+        called.assert_called_once()
+        args, _ = called.call_args
+        self.assertEqual(args[0], ("93.184.216.34", 443))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_wraps_dns_failure(self, mock_gai):
+        mock_gai.side_effect = socket.gaierror("Name or service not known")
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with self.assertRaises(HttpClientError) as ctx:
+            _safe_create_connection(("nonexistent.invalid", 443), timeout=1)
+        self.assertIn("DNS resolution failed", str(ctx.exception))
+
+    @patch("apollo.integrations.http.url_safety.socket.getaddrinfo")
+    def test_iterates_validated_ips_on_failure(self, mock_gai):
+        # Multi-IP fallback: if the first connect fails (OSError), the hook
+        # falls back to the next validated address, mirroring urllib3's
+        # original behavior.
+        mock_gai.return_value = [
+            _addrinfo("93.184.216.34"),
+            _addrinfo("93.184.216.35"),
+        ]
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        sentinel_sock = MagicMock(name="socket")
+        with patch.object(
+            url_safety,
+            "_original_create_connection",
+            side_effect=[OSError("first try fails"), sentinel_sock],
+        ) as called:
+            result = _safe_create_connection(("example.com", 443), timeout=1)
+        self.assertIs(result, sentinel_sock)
+        self.assertEqual(called.call_count, 2)
+        first_args, _ = called.call_args_list[0]
+        second_args, _ = called.call_args_list[1]
+        self.assertEqual(first_args[0], ("93.184.216.34", 443))
+        self.assertEqual(second_args[0], ("93.184.216.35", 443))
+
+
+class TestExtraBlockedCidrs(TestCase):
+    """``MCD_HTTP_BLOCKED_CIDRS`` env var feeds the ``_EXTRA_NETWORKS``
+    list at import time. We test the parsing function directly and verify
+    the hook honors the list via ``patch.object`` — no module reload
+    required (reload would create new ``_policy`` / ``_safe_create_connection``
+    objects, invalidating any references the tests hold)."""
+
+    def tearDown(self):
+        _policy.active = False
+
+    def _assert_hook_blocks(self, ip: str, *, extra_networks):
+        """Activate the policy, patch _EXTRA_NETWORKS, and verify the
+        hook rejects ``ip`` before any connect."""
+        _policy.active = True
+        _policy.strict_ip_policy = False
+        with patch.object(url_safety, "_EXTRA_NETWORKS", extra_networks):
+            with patch.object(url_safety, "_original_create_connection") as called:
+                with self.assertRaises(HttpClientError):
+                    _safe_create_connection((ip, 443), timeout=1)
+            called.assert_not_called()
+
+    def test_extra_cidr_honored_by_hook(self):
+        self._assert_hook_blocks(
+            "203.0.113.5",
+            extra_networks=[ipaddress.ip_network("203.0.113.0/24")],
+        )
+
+    def test_multiple_extra_cidrs_honored_by_hook(self):
+        extra = [
+            ipaddress.ip_network("203.0.113.0/24"),
+            ipaddress.ip_network("198.51.100.0/24"),
+        ]
+        self._assert_hook_blocks("203.0.113.7", extra_networks=extra)
+        self._assert_hook_blocks("198.51.100.7", extra_networks=extra)
+
+    def test_env_var_parsing_at_import(self):
+        # Verifies the env var actually feeds _EXTRA_NETWORKS — covers the
+        # parsing path that runs at module load.
+        with patch.dict(
+            "os.environ", {"MCD_HTTP_BLOCKED_CIDRS": "203.0.113.0/24,198.51.100.0/24"}
+        ):
+            networks = url_safety._load_extra_blocked_networks()
+        self.assertEqual(
+            sorted(str(n) for n in networks),
+            ["198.51.100.0/24", "203.0.113.0/24"],
+        )
+
+    def test_invalid_cidr_logged_and_skipped(self):
+        with self.assertLogs(
+            "apollo.integrations.http.url_safety", level="WARNING"
+        ) as cm:
+            result = url_safety._parse_cidrs(
+                ("not-a-cidr", "203.0.113.0/24"), source="test"
+            )
+        self.assertEqual([str(n) for n in result], ["203.0.113.0/24"])
+        self.assertTrue(
+            any("invalid CIDR" in msg for msg in cm.output),
+            f"expected 'invalid CIDR' warning, got: {cm.output}",
+        )
+
+
+class TestSafetyPolicyContext(TestCase):
+    """The context manager is what callers actually invoke. Verify it
+    sets and clears the per-thread policy and validates the URL upfront."""
+
+    def tearDown(self):
+        _policy.active = False
+
+    def test_activates_and_deactivates(self):
+        self.assertFalse(getattr(_policy, "active", False))
+        with safety_policy("https://example.com/"):
+            self.assertTrue(_policy.active)
+        self.assertFalse(_policy.active)
+
+    def test_deactivates_on_exception(self):
+        with self.assertRaises(RuntimeError):
+            with safety_policy("https://example.com/"):
+                raise RuntimeError("boom")
+        self.assertFalse(_policy.active)
+
+    def test_url_scheme_check_runs_upfront(self):
+        # The scheme check is at the URL layer; failure must happen before
+        # the policy is even activated.
+        with self.assertRaises(HttpClientError) as ctx:
+            with safety_policy("ftp://example.com/"):
+                self.fail("body should not run")
+        self.assertIn("scheme", str(ctx.exception))
+        self.assertFalse(getattr(_policy, "active", False))
+
+    def test_https_only_rejects_http(self):
+        with self.assertRaises(HttpClientError) as ctx:
+            with safety_policy("http://93.184.216.34/", https_only=True):
+                pass
+        self.assertIn("scheme", str(ctx.exception))
+
+    def test_rejects_localhost(self):
+        with self.assertRaises(HttpClientError) as ctx:
+            with safety_policy("https://localhost/foo"):
+                pass
+        self.assertIn("localhost", str(ctx.exception))
+
+    def test_rejects_empty_host(self):
+        with self.assertRaises(HttpClientError):
+            with safety_policy("https:///foo"):
+                pass
+
+    def test_url_none_skips_upfront_validation(self):
+        # Advanced callers that have done their own URL validation can
+        # activate the policy without an upfront URL check.
+        with safety_policy(url=None, strict_ip_policy=True):
+            self.assertTrue(_policy.active)
+            self.assertTrue(_policy.strict_ip_policy)
+        self.assertFalse(_policy.active)
+
+
+class TestSafeRequest(TestCase):
+    """End-to-end smoke test on the public ``safe_request`` API."""
+
+    def tearDown(self):
+        _policy.active = False
+
+    @patch("apollo.integrations.http.url_safety.requests.request")
+    def test_passes_method_url_and_kwargs_through(self, mock_request):
+        mock_request.return_value = "stub-response"
+        result = safe_request(
+            "GET", "https://93.184.216.34/path", timeout=5, headers={"X": "y"}
+        )
+        self.assertEqual(result, "stub-response")
+        mock_request.assert_called_once_with(
+            "GET", "https://93.184.216.34/path", timeout=5, headers={"X": "y"}
+        )
+
+    def test_rejects_unsupported_scheme_before_calling_requests(self):
+        with patch(
+            "apollo.integrations.http.url_safety.requests.request"
+        ) as mock_request:
+            with self.assertRaises(HttpClientError):
+                safe_request("GET", "ftp://example.com/")
+            mock_request.assert_not_called()
+
+    @patch("apollo.integrations.http.url_safety.requests.request")
+    def test_clears_policy_on_exception(self, mock_request):
+        mock_request.side_effect = RuntimeError("boom")
+        with self.assertRaises(RuntimeError):
+            safe_request("GET", "https://93.184.216.34/")
+        self.assertFalse(getattr(_policy, "active", False))


### PR DESCRIPTION
## Summary

Blocks the agent's outbound HTTP integrations from connecting to cloud
metadata services (169.254.169.254 and friends) and other non-routable
addresses. Flagged by customer security teams as an SSRF risk in the
generic ``http`` connection type.

## Policy

The guard runs inside a wrapper around ``urllib3.util.connection.create_connection``.
The wrapper is a no-op (passthrough) when no policy is active on the current
thread, so unrelated urllib3 consumers in the same process (Snowflake connector,
GCS/Azure SDKs, OpenTelemetry exporter, etc.) are unaffected. Two policy tiers
share one implementation:

| Tier | Used by | Blocks |
|---|---|---|
| **Default** | ``HttpProxyClient.do_request``, ``TableauProxyClient.api_request`` | `169.254.0.0/16` (IMDS), `fe80::/10` (IPv6 link-local), `127.0.0.0/8` + `::1/128` (loopback). **RFC1918 allowed** for VPC / Private Link traffic. |
| **Strict** | ``HttpProxyClient.download_*`` (pre-signed URLs from further upstream) | All non-public IPs (RFC1918, link-local, loopback, multicast, reserved, unspecified) + non-HTTPS. Replaces ``_assert_safe_download_url``. |
| **Network troubleshooting validators** | ``ValidateNetwork.validate_http_connection`` (via ``safe_request``); ``validate_tcp_open_connection`` and ``validate_telnet_connection`` (via ``assert_safe_destination``) | Same default-tier rules. The troubleshooting endpoint can no longer be used to reach cloud metadata services even from a Monte Carlo operator session. |

Operators can extend the default block list via the
``MCD_HTTP_BLOCKED_CIDRS`` env var (e.g.
``MCD_HTTP_BLOCKED_CIDRS="100.64.0.0/10,10.50.0.0/16"``). Invalid entries are
logged and skipped at import time. The extension applies under both tiers.

Operators can also enforce HTTPS in the default tier via
``MCD_HTTP_REQUIRE_HTTPS=true`` (default ``false`` — preserves current behavior
for existing customer integrations that use plain HTTP over private networks).

## Design notes

- **Redirects:** every hop goes through ``create_connection``, so the guard
  runs on each redirect target without any ``requests.Session`` subclassing.
- **Multi-IP fallback:** when a hostname resolves to multiple addresses, the
  hook iterates them, validating each just before its connect attempt and
  falling back on transient connect failure — matches urllib3's native
  behavior.
- **Exception propagation:** ``HttpClientError`` raised from inside
  ``create_connection`` propagates cleanly through urllib3 and ``HTTPAdapter``
  (neither catches arbitrary subclasses), so callers see the original
  exception type rather than a wrapped ``ConnectionError``.
- **Composability:** ``safety_policy`` saves/restores prior thread-local
  state on entry/exit, so nesting contexts (or test re-use of the same
  thread) doesn't silently deactivate an outer policy.
- **Idempotency:** the urllib3 hook install carries a marker attribute and
  no-ops on re-import, preventing wrapper stacking.
- **Threading:** the policy is ``threading.local`` — fan-out to a worker
  thread (``ThreadPoolExecutor``, ``run_in_executor``) requires re-entering
  ``safety_policy`` on the worker.

## Out of scope

- **DB clients** (Snowflake, BigQuery, Redshift, Starburst, Salesforce Data
  Cloud, etc.) speak DB-specific wire protocols; a metadata-service IP fails
  handshake rather than serving credentials. Different threat model.
- **CTP transforms** (``oauth``, ``resolve_informatica_session``) don't return
  response bodies to the caller, so SSRF doesn't yield meaningful exfiltration
  here. The real risk in these is generic DC-supplied URL substitution for
  credential leak, which this guard doesn't address (and which RFC1918-allow
  in the default tier wouldn't address either).

## Files changed

- New: ``apollo/integrations/http/url_safety.py`` — the helper (
  ``safety_policy`` context manager, ``safe_request`` wrapper, ``HttpClientError``,
  ``_safe_create_connection`` hook).
- New: ``apollo/integrations/http/CLAUDE.md`` — architecture, call-site
  guidance, threading limitation, out-of-scope notes.
- ``apollo/integrations/http/http_proxy_client.py`` — ``do_request`` uses
  ``safe_request``; ``_open_download_response`` uses
  ``safety_policy(url, strict_ip_policy=True, https_only=True)``;
  ``_assert_safe_download_url`` deleted; explicit
  ``HttpClientError as HttpClientError`` re-export.
- ``apollo/integrations/tableau/tableau_proxy_client.py`` — ``api_request``
  uses ``safe_request``.
- ``README.md`` + ``.envrc.example`` — document
  ``MCD_HTTP_BLOCKED_CIDRS`` and ``MCD_HTTP_REQUIRE_HTTPS``.
- New: ``tests/test_url_safety.py`` — hook install, passthrough,
  default + strict tiers, multi-IP fallback, env-var parsing, context
  manager, nested-context save/restore, cross-thread isolation,
  ``MCD_HTTP_REQUIRE_HTTPS`` behavior.
- ``tests/test_http_client.py`` — download-tier tests updated for new
  error wording; ``TestHttpClientSsrfGuard`` for the
  ``do_request`` integration path.
- ``tests/test_tableau_client.py`` — assertion updated to match
  ``requests.request`` positional call shape (now goes through
  ``safe_request``).
- ``apollo/validators/validate_network.py`` — ``validate_http_connection``
  uses ``safe_request``; ``validate_tcp_open_connection`` and
  ``validate_telnet_connection`` call ``assert_safe_destination`` before
  opening the socket / Telnet session. ``perform_dns_lookup`` is unchanged
  (reconnaissance-only, no connection).
- ``tests/test_health_network.py`` — existing tests use a public IP literal
  so the new pre-flight short-circuits; new SSRF regression tests for the
  three guarded validators.
- ``apollo/integrations/http/url_safety.py`` — added the
  ``assert_safe_destination(host, port, *, strict_ip_policy=False)`` helper.

## Test plan

- [x] All affected unit tests pass locally (1173 passed in the full suite;
  the 3 pre-existing collection errors are unrelated — missing ODBC driver
  on the dev machine).
- [x] Ran `/code-review` (two rounds + a third round for the
  ``validate_network`` follow-up)
- [ ] CI green.
- [ ] Manual verification: confirm a sample integration (Tableau, MuleSoft)
  still works against a real endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

