### PR TITLE
feat: add custom ETL connector support (YET-1178)

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -398,7 +398,7 @@ class Agent:
     def get_supported_connector_types(self, trace_id: Optional[str]) -> AgentResponse:
         """
         Returns the connector types this agent supports, split into
-        native (built-in) and custom categories.
+        native (built-in), custom, and custom_etl categories.
         """
         with self._inject_log_context("get_supported_connector_types", trace_id):
             try:
@@ -409,12 +409,16 @@ class Agent:
                 from apollo.integrations.custom.custom_proxy_client import (
                     CustomProxyClient,
                 )
+                from apollo.integrations.custom_etl.custom_etl_proxy_client import (
+                    CustomEtlProxyClient,
+                )
 
                 return AgentUtils.agent_ok_response(
                     {
                         "connector_types": {
                             "native": get_native_connection_types(),
                             "custom": CustomProxyClient.get_custom_connector_types(),
+                            "custom_etl": CustomEtlProxyClient.get_custom_etl_connector_types(),
                         }
                     },
                     trace_id,
@@ -427,7 +431,7 @@ class Agent:
     def get_connection_manifests(self, trace_id: Optional[str]) -> AgentResponse:
         """
         Returns manifests, capabilities, and templates for all custom
-        connectors installed on this agent.
+        connectors (warehouse and ETL) installed on this agent.
         """
         with self._inject_log_context("get_connection_manifests", trace_id):
             try:
@@ -435,8 +439,12 @@ class Agent:
                 from apollo.integrations.custom.custom_proxy_client import (
                     CustomProxyClient,
                 )
+                from apollo.integrations.custom_etl.custom_etl_proxy_client import (
+                    CustomEtlProxyClient,
+                )
 
                 manifests = CustomProxyClient.get_connection_manifests()
+                manifests.update(CustomEtlProxyClient.get_connection_manifests())
                 return AgentUtils.agent_ok_response(manifests, trace_id)
             except Exception:  # noqa
                 return AgentUtils.agent_response_for_last_exception(

--- a/apollo/agent/proxy_client_factory.py
+++ b/apollo/agent/proxy_client_factory.py
@@ -378,6 +378,16 @@ def _get_proxy_client_custom(
     return CustomProxyClient(credentials=credentials, connector_dir=connector_dir)
 
 
+def _get_proxy_client_custom_etl(
+    credentials: Optional[Dict], connector_dir: str, **kwargs  # type: ignore
+) -> BaseProxyClient:
+    from apollo.integrations.custom_etl.custom_etl_proxy_client import (
+        CustomEtlProxyClient,
+    )
+
+    return CustomEtlProxyClient(credentials=credentials, connector_dir=connector_dir)
+
+
 def _get_proxy_client_microsoft_fabric(
     credentials: Optional[Dict], platform: str, **kwargs  # type: ignore
 ) -> BaseProxyClient:
@@ -542,6 +552,17 @@ class ProxyClientFactory:
             connector_dir = custom_registry.get(connection_type)
             if connector_dir:
                 return _get_proxy_client_custom(
+                    credentials, connector_dir=connector_dir
+                )
+
+            from apollo.integrations.custom_etl.custom_etl_connector_loader import (
+                get_custom_etl_connector_registry,
+            )
+
+            custom_etl_registry = get_custom_etl_connector_registry()
+            connector_dir = custom_etl_registry.get(connection_type)
+            if connector_dir:
+                return _get_proxy_client_custom_etl(
                     credentials, connector_dir=connector_dir
                 )
 

--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -1,0 +1,62 @@
+# Custom ETL Connectors
+
+Runtime-loaded ETL connectors baked into the Docker image at `/opt/custom-etl-connectors`.
+Each connector provides a `manifest.json` and a `connector.py` (implementing a `Connector`
+class that inherits from `BaseEtlConnector`).
+
+## Key modules
+
+- **`custom_etl_connector_loader.py`** — discovers connectors on the filesystem, loads modules
+  dynamically via `importlib.util`, and caches the registry at module level.
+- **`custom_etl_proxy_client.py`** — `CustomEtlProxyClient(BaseProxyClient)` wraps a loaded
+  connector module. Exposes `fetch_etl_assets` and `fetch_etl_runs` which delegate to the
+  connector's `fetch_metadata` and `_fetch_run_details` methods, serializing the model objects
+  (EtlAsset/EtlRunEvent) to dicts for the data-collector.
+
+## Opt-in gating
+
+Custom ETL connectors share the same gate as custom connectors: the env var
+`MCD_CUSTOM_CONNECTORS_ENABLED=true`. The factory in `apollo/agent/proxy_client_factory.py`
+checks this before falling through to either custom connector path.
+
+## Connector directory structure
+
+```
+/opt/custom-etl-connectors/<name>/
+├── manifest.json        # connection_type, name, terminology, icon_url
+└── connector.py         # Connector(BaseEtlConnector) class
+```
+
+## Manifest format
+
+```json
+{
+  "connection_type": "custom-etl-connector-<hash>",
+  "name": "adf",
+  "terminology": {
+    "group": "Factory",
+    "job": "Pipeline",
+    "task": "Activity"
+  },
+  "icon_url": "https://example.com/icon.png"
+}
+```
+
+## Connector interface
+
+The `connector.py` module must define a `Connector` class with:
+- `credentials` attribute (set by the proxy before `setup_connection`)
+- `setup_connection()` — establish connection using credentials
+- `close_connection()` — clean up resources
+- `fetch_metadata(limit, offset)` → `List[EtlAsset]`
+- `_fetch_run_details(run_ids, lookback, limit, offset)` → `List[EtlRunEvent]`
+
+## How it differs from custom (warehouse) connectors
+
+| Aspect | Custom connectors | Custom ETL connectors |
+|--------|------------------|-----------------------|
+| Base path | `/opt/custom-connectors` | `/opt/custom-etl-connectors` |
+| Connector class | `BaseConnector` | `Connector(BaseEtlConnector)` |
+| Templates | Jinja2 `.j2` SQL templates | None (code-only) |
+| Methods | SQL-oriented (fetch_tables, etc.) | ETL-oriented (fetch_metadata, runs) |
+| Type prefix | `custom-connector-<hash>` | `custom-etl-connector-<hash>` |

--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -10,7 +10,7 @@ class that inherits from `BaseEtlConnector`).
   dynamically via `importlib.util`, and caches the registry at module level.
 - **`custom_etl_proxy_client.py`** — `CustomEtlProxyClient(BaseProxyClient)` wraps a loaded
   connector module. Exposes `fetch_etl_assets` and `fetch_etl_runs` which delegate to the
-  connector's `fetch_metadata` and `_fetch_run_details` methods, serializing the model objects
+  connector's `fetch_metadata` and `fetch_run_details` methods, serializing the model objects
   (EtlAsset/EtlRunEvent) to dicts for the data-collector.
 
 ## Opt-in gating
@@ -49,7 +49,7 @@ The `connector.py` module must define a `Connector` class with:
 - `setup_connection()` — establish connection using credentials
 - `close_connection()` — clean up resources
 - `fetch_metadata(limit, offset)` → `List[EtlAsset]`
-- `_fetch_run_details(run_ids, lookback, limit, offset)` → `List[EtlRunEvent]`
+- `fetch_run_details(run_ids, lookback, limit, offset)` → `List[EtlRunEvent]`
 
 ## How it differs from custom (warehouse) connectors
 

--- a/apollo/integrations/custom_etl/custom_etl_connector_loader.py
+++ b/apollo/integrations/custom_etl/custom_etl_connector_loader.py
@@ -12,6 +12,9 @@ _CUSTOM_ETL_CONNECTORS_BASE_PATH = "/opt/custom-etl-connectors"
 # Module-level cache: {connection_type: connector_dir_path}
 _custom_etl_connector_registry: Optional[Dict[str, str]] = None
 
+# Module-level cache: {module_name: loaded module}
+_loaded_modules: Dict[str, types.ModuleType] = {}
+
 
 def _discover_custom_etl_connectors() -> Dict[str, str]:
     """
@@ -84,11 +87,15 @@ def load_connector_module(connector_dir: str) -> types.ModuleType:
     dir_name = os.path.basename(connector_dir)
     module_name = f"custom_etl_connector_{dir_name}"
 
+    if module_name in _loaded_modules:
+        return _loaded_modules[module_name]
+
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise ImportError(f"Failed to create module spec for {module_path}")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    _loaded_modules[module_name] = module
     return module
 
 

--- a/apollo/integrations/custom_etl/custom_etl_connector_loader.py
+++ b/apollo/integrations/custom_etl/custom_etl_connector_loader.py
@@ -1,0 +1,105 @@
+import importlib.util
+import json
+import logging
+import os
+import types
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_CUSTOM_ETL_CONNECTORS_BASE_PATH = "/opt/custom-etl-connectors"
+
+# Module-level cache: {connection_type: connector_dir_path}
+_custom_etl_connector_registry: Optional[Dict[str, str]] = None
+
+
+def _discover_custom_etl_connectors() -> Dict[str, str]:
+    """
+    Scan the custom ETL connectors directory and build a mapping of
+    connection_type -> directory path by reading each manifest.json.
+    """
+    registry: Dict[str, str] = {}
+    base_path = _CUSTOM_ETL_CONNECTORS_BASE_PATH
+
+    if not os.path.isdir(base_path):
+        logger.info("Custom ETL connectors directory not found: %s", base_path)
+        return registry
+
+    for name in sorted(os.listdir(base_path)):
+        connector_dir = os.path.join(base_path, name)
+        if not os.path.isdir(connector_dir):
+            continue
+
+        manifest_path = os.path.join(connector_dir, "manifest.json")
+        if not os.path.isfile(manifest_path):
+            logger.warning("Skipping custom ETL connector %s: no manifest.json", name)
+            continue
+
+        try:
+            with open(manifest_path) as f:
+                manifest = json.load(f)
+            connection_type = manifest.get("connection_type")
+            if not connection_type:
+                logger.warning(
+                    "Skipping custom ETL connector %s: no connection_type in manifest",
+                    name,
+                )
+                continue
+            registry[connection_type] = connector_dir
+            logger.info(
+                "Discovered custom ETL connector: %s -> %s",
+                connection_type,
+                connector_dir,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to read manifest for custom ETL connector %s", name
+            )
+
+    return registry
+
+
+def get_custom_etl_connector_registry() -> Dict[str, str]:
+    """
+    Return the cached custom ETL connector registry, discovering on first access.
+    Contents are baked into the Docker image so they never change at runtime.
+    """
+    global _custom_etl_connector_registry
+    if _custom_etl_connector_registry is None:
+        _custom_etl_connector_registry = _discover_custom_etl_connectors()
+    return _custom_etl_connector_registry
+
+
+def load_connector_module(connector_dir: str) -> types.ModuleType:
+    """
+    Dynamically load connector.py from the given directory.
+    Uses a unique module name per connector to avoid namespace collisions.
+    Returns the loaded module.
+    """
+    module_path = os.path.join(connector_dir, "connector.py")
+    if not os.path.isfile(module_path):
+        raise FileNotFoundError(f"connector.py not found in {connector_dir}")
+
+    # Use directory name as part of module name for uniqueness
+    dir_name = os.path.basename(connector_dir)
+    module_name = f"custom_etl_connector_{dir_name}"
+
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Failed to create module spec for {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_manifest(connector_dir: str) -> Dict:
+    """
+    Read manifest.json from the connector directory.
+    Returns the parsed dict, or empty dict if not found.
+    """
+    manifest_path = os.path.join(connector_dir, "manifest.json")
+    if not os.path.isfile(manifest_path):
+        return {}
+
+    with open(manifest_path) as f:
+        return json.load(f)

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -30,7 +30,7 @@ def _serialize(obj: Any) -> Any:
     if isinstance(obj, list):
         return [_serialize(item) for item in obj]
     if isinstance(obj, dict):
-        return {k: _serialize(v) for k, v in obj.items()}
+        return {k: _serialize(v) for k, v in obj.items() if v is not None}
     try:
         if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
             return {
@@ -65,14 +65,14 @@ class CustomEtlProxyClient(BaseProxyClient):
         connector_dir: str,
         **kwargs: Any,
     ):
-        module = load_connector_module(connector_dir)
-        self._connector = module.Connector()
-
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Custom ETL connector agent client requires "
                 f"{_ATTR_CONNECT_ARGS} in credentials"
             )
+
+        module = load_connector_module(connector_dir)
+        self._connector = module.Connector()
 
         self._connector.credentials = credentials[_ATTR_CONNECT_ARGS]
         self._connector.setup_connection()
@@ -113,7 +113,7 @@ class CustomEtlProxyClient(BaseProxyClient):
         """Fetch ETL run events from the connector.
 
         Translates the DC-facing parameters into the connector's
-        ``_fetch_run_details`` interface: ``lookback_min`` becomes a
+        ``fetch_run_details`` interface: ``lookback_min`` becomes a
         ``timedelta``, ``job_run_ids`` maps to ``run_ids``.  When
         ``job_ids`` is provided, results are post-filtered to include
         only runs whose ``job_source_id`` is in the set.

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -56,7 +56,7 @@ class CustomEtlProxyClient(BaseProxyClient):
 
     The connector module is expected to define a Connector class
     (inheriting from BaseEtlConnector) with methods: setup_connection,
-    close_connection, fetch_metadata, and _fetch_run_details.
+    close_connection, fetch_metadata, and fetch_run_details.
     """
 
     def __init__(
@@ -119,7 +119,7 @@ class CustomEtlProxyClient(BaseProxyClient):
         only runs whose ``job_source_id`` is in the set.
         """
         lookback = timedelta(minutes=lookback_min)
-        runs = self._connector._fetch_run_details(
+        runs = self._connector.fetch_run_details(
             run_ids=job_run_ids,
             lookback=lookback,
             limit=limit,

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -1,0 +1,190 @@
+import dataclasses
+import logging
+from datetime import timedelta
+from typing import Any, Dict, List, Optional
+
+from apollo.integrations.base_proxy_client import BaseProxyClient
+from apollo.integrations.custom_etl.custom_etl_connector_loader import (
+    get_custom_etl_connector_registry,
+    load_connector_module,
+    load_manifest,
+)
+
+logger = logging.getLogger(__name__)
+
+_ATTR_CONNECT_ARGS = "connect_args"
+
+
+def _serialize(obj: Any) -> Any:
+    """Serialize connector model objects to JSON-compatible dicts.
+
+    Handles dataclasses (via ``dataclasses.asdict``), objects with ``__dict__``,
+    and primitive/collection types.  ``None`` values are stripped from the
+    top-level dict so the response stays compact — downstream consumers treat
+    absent keys as null anyway.
+    """
+    if obj is None:
+        return None
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, list):
+        return [_serialize(item) for item in obj]
+    if isinstance(obj, dict):
+        return {k: _serialize(v) for k, v in obj.items()}
+    try:
+        if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+            return {
+                k: _serialize(v)
+                for k, v in dataclasses.asdict(obj).items()
+                if v is not None
+            }
+    except Exception:
+        pass
+    if hasattr(obj, "__dict__"):
+        return {
+            k: _serialize(v)
+            for k, v in obj.__dict__.items()
+            if not k.startswith("_") and v is not None
+        }
+    return str(obj)
+
+
+class CustomEtlProxyClient(BaseProxyClient):
+    """
+    Proxy client for custom ETL connectors loaded from
+    /opt/custom-etl-connectors/{name}/.
+
+    The connector module is expected to define a Connector class
+    (inheriting from BaseEtlConnector) with methods: setup_connection,
+    close_connection, fetch_metadata, and _fetch_run_details.
+    """
+
+    def __init__(
+        self,
+        credentials: Optional[Dict],
+        connector_dir: str,
+        **kwargs: Any,
+    ):
+        module = load_connector_module(connector_dir)
+        self._connector = module.Connector()
+
+        if not credentials or _ATTR_CONNECT_ARGS not in credentials:
+            raise ValueError(
+                f"Custom ETL connector agent client requires "
+                f"{_ATTR_CONNECT_ARGS} in credentials"
+            )
+
+        self._connector.credentials = credentials[_ATTR_CONNECT_ARGS]
+        self._connector.setup_connection()
+        self._manifest = load_manifest(connector_dir)
+
+        logger.info("Opened custom ETL connector from %s", connector_dir)
+
+    @property
+    def wrapped_client(self):
+        return self._connector
+
+    def test_connection(self) -> Dict[str, bool]:
+        """Connection is established in __init__; if we got here it succeeded."""
+        return {"success": True}
+
+    def fetch_etl_assets(
+        self,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Fetch ETL asset metadata from the connector.
+
+        Delegates to the connector's ``fetch_metadata`` and serializes the
+        returned model objects into the unified ETL asset shape expected by
+        the data-collector.
+        """
+        assets = self._connector.fetch_metadata(limit=limit, offset=offset)
+        return {"all_results": [_serialize(a) for a in assets]}
+
+    def fetch_etl_runs(
+        self,
+        lookback_min: int,
+        job_ids: Optional[List[str]] = None,
+        job_run_ids: Optional[List[str]] = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> Dict[str, Any]:
+        """Fetch ETL run events from the connector.
+
+        Translates the DC-facing parameters into the connector's
+        ``_fetch_run_details`` interface: ``lookback_min`` becomes a
+        ``timedelta``, ``job_run_ids`` maps to ``run_ids``.  When
+        ``job_ids`` is provided, results are post-filtered to include
+        only runs whose ``job_source_id`` is in the set.
+        """
+        lookback = timedelta(minutes=lookback_min)
+        runs = self._connector._fetch_run_details(
+            run_ids=job_run_ids,
+            lookback=lookback,
+            limit=limit,
+            offset=offset,
+        )
+        if job_ids:
+            allowed = set(job_ids)
+            runs = [r for r in runs if getattr(r, "job_source_id", None) in allowed]
+        return {"all_results": [_serialize(r) for r in runs]}
+
+    def get_manifest(self) -> Dict:
+        """Return the full manifest from manifest.json."""
+        return self._manifest
+
+    @staticmethod
+    def get_custom_etl_connector_types() -> List[Dict[str, str]]:
+        """
+        Return a lightweight list of supported custom ETL connector types.
+
+        Each entry contains:
+          - type: the connection_type identifier from the manifest
+          - name: the human-readable name (falls back to type)
+
+        Returns an empty list when no custom ETL connectors are installed.
+        """
+        registry = get_custom_etl_connector_registry()
+        result: List[Dict[str, str]] = []
+        for connection_type, connector_dir in registry.items():
+            manifest = load_manifest(connector_dir)
+            result.append(
+                {
+                    "type": connection_type,
+                    "name": manifest.get("name", connection_type),
+                }
+            )
+        return result
+
+    @staticmethod
+    def get_connection_manifests() -> Dict[str, Dict[str, Any]]:
+        """
+        Discover all custom ETL connectors and return their manifests.
+
+        Returns a dict keyed by connection_type, e.g.:
+            {
+                "custom-etl-connector-de8d7c2": {
+                    "manifest": {
+                        "connection_type": "custom-etl-connector-de8d7c2",
+                        "name": "adf",
+                        "terminology": {...},
+                        "icon_url": "..."
+                    }
+                }
+            }
+        """
+        registry = get_custom_etl_connector_registry()
+        result: Dict[str, Dict[str, Any]] = {}
+        for connection_type, connector_dir in registry.items():
+            result[connection_type] = {
+                "manifest": load_manifest(connector_dir),
+            }
+        return result
+
+    def close(self):
+        try:
+            self._connector.close_connection()
+            logger.info("Closed custom ETL connector connection")
+        except Exception:
+            logger.exception("Error closing custom ETL connector connection")

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -76,6 +76,11 @@ class Connector:
 
 
 class TestCustomEtlConnectorDiscovery(TestCase):
+    def tearDown(self):
+        import apollo.integrations.custom_etl.custom_etl_connector_loader as loader
+
+        loader._custom_etl_connector_registry = None
+
     def test_discovery_reads_manifests(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_etl_connector_dir(
@@ -525,6 +530,48 @@ class TestCustomEtlProxyClient(TestCase):
     @patch(
         "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
     )
+    def test_setup_connection_failure_propagates(
+        self, mock_load_module, mock_load_manifest
+    ):
+        mock_load_module.return_value = self._mock_module
+        self._mock_connector.setup_connection.side_effect = RuntimeError("auth failed")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            CustomEtlProxyClient(
+                credentials={"connect_args": {"tenant_id": "abc"}},
+                connector_dir="/opt/custom-etl-connectors/adf",
+            )
+        self.assertIn("auth failed", str(ctx.exception))
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_close_suppresses_exception(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        self._mock_connector.close_connection.side_effect = RuntimeError(
+            "disconnect failed"
+        )
+
+        # close() should not raise
+        client.close()
+        self._mock_connector.close_connection.assert_called_once()
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
     def test_wrapped_client_returns_connector(
         self, mock_load_module, mock_load_manifest
     ):
@@ -544,6 +591,11 @@ class TestCustomEtlProxyClient(TestCase):
 
 
 class TestGetConnectionManifests(TestCase):
+    def tearDown(self):
+        import apollo.integrations.custom_etl.custom_etl_connector_loader as loader
+
+        loader._custom_etl_connector_registry = None
+
     def test_returns_all_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_etl_connector_dir(
@@ -598,6 +650,11 @@ class TestGetConnectionManifests(TestCase):
 
 
 class TestGetCustomEtlConnectorTypes(TestCase):
+    def tearDown(self):
+        import apollo.integrations.custom_etl.custom_etl_connector_loader as loader
+
+        loader._custom_etl_connector_registry = None
+
     def test_returns_all_types(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_etl_connector_dir(tmp_dir, "adf", "custom-etl-connector-aaa")
@@ -740,6 +797,11 @@ class TestAgentGetSupportedConnectorTypes(TestCase):
 
 
 class TestProxyClientFactory(TestCase):
+    def tearDown(self):
+        import apollo.integrations.custom_etl.custom_etl_connector_loader as loader
+
+        loader._custom_etl_connector_registry = None
+
     @patch(
         "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
         "/nonexistent",

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -61,7 +61,7 @@ class Connector:
     def fetch_metadata(self, limit=1000, offset=0):
         return []
 
-    def _fetch_run_details(self, run_ids=None, lookback=None, limit=100, offset=0):
+    def fetch_run_details(self, run_ids=None, lookback=None, limit=100, offset=0):
         return []
 """
     with open(os.path.join(connector_dir, "connector.py"), "w") as f:
@@ -371,7 +371,7 @@ class TestCustomEtlProxyClient(TestCase):
             job_source_id="job-1", run_source_id="run-1", status="success"
         )
         run2 = _FakeModel(job_source_id="job-1", run_source_id="run-2", status="failed")
-        self._mock_connector._fetch_run_details.return_value = [run1, run2]
+        self._mock_connector.fetch_run_details.return_value = [run1, run2]
 
         client = CustomEtlProxyClient(
             credentials={"connect_args": {}},
@@ -379,7 +379,7 @@ class TestCustomEtlProxyClient(TestCase):
         )
         result = client.fetch_etl_runs(lookback_min=1440, limit=100, offset=0)
 
-        self._mock_connector._fetch_run_details.assert_called_once_with(
+        self._mock_connector.fetch_run_details.assert_called_once_with(
             run_ids=None,
             lookback=timedelta(minutes=1440),
             limit=100,
@@ -403,7 +403,7 @@ class TestCustomEtlProxyClient(TestCase):
         run1 = _FakeModel(
             job_source_id="job-1", run_source_id="run-1", status="success"
         )
-        self._mock_connector._fetch_run_details.return_value = [run1]
+        self._mock_connector.fetch_run_details.return_value = [run1]
 
         client = CustomEtlProxyClient(
             credentials={"connect_args": {}},
@@ -416,7 +416,7 @@ class TestCustomEtlProxyClient(TestCase):
             offset=10,
         )
 
-        self._mock_connector._fetch_run_details.assert_called_once_with(
+        self._mock_connector.fetch_run_details.assert_called_once_with(
             run_ids=["run-1"],
             lookback=timedelta(minutes=720),
             limit=50,
@@ -441,7 +441,7 @@ class TestCustomEtlProxyClient(TestCase):
         run2 = _FakeModel(
             job_source_id="job-2", run_source_id="run-2", status="success"
         )
-        self._mock_connector._fetch_run_details.return_value = [run1, run2]
+        self._mock_connector.fetch_run_details.return_value = [run1, run2]
 
         client = CustomEtlProxyClient(
             credentials={"connect_args": {}},
@@ -467,7 +467,7 @@ class TestCustomEtlProxyClient(TestCase):
     )
     def test_fetch_etl_runs_empty(self, mock_load_module, mock_load_manifest):
         mock_load_module.return_value = self._mock_module
-        self._mock_connector._fetch_run_details.return_value = []
+        self._mock_connector.fetch_run_details.return_value = []
 
         client = CustomEtlProxyClient(
             credentials={"connect_args": {}},

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -1,0 +1,787 @@
+import json
+import os
+import tempfile
+from datetime import timedelta
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from apollo.integrations.custom_etl.custom_etl_connector_loader import (
+    _discover_custom_etl_connectors,
+    load_connector_module,
+    load_manifest,
+)
+from apollo.agent.agent import Agent
+from apollo.integrations.custom_etl.custom_etl_proxy_client import (
+    CustomEtlProxyClient,
+    _serialize,
+)
+
+
+class _FakeModel:
+    """Lightweight stand-in for connector model objects (EtlAsset / EtlRunEvent)."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+def _create_mock_etl_connector_dir(
+    tmp_dir,
+    name,
+    connection_type,
+    terminology=None,
+    icon_url=None,
+):
+    """Helper to create a mock ETL connector directory structure."""
+    connector_dir = os.path.join(tmp_dir, name)
+    os.makedirs(connector_dir, exist_ok=True)
+
+    manifest = {
+        "connection_type": connection_type,
+        "name": name,
+    }
+    if terminology is not None:
+        manifest["terminology"] = terminology
+    if icon_url is not None:
+        manifest["icon_url"] = icon_url
+    with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
+        json.dump(manifest, f)
+
+    # connector.py — mock Connector class mimicking BaseEtlConnector interface
+    connector_code = """
+class Connector:
+    credentials = {}
+
+    def setup_connection(self):
+        pass
+
+    def close_connection(self):
+        pass
+
+    def fetch_metadata(self, limit=1000, offset=0):
+        return []
+
+    def _fetch_run_details(self, run_ids=None, lookback=None, limit=100, offset=0):
+        return []
+"""
+    with open(os.path.join(connector_dir, "connector.py"), "w") as f:
+        f.write(connector_code)
+
+    return connector_dir
+
+
+# ---------------------------------------------------------------------------
+# Loader tests
+# ---------------------------------------------------------------------------
+
+
+class TestCustomEtlConnectorDiscovery(TestCase):
+    def test_discovery_reads_manifests(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(
+                tmp_dir, "adf", "custom-etl-connector-de8d7c2"
+            )
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ):
+                registry = _discover_custom_etl_connectors()
+
+            self.assertIn("custom-etl-connector-de8d7c2", registry)
+            self.assertEqual(
+                registry["custom-etl-connector-de8d7c2"],
+                os.path.join(tmp_dir, "adf"),
+            )
+
+    def test_multiple_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(tmp_dir, "adf", "custom-etl-connector-aaa")
+            _create_mock_etl_connector_dir(
+                tmp_dir, "airflow", "custom-etl-connector-bbb"
+            )
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ):
+                registry = _discover_custom_etl_connectors()
+
+            self.assertEqual(len(registry), 2)
+            self.assertIn("custom-etl-connector-aaa", registry)
+            self.assertIn("custom-etl-connector-bbb", registry)
+
+    def test_discovery_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ):
+                registry = _discover_custom_etl_connectors()
+
+            self.assertEqual(registry, {})
+
+    def test_discovery_missing_directory(self):
+        with patch(
+            "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+            "/nonexistent/path",
+        ):
+            registry = _discover_custom_etl_connectors()
+
+        self.assertEqual(registry, {})
+
+    def test_discovery_skips_missing_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.makedirs(os.path.join(tmp_dir, "bad_integration"))
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ):
+                registry = _discover_custom_etl_connectors()
+
+            self.assertEqual(registry, {})
+
+
+class TestLoadConnectorModule(TestCase):
+    def test_successful_load(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(tmp_dir, "adf", "custom-etl-connector-abc")
+            connector_dir = os.path.join(tmp_dir, "adf")
+
+            module = load_connector_module(connector_dir)
+
+            self.assertTrue(hasattr(module, "Connector"))
+            connector = module.Connector()
+            # Should not raise
+            connector.setup_connection()
+
+    def test_missing_connector_py(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(FileNotFoundError) as ctx:
+                load_connector_module(tmp_dir)
+            self.assertIn("connector.py not found", str(ctx.exception))
+
+    def test_syntax_error_in_connector(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            connector_path = os.path.join(tmp_dir, "connector.py")
+            with open(connector_path, "w") as f:
+                f.write("class Connector:\n    def bad_method(self\n")
+
+            with self.assertRaises(SyntaxError):
+                load_connector_module(tmp_dir)
+
+
+class TestLoadManifest(TestCase):
+    def test_load_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            manifest = {
+                "connection_type": "custom-etl-connector-abc",
+                "name": "adf",
+                "terminology": {"group": "Factory", "job": "Pipeline"},
+            }
+            with open(os.path.join(tmp_dir, "manifest.json"), "w") as f:
+                json.dump(manifest, f)
+
+            result = load_manifest(tmp_dir)
+
+            self.assertEqual(result, manifest)
+
+    def test_load_manifest_no_file(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = load_manifest(tmp_dir)
+            self.assertEqual(result, {})
+
+
+# ---------------------------------------------------------------------------
+# Serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerialize(TestCase):
+    def test_serialize_dict(self):
+        self.assertEqual(_serialize({"a": 1, "b": "c"}), {"a": 1, "b": "c"})
+
+    def test_serialize_strips_none_from_dataclass(self):
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Sample:
+            name: str
+            value: int = None
+
+        obj = Sample(name="test", value=None)
+        result = _serialize(obj)
+        self.assertEqual(result, {"name": "test"})
+
+    def test_serialize_nested_dataclass(self):
+        import dataclasses
+
+        @dataclasses.dataclass
+        class Inner:
+            key: str
+            value: str
+
+        @dataclasses.dataclass
+        class Outer:
+            name: str
+            tags: list
+
+        obj = Outer(name="job1", tags=[Inner(key="env", value="prod")])
+        result = _serialize(obj)
+        self.assertEqual(
+            result, {"name": "job1", "tags": [{"key": "env", "value": "prod"}]}
+        )
+
+    def test_serialize_plain_object(self):
+        class Obj:
+            def __init__(self):
+                self.name = "test"
+                self._private = "hidden"
+                self.empty = None
+
+        result = _serialize(Obj())
+        self.assertEqual(result, {"name": "test"})
+
+    def test_serialize_primitives(self):
+        self.assertEqual(_serialize("hello"), "hello")
+        self.assertEqual(_serialize(42), 42)
+        self.assertIsNone(_serialize(None))
+
+
+# ---------------------------------------------------------------------------
+# Proxy client tests
+# ---------------------------------------------------------------------------
+
+
+class TestCustomEtlProxyClient(TestCase):
+    def setUp(self):
+        self._mock_module = MagicMock()
+        self._mock_connector = MagicMock()
+        self._mock_module.Connector.return_value = self._mock_connector
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={
+            "connection_type": "custom-etl-connector-abc",
+            "name": "adf",
+        },
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_test_connection(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {"tenant_id": "abc"}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.test_connection()
+
+        self.assertEqual(result, {"success": True})
+        self._mock_connector.setup_connection.assert_called_once()
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_missing_connect_args_raises(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        with self.assertRaises(ValueError) as ctx:
+            CustomEtlProxyClient(
+                credentials={"key": "value"},
+                connector_dir="/opt/custom-etl-connectors/adf",
+            )
+        self.assertIn("connect_args", str(ctx.exception))
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_none_credentials_raises(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        with self.assertRaises(ValueError):
+            CustomEtlProxyClient(
+                credentials=None,
+                connector_dir="/opt/custom-etl-connectors/adf",
+            )
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_assets(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+        asset1 = _FakeModel(job_source_id="job-1", name="Daily load")
+        asset2 = _FakeModel(job_source_id="job-2", name="Hourly sync")
+        self._mock_connector.fetch_metadata.return_value = [asset1, asset2]
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {"tenant_id": "abc"}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_assets(limit=100, offset=0)
+
+        self._mock_connector.fetch_metadata.assert_called_once_with(limit=100, offset=0)
+        self.assertEqual(len(result["all_results"]), 2)
+        self.assertEqual(result["all_results"][0]["job_source_id"], "job-1")
+        self.assertEqual(result["all_results"][1]["job_source_id"], "job-2")
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_assets_empty(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+        self._mock_connector.fetch_metadata.return_value = []
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_assets(limit=100, offset=0)
+
+        self.assertEqual(result, {"all_results": []})
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_runs(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+        run1 = _FakeModel(
+            job_source_id="job-1", run_source_id="run-1", status="success"
+        )
+        run2 = _FakeModel(job_source_id="job-1", run_source_id="run-2", status="failed")
+        self._mock_connector._fetch_run_details.return_value = [run1, run2]
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_runs(lookback_min=1440, limit=100, offset=0)
+
+        self._mock_connector._fetch_run_details.assert_called_once_with(
+            run_ids=None,
+            lookback=timedelta(minutes=1440),
+            limit=100,
+            offset=0,
+        )
+        self.assertEqual(len(result["all_results"]), 2)
+        self.assertEqual(result["all_results"][0]["run_source_id"], "run-1")
+        self.assertEqual(result["all_results"][1]["status"], "failed")
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_runs_with_job_run_ids(
+        self, mock_load_module, mock_load_manifest
+    ):
+        mock_load_module.return_value = self._mock_module
+        run1 = _FakeModel(
+            job_source_id="job-1", run_source_id="run-1", status="success"
+        )
+        self._mock_connector._fetch_run_details.return_value = [run1]
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_runs(
+            lookback_min=720,
+            job_run_ids=["run-1"],
+            limit=50,
+            offset=10,
+        )
+
+        self._mock_connector._fetch_run_details.assert_called_once_with(
+            run_ids=["run-1"],
+            lookback=timedelta(minutes=720),
+            limit=50,
+            offset=10,
+        )
+        self.assertEqual(len(result["all_results"]), 1)
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_runs_filters_by_job_ids(
+        self, mock_load_module, mock_load_manifest
+    ):
+        mock_load_module.return_value = self._mock_module
+        run1 = _FakeModel(
+            job_source_id="job-1", run_source_id="run-1", status="success"
+        )
+        run2 = _FakeModel(
+            job_source_id="job-2", run_source_id="run-2", status="success"
+        )
+        self._mock_connector._fetch_run_details.return_value = [run1, run2]
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_runs(
+            lookback_min=1440,
+            job_ids=["job-1"],
+            limit=100,
+            offset=0,
+        )
+
+        # Only run1 should be included (job_ids filter)
+        self.assertEqual(len(result["all_results"]), 1)
+        self.assertEqual(result["all_results"][0]["job_source_id"], "job-1")
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_fetch_etl_runs_empty(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+        self._mock_connector._fetch_run_details.return_value = []
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.fetch_etl_runs(lookback_min=1440, limit=100, offset=0)
+
+        self.assertEqual(result, {"all_results": []})
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={
+            "connection_type": "custom-etl-connector-abc",
+            "name": "adf",
+            "terminology": {"group": "Factory"},
+        },
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_get_manifest(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.get_manifest()
+
+        self.assertEqual(result["name"], "adf")
+        self.assertEqual(result["terminology"], {"group": "Factory"})
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_close(self, mock_load_module, mock_load_manifest):
+        mock_load_module.return_value = self._mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        client.close()
+
+        self._mock_connector.close_connection.assert_called_once()
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_wrapped_client_returns_connector(
+        self, mock_load_module, mock_load_manifest
+    ):
+        mock_load_module.return_value = self._mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+
+        self.assertEqual(client.wrapped_client, self._mock_connector)
+
+
+# ---------------------------------------------------------------------------
+# Discovery static method tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnectionManifests(TestCase):
+    def test_returns_all_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(
+                tmp_dir,
+                "adf",
+                "custom-etl-connector-aaa",
+                terminology={"group": "Factory", "job": "Pipeline"},
+                icon_url="https://example.com/icon.png",
+            )
+            _create_mock_etl_connector_dir(
+                tmp_dir,
+                "airflow",
+                "custom-etl-connector-bbb",
+            )
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_connection_manifests()
+
+            self.assertEqual(len(result), 2)
+
+            self.assertIn("custom-etl-connector-aaa", result)
+            aaa = result["custom-etl-connector-aaa"]
+            self.assertEqual(
+                aaa["manifest"]["connection_type"], "custom-etl-connector-aaa"
+            )
+            self.assertEqual(aaa["manifest"]["name"], "adf")
+            self.assertEqual(
+                aaa["manifest"]["terminology"],
+                {"group": "Factory", "job": "Pipeline"},
+            )
+
+            self.assertIn("custom-etl-connector-bbb", result)
+
+    def test_returns_empty_when_no_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_connection_manifests()
+
+            self.assertEqual(result, {})
+
+
+class TestGetCustomEtlConnectorTypes(TestCase):
+    def test_returns_all_types(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(tmp_dir, "adf", "custom-etl-connector-aaa")
+            _create_mock_etl_connector_dir(
+                tmp_dir, "airflow", "custom-etl-connector-bbb"
+            )
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_custom_etl_connector_types()
+
+            self.assertEqual(len(result), 2)
+            types_by_id = {entry["type"]: entry["name"] for entry in result}
+            self.assertEqual(types_by_id["custom-etl-connector-aaa"], "adf")
+            self.assertEqual(types_by_id["custom-etl-connector-bbb"], "airflow")
+
+    def test_returns_empty_list_when_no_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_custom_etl_connector_types()
+
+            self.assertEqual(result, [])
+
+    def test_falls_back_to_type_when_no_name(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            connector_dir = os.path.join(tmp_dir, "noname")
+            os.makedirs(connector_dir)
+            with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
+                json.dump({"connection_type": "custom-etl-connector-xyz"}, f)
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_custom_etl_connector_types()
+
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result[0]["type"], "custom-etl-connector-xyz")
+            self.assertEqual(result[0]["name"], "custom-etl-connector-xyz")
+
+
+# ---------------------------------------------------------------------------
+# Agent integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentGetConnectionManifests(TestCase):
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        return_value={},
+    )
+    def test_returns_ok_response(self, _mock_custom, _mock_etl):
+        a = Agent(None)
+        response = a.get_connection_manifests(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_result__", response.result)
+        self.assertEqual(response.result["__mcd_result__"], {})
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        side_effect=RuntimeError("boom"),
+    )
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        return_value={},
+    )
+    def test_returns_error_on_failure(self, _mock_custom, _mock_etl):
+        a = Agent(None)
+        response = a.get_connection_manifests(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_error__", response.result)
+
+
+class TestAgentGetSupportedConnectorTypes(TestCase):
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        return_value={},
+    )
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        return_value={},
+    )
+    def test_returns_native_custom_and_custom_etl(self, _mock_custom, _mock_etl):
+        a = Agent(None)
+        response = a.get_supported_connector_types(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_result__", response.result)
+        result = response.result["__mcd_result__"]
+        self.assertIn("connector_types", result)
+        self.assertIn("native", result["connector_types"])
+        self.assertIn("custom", result["connector_types"])
+        self.assertIn("custom_etl", result["connector_types"])
+        # native should contain known built-in types
+        native = result["connector_types"]["native"]
+        self.assertIn("bigquery", native)
+        self.assertIn("snowflake", native)
+        # custom_etl is empty because registry is mocked empty
+        self.assertEqual(result["connector_types"]["custom_etl"], [])
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        side_effect=RuntimeError("boom"),
+    )
+    @patch(
+        "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
+        return_value={},
+    )
+    def test_returns_error_on_failure(self, _mock_custom, _mock_etl):
+        a = Agent(None)
+        response = a.get_supported_connector_types(trace_id="test-trace")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("__mcd_error__", response.result)
+
+
+# ---------------------------------------------------------------------------
+# Factory integration test
+# ---------------------------------------------------------------------------
+
+
+class TestProxyClientFactory(TestCase):
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+        "/nonexistent",
+    )
+    @patch.dict(os.environ, {"MCD_CUSTOM_CONNECTORS_ENABLED": "true"})
+    def test_custom_etl_connector_lookup(self):
+        """Factory routes custom-etl-connector types to CustomEtlProxyClient."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _create_mock_etl_connector_dir(
+                tmp_dir, "adf", "custom-etl-connector-de8d7c2"
+            )
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ), patch(
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
+                {},
+            ):
+                from apollo.agent.proxy_client_factory import ProxyClientFactory
+
+                client = ProxyClientFactory._create_proxy_client(
+                    connection_type="custom-etl-connector-de8d7c2",
+                    credentials={"connect_args": {"tenant_id": "abc"}},
+                    platform="generic",
+                )
+
+            self.assertIsInstance(client, CustomEtlProxyClient)
+            client.close()
+
+    @patch.dict(os.environ, {"MCD_CUSTOM_CONNECTORS_ENABLED": "false"})
+    def test_custom_etl_connector_disabled(self):
+        """When custom connectors are disabled, custom ETL types raise."""
+        from apollo.agent.proxy_client_factory import ProxyClientFactory
+        from apollo.common.agent.models import AgentError
+
+        with self.assertRaises(AgentError):
+            ProxyClientFactory._create_proxy_client(
+                connection_type="custom-etl-connector-de8d7c2",
+                credentials={"connect_args": {}},
+                platform="generic",
+            )

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -609,10 +609,14 @@ class TestGetConnectionManifests(TestCase):
 
 class TestAgentGetConnectionManifests(TestCase):
     @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        return_value={},
+    )
+    @patch(
         "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
         return_value={},
     )
-    def test_returns_ok_response(self, _mock_registry):
+    def test_returns_ok_response(self, _mock_registry, _mock_etl_registry):
         agent = Agent(None)
         response = agent.get_connection_manifests(trace_id="test-trace")
 
@@ -690,10 +694,14 @@ class TestGetCustomConnectorTypes(TestCase):
 
 class TestAgentGetSupportedConnectorTypes(TestCase):
     @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.get_custom_etl_connector_registry",
+        return_value={},
+    )
+    @patch(
         "apollo.integrations.custom.custom_proxy_client.get_custom_connector_registry",
         return_value={},
     )
-    def test_returns_native_and_custom(self, _mock_registry):
+    def test_returns_native_and_custom(self, _mock_registry, _mock_etl_registry):
         agent = Agent(None)
         response = agent.get_supported_connector_types(trace_id="test-trace")
 
@@ -703,6 +711,7 @@ class TestAgentGetSupportedConnectorTypes(TestCase):
         self.assertIn("connector_types", result)
         self.assertIn("native", result["connector_types"])
         self.assertIn("custom", result["connector_types"])
+        self.assertIn("custom_etl", result["connector_types"])
         # native should contain known built-in types
         native = result["connector_types"]["native"]
         self.assertIn("bigquery", native)
@@ -710,8 +719,9 @@ class TestAgentGetSupportedConnectorTypes(TestCase):
         self.assertIn("postgres", native)
         # native list should be sorted
         self.assertEqual(native, sorted(native))
-        # custom is empty because registry is mocked empty
+        # custom and custom_etl are empty because registries are mocked empty
         self.assertEqual(result["connector_types"]["custom"], [])
+        self.assertEqual(result["connector_types"]["custom_etl"], [])
         self.assertEqual(response.trace_id, "test-trace")
 
     @patch(


### PR DESCRIPTION
## Summary
- Add runtime-loaded custom ETL connector infrastructure at `apollo/integrations/custom_etl/`, mirroring the existing custom (warehouse) connector scaffolding
- `CustomEtlProxyClient` wraps `Connector(BaseEtlConnector)` modules loaded from `/opt/custom-etl-connectors/{name}/`, exposing `fetch_etl_assets` and `fetch_etl_runs` methods that match the agent calls in data-collector PR #2390
- Factory routes `custom-etl-connector-<hash>` connection types through the new proxy client (gated by `MCD_CUSTOM_CONNECTORS_ENABLED`)
- Discovery endpoints (`/api/v1/agent/connectors/types` and `/api/v1/agent/custom-connectors/manifests`) now return custom ETL connector types and manifests alongside existing native/custom entries

## Related issues and PRs
- [YET-1178](https://linear.app/montecarloai/issue/YET-1178)
- data-collector [PR #2390](https://github.com/monte-carlo-data/data-collector/pull/2390) (DC-side agent calls)

## Test plan
- [x] 40 new tests in \`tests/test_custom_etl_proxy_client.py\` covering loader, serialization, proxy client, discovery, agent integration, and factory routing
- [x] Existing \`test_custom_proxy_client.py\` (33 tests) updated and passing
- [x] \`test_proxy_client_factory.py\` passing
- [x] pyright clean on new modules (0 errors)
- [ ] CI passes
- [x] Ran \`/code-review\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)