### PR TITLE
docs(azure): add sync storage execute endpoint to openapi spec

### DIFF
--- a/apollo/interfaces/azure/openapi.yaml
+++ b/apollo/interfaces/azure/openapi.yaml
@@ -28,6 +28,8 @@ tags:
     description: Infrastructure detail retrieval.
   - name: Azure Logs
     description: Query Azure Application Insights log events.
+  - name: Agent Operations
+    description: Synchronous operation execution handled by the Flask WSGI app.
   - name: Azure Async Operations
     description: Asynchronous operation execution via Azure Durable Functions.
 
@@ -428,6 +430,57 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AzureLogsResponse"
+
+  # ---------------------------------------------------------------------------
+  # Synchronous agent operations
+  # ---------------------------------------------------------------------------
+
+  /api/v1/agent/execute/storage/{operation_name}:
+    post:
+      summary: Execute a synchronous storage agent operation
+      description: >
+        Executes a storage agent operation synchronously and returns the result in
+        the same response.
+
+        On Azure, agent operations are normally run asynchronously via Azure Durable
+        Functions (see `POST /async/api/v1/agent/execute/{connection_type}/{operation_name}`)
+        because they can exceed the 4 minute Azure Functions execution limit. Storage
+        operations are the exception: they are short-lived and are always invoked
+        synchronously, so `storage` is the only connection type served by this route.
+      tags: [Agent Operations]
+      parameters:
+        - name: operation_name
+          in: path
+          required: true
+          description: >
+            Name of the operation, used for logging only. The actual commands are
+            defined in the `operation` body field.
+          schema:
+            type: string
+            example: is_bucket_private
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecuteOperationRequest"
+            example:
+              credentials:
+                connect_args:
+                  account_name: account_name
+                  account_key: account_key
+              operation:
+                trace_id: "324986b4-b185-4187-b4af-b0c2cd60f7a0"
+                commands:
+                  - method: is_bucket_private
+                    args: []
+      responses:
+        "200":
+          description: The result of the storage operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentOperationResponse"
 
   # ---------------------------------------------------------------------------
   # Azure Durable Functions – async operations


### PR DESCRIPTION
## What

Adds the synchronous storage execute endpoint to the Azure OpenAPI spec:

`POST /api/v1/agent/execute/storage/{operation_name}`

- `connection_type` is **hardcoded to `storage`** — the only connection type Azure invokes synchronously.
- `operation_name` is left **dynamic** (path param), example `is_bucket_private`.
- Reuses the existing `ExecuteOperationRequest` body and `AgentOperationResponse` envelope.
- Adds a new `Agent Operations` tag for synchronous (Flask WSGI) operations.

## Why

The Azure spec was built from `azure/main.py` with the sync execute variant removed, under the assumption that Azure only uses async operations (Azure Durable Functions, needed for operations exceeding the 4-minute Functions limit). But the data-collector routes **all** Azure agent operations to `/async` **except** storage, which is invoked synchronously — see `agent_client.py` `_requires_async_call`.

This left the storage sync route undocumented even though customers hit it in production (M&T flagged `/api/v1/agent/execute/storage/is_bucket_private` not appearing in the spec).

## Notes

- Deliberately scoped to only the storage sync execute endpoint. Other undocumented sync routes (`execute_script`, `ctp/validate`, `connectors/types`, `custom-connectors/manifests`) are intentionally **not** added here — not relevant for this use case or most customers.
- The `is_bucket_private` example uses `args: []` since the bucket name is configured agent-side.
- Docs-only change; no agent code touched. YAML validated and both `$ref`s resolve to existing schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)