### PR TITLE
build(deps): remove unused oscrypto git dependency

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -51,7 +51,6 @@ tableauserverclient==0.38 ; python_version >= "3.10"
 urllib3~=2.7  # CVE-2026-44431, CVE-2026-44432
 
 teradatasql>=20.0.0.60  # 20.0.0.60 bumps embedded golang.org/x/crypto 0.47.0->0.52.0 (closes CVE-2026-39829/-39830/-39831/-39832/-39833/-39834/-42508/-46595/-46597) and golang.org/x/net 0.49.0->0.54.0 (closes CVE-2026-33814); Go stdlib still 1.26.3. Still bundled at vulnerable versions: x/net 0.54.0 (CVE-2026-39821 needs >=0.55.0) + thrift 0.22.0 (CVE-2026-41602 needs >=0.23.0), pending upstream
-oscrypto @ git+https://github.com/wbond/oscrypto@master
 
 impyla==0.22.0
 werkzeug==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@
 agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.2
     # via -r requirements.in
 asn1crypto==1.5.1
-    # via
-    #   oscrypto
-    #   snowflake-connector-python
+    # via snowflake-connector-python
 attrs==23.2.0
     # via
     #   cattrs
@@ -230,8 +228,6 @@ orjson==3.11.7
     # via
     #   -r requirements.in
     #   trino
-oscrypto @ git+https://github.com/wbond/oscrypto@master
-    # via -r requirements.in
 packaging==24.1
     # via
     #   gunicorn


### PR DESCRIPTION
## What
Removes the `oscrypto @ git+https://github.com/wbond/oscrypto@master` dependency from `requirements.in` and recompiles `requirements.txt`.

## Why
A customer security review flagged this dependency for pointing at an **unpinned `@master` git ref** rather than a released, pinned version.

Investigation showed it is **dead weight**:
- It was originally added (commit `293cb24`) purely as a workaround for a `snowflake-connector-python` `LibraryNotFoundError` / libcrypto-detection bug.
- `snowflake-connector-python` **dropped its oscrypto dependency in v3.4.0** (Nov 2023) — *"Removed dependencies on pycryptodomex and oscrypto. All connections now go through OpenSSL via the cryptography library."* We pin `snowflake-connector-python>=4.0.0` (currently resolves to 4.4.0), well past that.
- `oscrypto` is **not imported anywhere** in the apollo-agent codebase.
- `pip-compile` confirms nothing else depends on it — it was annotated `# via -r requirements.in` (direct only), never `# via snowflake-connector-python`.

## Change
- Deleted the `oscrypto` line from `requirements.in`.
- Recompiled `requirements.txt`. Net diff is **only** the oscrypto removal: the package entry is gone and `asn1crypto==1.5.1` loses its oscrypto annotation (it stays, still required by `snowflake-connector-python`). No other pins moved.

## Downstream note
apollo-agent (`mcd-agent`) is a dependency of `data-collector`, where `oscrypto` currently leaks in transitively (`# via mcd-agent`). data-collector neither lists nor imports it, and pins `snowflake-connector-python==3.14.0` (also past v3.4.0), so it will drop naturally the next time the apollo-agent pin is bumped there. No data-collector change in this PR.

## Testing
- [x] `pip-compile` regenerates cleanly with no collateral version churn
- [x] Confirmed `oscrypto` has no importers in apollo-agent or data-collector
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)