### PR TITLE
chore(security): bump teradatasql 20.0.0.59 -> 20.0.0.60

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -50,7 +50,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 tableauserverclient==0.38 ; python_version >= "3.10"
 urllib3~=2.7  # CVE-2026-44431, CVE-2026-44432
 
-teradatasql>=20.0.0.59  # 20.0.0.59 bumps embedded Go stdlib to 1.26.3 (closes CVE-2026-33811, -39820, -39836, -42499); golang.org/x/net 0.49.0 + thrift 0.22.0 still bundled (33814, 41602 pending upstream)
+teradatasql>=20.0.0.60  # 20.0.0.60 bumps embedded golang.org/x/crypto 0.47.0->0.52.0 (closes CVE-2026-39829/-39830/-39831/-39832/-39833/-39834/-42508/-46595/-46597) and golang.org/x/net 0.49.0->0.54.0 (closes CVE-2026-33814); Go stdlib still 1.26.3. Still bundled at vulnerable versions: x/net 0.54.0 (CVE-2026-39821 needs >=0.55.0) + thrift 0.22.0 (CVE-2026-41602 needs >=0.23.0), pending upstream
 oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 impyla==0.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -363,7 +363,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tableauserverclient==0.38 ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.59
+teradatasql==20.0.0.60
     # via -r requirements.in
 thrift==0.16.0
     # via


### PR DESCRIPTION
## What

Bumps **teradatasql 20.0.0.59 → 20.0.0.60** to close most of the teradata-attributed Go-module CVEs from the daily collection-agent vuln scan.

> ⚠️ **Stacked PR** — based on `mrostan/yet-1356-yeti-gunicorn` (gunicorn PR #312), not `main`. The diff here is teradata-only. Retarget to `main` after #312 merges, or merge #312 first.

## Embedded module changes (verified by extracting the wheel + inspecting `teradatasql.so` / `teradatasql.arm.fips.so` / `teradatasql.fips.so`)

| Module | .59 → .60 | Result |
|---|---|---|
| `golang.org/x/crypto` | 0.47.0 → **0.52.0** | Closes CVE-2026-39829/-39830/-39831/-39832/-39833/-39834/-42508/-46595/-46597 |
| `golang.org/x/net` | 0.49.0 → **0.54.0** | Closes CVE-2026-33814 |
| `github.com/apache/thrift` | 0.22.0 (unchanged) | — |
| Go stdlib | 1.26.3 (unchanged) | — |

**Net effect on teradata-attributed HIGH/CRITICAL: 10 of 12 resolved** (down to 1 CRITICAL + 1 HIGH).

## Still bundled at vulnerable versions (pending upstream Teradata — cannot fix from our side)

- `golang.org/x/net` 0.54.0 — **CVE-2026-39821** (CRITICAL) needs `>=0.55.0`
- `github.com/apache/thrift` 0.22.0 — **CVE-2026-41602** (HIGH) needs `>=0.23.0`

## Verification

- `pip-compile` produced no transitive churn (only the teradatasql pin moved).
- Built the `generic` image (`linux/amd64`) + `docker scout cves` → only the two pending-upstream CVEs remain on the teradata libs.
- Built the `tests` image → **1131 passed**.

## Checklist

- [x] Vulnerabilities remediated (10 of 12; remaining 2 are upstream-blocked, documented above)
- [x] Tests pass (1131 passed in tests image)
- [na] New tests — pure dependency version bump, no code change
- [na] Docs — no behavior change
- [ ] File a tracking ticket for the 2 upstream-pending CVEs
- [ ] Re-scan in Aikido after merge to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)