### PR TITLE
build(deps): bump pyjwt to 2.13.0 for CVE-2026-48526

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,7 @@ psycopg2-binary==2.9.9
 pyarrow==23.0.1  # CVE-2026-25087 (Python bindings unaffected per GHSA-rgxp-2hwp-jwgg, but Trivy/Scout flag <23.0.1)
 pyasn1>=0.6.3  # CVE-2026-30922 (uncontrolled recursion), CVE-2026-23490
 pycryptodome>=3.21.0
-pyjwt>=2.12.0  # CVE-2026-32597
+pyjwt>=2.13.0  # CVE-2026-32597, CVE-2026-48526
 PyMySQL>=1.1.1
 pyodbc==5.0.1
 pyOpenSSL>=26.0.0  # CVE-2026-27459 (buffer overflow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -280,7 +280,7 @@ pycryptodome==3.21.0
     # via
     #   -r requirements.in
     #   teradatasql
-pyjwt==2.12.1
+pyjwt==2.13.0
     # via
     #   -r requirements.in
     #   msal


### PR DESCRIPTION
## What

Bumps `pyjwt` from 2.12.1 → 2.13.0 to resolve **CVE-2026-48526** (HIGH), flagged in the daily `#collection-agent-vuln-scans` report (2026-06-03).

- `requirements.in`: floor `pyjwt>=2.12.0` → `pyjwt>=2.13.0`, comment updated
- `requirements.txt`: recompiled via `pip-compile` — only pyjwt moved, no transitive churn

## Why this is the only fixable HIGH/CRITICAL right now

From the latest scan, the other HIGH/CRITICAL findings are not actionable:
- `golang.org/x/net` (CVE-2026-39821, CRIT) and `apache/thrift` (CVE-2026-41602, HIGH) are statically compiled into the Teradata FIPS driver (`teradatasql.arm.fips.so`) — blocked until Teradata ships an updated driver.
- `debian/perl` (×5), `libnss3` (×2), `libhttp-daemon-perl` — no upstream fix available yet.

## Verification

- ✅ `pyjwt 2.13.0` installs; `jwt` + `msal` (its dependent) import cleanly
- ✅ All 110 tests across the files using pyjwt pass (`test_tableau_client.py`, `ctp/test_transforms.py`, `ctp/test_resolve_informatica_session.py`)
- ✅ Checked the new `InsecureKeyLengthWarning` in 2.13.0: both HS256 sites sign Tableau Connected App JWTs with customer GUID secrets (≥36 bytes), so it won't trip in practice; and it's a non-fatal warning regardless — no `-W error`/`filterwarnings`/`PYTHONWARNINGS` promotion exists in the repo, CI, or Dockerfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)