### PR TITLE
chore(security): bump gunicorn 23.0.0 -> 26.0.0 (YET-1356)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ flask-compress==1.14
 google-api-python-client==2.176.0  # Upgraded in VULN-620
 google-cloud-secret-manager==2.25.0
 google-cloud-storage==2.10.0
-gunicorn==23.0.0
+gunicorn==26.0.0  # VULN-1117/YET-1356: request-smuggling & header-framing hardening (AIKIDO-2026-10742); stricter RFC 9112/9110 parsing. Default sync/gthread workers unaffected by the eventlet-worker removal.
 hdbcli==2.18.27
 ibm-db==3.2.7
 jinja2>=3.1.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,7 +153,7 @@ grpcio==1.76.0
     #   grpcio-status
 grpcio-status==1.71.2
     # via google-api-core
-gunicorn==23.0.0
+gunicorn==26.0.0
     # via -r requirements.in
 hdbcli==2.18.27
     # via -r requirements.in


### PR DESCRIPTION
## What

Bumps **gunicorn 23.0.0 → 26.0.0** to close the gunicorn HIGH/CRITICAL findings from the daily collection-agent vuln scan.

- Linear: [YET-1356](https://linear.app/montecarloai/issue/YET-1356/yeti-gunicorn) (parent [VULN-1117](https://linear.app/montecarloai/issue/VULN-1117/major-upgrade-for-gunicorn), AIKIDO-2026-10742)
- 26.0.0 introduces stricter RFC 9112/9110 request parsing that fixes the request-smuggling and header-framing hazards flagged by the scanner.

## Why it's safe for apollo-agent

- All images run Python 3.12 (gunicorn 26.0.0 requires `>=3.10`).
- Only mandatory runtime dep is `packaging`, already pinned — `pip-compile` produced no transitive churn (only this pin moved).
- We launch the default sync/gthread workers, so the 26.0.0 **eventlet-worker removal** (the one breaking change) does not apply. `--bind/--workers/--threads/--timeout` are all unchanged.

## Verification

- Built the `generic` image (`linux/amd64`) and ran `docker scout cves` → gunicorn no longer appears in HIGH/CRITICAL findings.
- Confirmed gunicorn 26.0.0 installed and `gunicorn --version` works in the image.
- Built the `tests` image → **1131 passed**.

## Checklist

- [x] Vulnerability remediated (gunicorn dropped from HIGH/CRITICAL scout findings)
- [x] Tests pass (1131 passed in tests image)
- [na] New tests — pure dependency version bump, no code change
- [na] Docs — no behavior change
- [ ] Re-scan in Aikido after merge to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)