### PR TITLE
Path-based session-header routing for v2 + v3 Informatica endpoints

### DIFF
--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -86,6 +86,10 @@ class InformaticaProxyClient(BaseProxyClient):
         """
         Execute an HTTP request against the Informatica API base URL.
 
+        The session header is selected by path prefix: ``/public/core/v3/...``
+        gets ``INFA-SESSION-ID``; everything else gets ``icSessionId``.
+        Caller-supplied ``additional_headers`` override on collision.
+
         :param path: Path to append to the API base URL (e.g., "/v2/jobs"). Must start with "/".
         :param http_method: HTTP method (GET, POST, PUT, DELETE, etc.)
         :param payload: Optional JSON payload for the request body

--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -14,16 +14,22 @@ class InformaticaProxyClient(BaseProxyClient):
     resolve_informatica_session transform) to contain a pre-resolved session:
 
         connect_args:
-            session_id    (required): icSessionId from the Informatica login response
+            session_id    (required): session token from the Informatica login response
             api_base_url  (required): API base URL from the Informatica login response
 
     All authentication — V2 password, V3 password, or JWT loginOAuth — is handled
     upstream in the CTP pipeline. This client is auth-method agnostic.
 
-    The icSessionId header is always used for API calls regardless of how the session
-    was obtained. This is intentional: the DC currently calls only V2 API endpoints,
-    which require icSessionId (not INFA-SESSION-ID).
+    The Informatica session header is selected per request based on the path:
+
+    - V3 endpoints (``/public/core/v3/...``) read the token from ``INFA-SESSION-ID``.
+    - Everything else (V2 ``/api/v2/...``) reads it from ``icSessionId``.
+
+    Each request carries only the header its endpoint actually reads — no
+    redundant auth header on the wire.
     """
+
+    _V3_PATH_PREFIX = "/public/core/v3/"
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
@@ -46,15 +52,12 @@ class InformaticaProxyClient(BaseProxyClient):
             )
 
         self._api_base_url: str = api_base_url.rstrip("/")
+        self._session_id: str = session_id
 
-        # icSessionId is used for all API calls — this is coupled to V2 API usage,
-        # not the auth method used to obtain the session.
-        http_credentials: Dict[str, Any] = {
-            "token": session_id,
-            "auth_header": "icSessionId",
-            "auth_type": "",  # empty string → send token as-is, no "Bearer " prefix
-        }
-        self._http_client = HttpProxyClient(credentials=http_credentials)
+        # The Informatica session header is path-dependent (V2 vs V3), so we
+        # don't rely on HttpProxyClient's auto-attached auth header. The right
+        # header is injected per request in ``do_http_request`` instead.
+        self._http_client = HttpProxyClient(credentials=None)
 
     @property
     def wrapped_client(self):
@@ -97,13 +100,24 @@ class InformaticaProxyClient(BaseProxyClient):
             path = f"/{path}"
         url = f"{self._api_base_url}{path}"
 
+        # Pick the session header for the API surface this path targets.
+        # Caller-supplied additional_headers win on collision so a deliberate
+        # override (e.g., for an unusual endpoint) isn't silently masked.
+        if path.startswith(self._V3_PATH_PREFIX):
+            session_header = "INFA-SESSION-ID"
+        else:
+            session_header = "icSessionId"
+        merged_headers: Dict[str, Any] = {session_header: self._session_id}
+        if additional_headers:
+            merged_headers.update(additional_headers)
+
         return self._http_client.do_request(
             url=url,
             http_method=http_method,
             payload=payload,
             content_type=content_type,
             timeout=timeout,
-            additional_headers=additional_headers,
+            additional_headers=merged_headers,
             params=params,
             retry_status_code_ranges=retry_status_code_ranges,
             data=data,

--- a/apollo/integrations/http/informatica_proxy_client.py
+++ b/apollo/integrations/http/informatica_proxy_client.py
@@ -23,7 +23,8 @@ class InformaticaProxyClient(BaseProxyClient):
     The Informatica session header is selected per request based on the path:
 
     - V3 endpoints (``/public/core/v3/...``) read the token from ``INFA-SESSION-ID``.
-    - Everything else (V2 ``/api/v2/...``) reads it from ``icSessionId``.
+    - Any other path falls back to ``icSessionId`` (which is what V2
+      ``/api/v2/...`` endpoints expect).
 
     Each request carries only the header its endpoint actually reads — no
     redundant auth header on the wire.

--- a/tests/test_informatica_proxy_client.py
+++ b/tests/test_informatica_proxy_client.py
@@ -84,12 +84,10 @@ class InformaticaHttpTests(TestCase):
         self.assertIn("/api/v2/workflow", api_url)
 
     @patch("requests.request")
-    def test_do_http_request_sends_ic_session_id_header(self, mock_request):
-        """All API calls use icSessionId header regardless of how the session was obtained.
-
-        This is coupled to V2 API usage, not the auth method. Acts as a regression
-        guard for the intentional icSessionId-over-INFA-SESSION-ID behavior.
-        """
+    def test_v2_path_sends_only_ic_session_id(self, mock_request):
+        """V2 endpoints (``/api/v2/...``) read the session token from
+        ``icSessionId``. The proxy sends only that header on the wire — no
+        redundant ``INFA-SESSION-ID`` carried for endpoints that don't read it."""
         mock_request.return_value = _make_api_mock({"result": "ok"})
 
         self._agent.execute_operation(
@@ -100,11 +98,50 @@ class InformaticaHttpTests(TestCase):
         )
 
         headers = mock_request.call_args[1]["headers"]
-        self.assertIn("icSessionId", headers, "icSessionId header must always be sent")
-        self.assertNotIn(
-            "INFA-SESSION-ID", headers, "INFA-SESSION-ID must not be used (V2 API path)"
+        self.assertEqual(headers.get("icSessionId"), _SESSION_ID)
+        self.assertNotIn("INFA-SESSION-ID", headers)
+
+    @patch("requests.request")
+    def test_v3_path_sends_only_infa_session_id(self, mock_request):
+        """V3 endpoints (``/public/core/v3/...``) read the session token from
+        ``INFA-SESSION-ID``. The proxy sends only that header — pinning the
+        path-based routing here so a future refactor doesn't silently regress
+        to dual-header or wrong-header behavior."""
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            _make_operation(
+                "/public/core/v3/objects",
+                params={"q": "type=='MTT'", "limit": 200, "skip": 0},
+            ),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
         )
-        self.assertEqual(headers["icSessionId"], _SESSION_ID)
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers.get("INFA-SESSION-ID"), _SESSION_ID)
+        self.assertNotIn("icSessionId", headers)
+
+    @patch("requests.request")
+    def test_caller_headers_win_on_session_header_collision(self, mock_request):
+        """Caller-supplied ``additional_headers`` override the proxy's defaults —
+        guards against the proxy silently masking a deliberate header override
+        from a DC call site."""
+        mock_request.return_value = _make_api_mock({"items": []})
+
+        self._agent.execute_operation(
+            "informatica",
+            "http_request",
+            _make_operation(
+                "/public/core/v3/objects",
+                additional_headers={"INFA-SESSION-ID": "caller-override-token"},
+            ),
+            {"connect_args": _RESOLVED_CONNECT_ARGS},
+        )
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers.get("INFA-SESSION-ID"), "caller-override-token")
 
     @patch("requests.request")
     def test_do_http_request_passes_params(self, mock_request):
@@ -294,6 +331,7 @@ class InformaticaV2ProxyClientReuseTests(TestCase):
         self.assertTrue(api_url.startswith(_API_BASE_URL))
         headers = mock_request.call_args[1]["headers"]
         self.assertEqual(headers["icSessionId"], _SESSION_ID)
+        self.assertNotIn("INFA-SESSION-ID", headers)
 
 
 class InformaticaConnectionMetadataTests(TestCase):


### PR DESCRIPTION
## Changes

Enables the agent-side `InformaticaProxyClient` to drive Informatica V3 API endpoints (e.g. `/public/core/v3/objects`) in addition to the existing V2 endpoints (`/api/v2/...`), without an architectural split or per-call routing decision from the DC.

Each Informatica API surface reads the session token from a different header:

- V2 endpoints (`/api/v2/...`) read `icSessionId`.
- V3 endpoints (`/public/core/v3/...`) read `INFA-SESSION-ID`.

`do_http_request` now picks the right header based on the request path so only the header that endpoint actually reads goes on the wire. The session token continues to be sourced from `connect_args.session_id` (resolved upstream by the `resolve_informatica_session` CTP transform).

This is the agent-side prerequisite for the Informatica v2 path-info enrichment cross-repo work — the DC's path enrichment fetches `/public/core/v3/objects?q=type=='MTT'` for self-hosted Informatica customers. Sibling PRs:

- `data-collector` / services/orchestrator: [#2369](https://github.com/monte-carlo-data/data-collector/pull/2369) — orchestrator data-cache endpoints (in review)
- `monolith-django` #13691 — loader + catalog metadata + search read surface (in dev for regression check)
- `data-collector`: [#2370](https://github.com/monte-carlo-data/data-collector/pull/2370) — DC-side path enrichment + `list_objects` agent-proxy method (depends on this)

## Design notes

- **Path-based routing in the proxy client, not per-version proxy clients.** A single Informatica connection hits both API surfaces in the same collection cycle (V2 for MTT detail / activity logs, V3 for the path enrichment), so splitting at the connection-type level would force two proxy instances per connection without removing the routing decision.
- **No per-method wrapper.** The agent's HTTP proxy is intentionally generic (`do_http_request(path, ...)`); typed wrappers live on the DC-side `InformaticaAgentProxyClient`. The DC's `list_objects` method calls `do_http_request(path="/public/core/v3/objects", params=...)` and the agent automatically sends the correct header.
- **No header auto-attach in HttpProxyClient.** Since the session header is path-dependent, the proxy no longer relies on `HttpProxyClient`'s `auth_header` credential — it injects the header explicitly per call via `additional_headers`. Caller-supplied `additional_headers` continue to win on collision so deliberate overrides aren't silently masked.

## Testing

- `pytest tests/test_informatica_proxy_client.py` — 13/13 passing.
- `pytest tests/ctp/test_informatica_ctp.py tests/ctp/test_informatica_v2_ctp.py tests/ctp/test_resolve_informatica_session.py` — 46/46 passing (regression check on the upstream session-resolve transforms).
- `black --check` and `pyright` — clean.

New / updated tests:

- `test_v2_path_sends_only_ic_session_id` — V2 paths get `icSessionId` and *not* `INFA-SESSION-ID` on the wire.
- `test_v3_path_sends_only_infa_session_id` — V3 paths get `INFA-SESSION-ID` and *not* `icSessionId`. Locks in the path-based routing so a future refactor doesn't silently regress to dual-header or wrong-header behavior.
- `test_caller_headers_win_on_session_header_collision` — caller-supplied `additional_headers` override the proxy's session-header pick.
- `test_v2_connection_type_uses_same_proxy_client` extended to assert the v2 connection type also sends only `icSessionId`.

## Verification after deploy

The target customer's agent needs to be running this version before the DC's path-enrichment PR ships. Coordinate the agent upgrade per the cross-repo plan.

1. After agent upgrade, hit a V2 endpoint through the agent (e.g., MTT list) — expect 200 with `icSessionId` on the wire (no regression).
2. Hit a V3 endpoint through the agent (`/public/core/v3/objects?q=type=='MTT'`) — expect 200 with `INFA-SESSION-ID` on the wire. End-to-end exercise lands with the DC path-enrichment PR.