### PR TITLE
run azure image as non-root mcdagent user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,6 +167,12 @@ FROM mcr.microsoft.com/azure-functions/python:4-python3.12 AS azure
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true
 
+# Register mcdagent early so COPY --chown below lands files mcdagent-owned
+# without a later `chown -R` layer.
+RUN groupadd --gid 1000 mcdagent \
+    && useradd --uid 1000 --gid mcdagent --no-create-home --home-dir /home/site/wwwroot --shell /usr/sbin/nologin mcdagent \
+    && chown mcdagent:mcdagent /home/site/wwwroot
+
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends git
 # install libcrypt1 for IBM DB2 ibm-db package compatibility (provides libcrypt.so.1)
@@ -201,14 +207,15 @@ COPY requirements-azure.txt /
 RUN pip install --no-cache-dir -r /requirements.txt -r /requirements-azure.txt && rm -rf /opt/python/3/_manifest
 RUN pip install --no-cache-dir -U setuptools==80.10.2  # INC-265 - opentelemetry requires pkg_resources that was removed in setuptools 81
 
-COPY apollo /home/site/wwwroot/apollo
+COPY --chown=mcdagent:mcdagent apollo /home/site/wwwroot/apollo
 
 # the files under apollo/interfaces/azure like function_app.py must be in the root folder of the app
-COPY apollo/interfaces/azure /home/site/wwwroot
+COPY --chown=mcdagent:mcdagent apollo/interfaces/azure /home/site/wwwroot
 
 ARG code_version="local"
 ARG build_number="0"
-RUN echo $code_version,$build_number > /home/site/wwwroot/apollo/agent/version
+RUN echo $code_version,$build_number > /home/site/wwwroot/apollo/agent/version \
+    && chown mcdagent:mcdagent /home/site/wwwroot/apollo/agent/version
 
 # delete MS provided SBOM as it's outdated after the packages we installed
 # docker scout will find vulnerabilities anyway by scanning the image
@@ -216,3 +223,11 @@ RUN rm -rf /usr/local/_manifest
 
 # required for the verify-version-in-docker-image step in circle-ci
 WORKDIR /home/site/wwwroot
+
+# Bind Kestrel on 8080 (non-root can't bind <1024). EXPOSE 8080 lets
+# App Service auto-discover the port when WEBSITES_PORT is not set; if
+# a customer pinned WEBSITES_PORT=80 explicitly, they need to unset it
+# or update to 8080.
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+USER mcdagent


### PR DESCRIPTION
## Summary

Make the existing `azure` target run as the non-root `mcdagent` user (UID/GID 1000) instead of root. The Functions host (ASP.NET Core Kestrel) binds to port 8080 instead of 80 because a non-root process can't bind to <1024.

This is the last apollo distribution image still running as root — `aws_proxied`, `cloudrun`, and `lambda` were converted in v1.7.0 via #306. Azure was held back because the port change wasn't safe to roll out in a back-compat way at the time.

## How the migration works

After verifying behavior on a test image (`montecarlodata/pre-release-agent:az-non-root`), it turns out Azure App Service **auto-discovers the port from the image's `EXPOSE` directive when `WEBSITES_PORT` is not set**. The deploy log we observed:

```
Container image exposes ports: ContainerExposedPort { Port = 8080, Protocol = TCP }.
Resolved main port to 8080. Setting value of PORT variable to 8080.
```

So for any customer that has not explicitly pinned `WEBSITES_PORT`, the migration to the new image is transparent.

The only customers who need a config change are those who set `WEBSITES_PORT=80` explicitly. They'll see this in the deploy log instead:

```
LastError: ContainerTimeout
LastErrorDetails: Container did not start within expected time limit of 230s.
```

The fix for them: either remove the `WEBSITES_PORT` app setting (let App Service auto-discover from `EXPOSE`) or update it to `WEBSITES_PORT=8080`. **Worth calling out in release notes** because the error message is misleading — it suggests a slow-start problem rather than a port mismatch.

## Dockerfile changes

- Register `mcdagent` (UID/GID 1000) up front so subsequent `COPY --chown` statements land files mcdagent-owned in the first place — avoids a final `chown -R` layer that would have duplicated the apollo source under `/home/site/wwwroot` into a new layer.
- `chown /home/site/wwwroot` itself in the same `RUN` as user creation, so the Functions host can write startup metadata into the directory at runtime if needed.
- `COPY --chown=mcdagent:mcdagent` on apollo source + `apollo/interfaces/azure`.
- `ENV ASPNETCORE_URLS=http://+:8080` to bind Kestrel to 8080.
- `EXPOSE 8080` so App Service auto-discovers the port.
- `USER mcdagent` at the end.

## CI changes

None. The existing `--target azure` build step in `build-and-push` keeps working — it just builds a non-root image now. Same tags (`latest-azure`, `<ver>-azure`), same SBOM + provenance attestations.

## End-to-end verification (against a real Azure Functions deployment in dev)

Pushed test image `montecarlodata/pre-release-agent:az-non-root` (built from this branch), pointed an existing Azure agent at it, and tested all three port configurations:

| Config | App Service routes to | Container listens on | Result |
|---|---|---|---|
| `WEBSITES_PORT` unset, `EXPOSE 8080` | 8080 (auto-discovered) | 8080 | ✅ Site started, health endpoint returns 200 |
| `WEBSITES_PORT=8080` explicit | 8080 (explicit) | 8080 | ✅ Site started, health endpoint returns 200 |
| `WEBSITES_PORT=80` explicit | 80 | 8080 | ❌ `ContainerTimeout` after 230s |

Health endpoint excerpt confirming the new image was the one serving:

```json
{
  "platform": "Azure",
  "platform_info": {
    "image": "DOCKER|docker.io/montecarlodata/pre-release-agent:az-non-root"
  },
  "version": "1.7.1-test"
}
```

## Test plan

- [x] CircleCI green on this PR (run-linter, run-test-docker, build-ok)
- [x] Manual: deploy test image to a dev Azure Functions container, verify `WEBSITES_PORT` unset works (auto-discovery)
- [x] Manual: confirm `WEBSITES_PORT=8080` explicit works
- [x] Manual: confirm `WEBSITES_PORT=80` explicit fails with `ContainerTimeout` (so we know exactly what to put in release notes)
- [ ] After merge to dev: `build-and-push-dev` succeeds and publishes `latest-azure` / `<ver>-azure` as non-root
- [ ] After merge to dev: spot-check Docker Hub image for `uid=1000(mcdagent)`, `ASPNETCORE_URLS=http://+:8080`, `EXPOSE 8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)