### PR TITLE
fix(ctp): guard ssl_options when-clauses against None

### DIFF
--- a/apollo/integrations/ctp/defaults/db2.py
+++ b/apollo/integrations/ctp/defaults/db2.py
@@ -55,7 +55,7 @@ DB2_DEFAULT_CTP = CtpConfig(
         TransformStep(
             type="tmp_file_write",
             when=(
-                "raw.ssl_options is defined"
+                "raw.ssl_options is mapping"
                 " and raw.ssl_options.ca_data is defined"
                 " and not (raw.ssl_options.disabled is defined and raw.ssl_options.disabled)"
             ),

--- a/apollo/integrations/ctp/defaults/git.py
+++ b/apollo/integrations/ctp/defaults/git.py
@@ -33,7 +33,7 @@ GIT_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined",
+            when="raw.ssl_options is mapping",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={
                 "ssl_options": "ssl_options",  # derived.ssl_options for condition access

--- a/apollo/integrations/ctp/defaults/http.py
+++ b/apollo/integrations/ctp/defaults/http.py
@@ -18,7 +18,7 @@ HTTP_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="tmp_file_write",
-            when="raw.ssl_options is defined and raw.ssl_options.ca_data is defined",
+            when="raw.ssl_options is mapping and raw.ssl_options.ca_data is defined",
             input={
                 "contents": "{{ raw.ssl_options.ca_data }}",
                 "file_suffix": ".pem",
@@ -41,7 +41,7 @@ HTTP_DEFAULT_CTP = CtpConfig(
             "auth_type": "{{ '' if (raw.auth_type is defined and raw.auth_type is none) else (raw.auth_type | default(none)) }}",
             # ssl_verify: pass through a pre-resolved path/bool (DC pre-shaped path),
             # or derive from ssl_options when present in raw credentials.
-            "ssl_verify": "{{ raw.ssl_verify if raw.ssl_verify is defined else (false if raw.ssl_options is defined and raw.ssl_options.disabled else none) }}",
+            "ssl_verify": "{{ raw.ssl_verify if raw.ssl_verify is defined else (false if raw.ssl_options is mapping and raw.ssl_options.disabled else none) }}",
         },
     ),
 )

--- a/apollo/integrations/ctp/defaults/mysql.py
+++ b/apollo/integrations/ctp/defaults/mysql.py
@@ -99,7 +99,7 @@ MYSQL_DEFAULT_CTP = CtpConfig(
         # Remote CA: download cert from URL/storage, pass as {"ca": path}
         TransformStep(
             type="fetch_remote_file",
-            when="raw.ssl_options is defined and raw.ssl_options.ca is defined",
+            when="raw.ssl_options is mapping and raw.ssl_options.ca is defined",
             input={
                 "url": "{{ raw.ssl_options.ca }}",
                 "sub_folder": "mysql",
@@ -113,7 +113,7 @@ MYSQL_DEFAULT_CTP = CtpConfig(
         # Inline cert data: build SSLContext from ca_data / cert_data / key_data
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined and raw.ssl_options.ca is not defined",
+            when="raw.ssl_options is mapping and raw.ssl_options.ca is not defined",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={"ssl_context": "ssl_context"},
             field_map={

--- a/apollo/integrations/ctp/defaults/postgres.py
+++ b/apollo/integrations/ctp/defaults/postgres.py
@@ -56,7 +56,7 @@ POSTGRES_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined",
+            when="raw.ssl_options is mapping",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={
                 "ssl_options": "ssl_options",

--- a/apollo/integrations/ctp/defaults/redshift.py
+++ b/apollo/integrations/ctp/defaults/redshift.py
@@ -61,7 +61,7 @@ REDSHIFT_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined",
+            when="raw.ssl_options is mapping",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={
                 "ssl_options": "ssl_options",

--- a/apollo/integrations/ctp/defaults/starburst_enterprise.py
+++ b/apollo/integrations/ctp/defaults/starburst_enterprise.py
@@ -61,7 +61,7 @@ STARBURST_ENTERPRISE_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined",
+            when="raw.ssl_options is mapping",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={
                 "ssl_options": "ssl_options",  # derived.ssl_options for condition access

--- a/apollo/integrations/ctp/defaults/starburst_galaxy.py
+++ b/apollo/integrations/ctp/defaults/starburst_galaxy.py
@@ -59,7 +59,7 @@ STARBURST_GALAXY_DEFAULT_CTP = CtpConfig(
     steps=[
         TransformStep(
             type="resolve_ssl_options",
-            when="raw.ssl_options is defined",
+            when="raw.ssl_options is mapping",
             input={"ssl_options": "{{ raw.ssl_options }}"},
             output={
                 "ssl_options": "ssl_options",  # derived.ssl_options for condition access

--- a/apollo/integrations/ctp/defaults/teradata.py
+++ b/apollo/integrations/ctp/defaults/teradata.py
@@ -71,7 +71,7 @@ TERADATA_DEFAULT_CTP = CtpConfig(
         TransformStep(
             type="tmp_file_write",
             when=(
-                "raw.ssl_options is defined"
+                "raw.ssl_options is mapping"
                 " and raw.ssl_options.ca_data is defined"
                 " and not (raw.ssl_options.disabled is defined and raw.ssl_options.disabled)"
             ),

--- a/tests/ctp/test_ssl_options_none_guard.py
+++ b/tests/ctp/test_ssl_options_none_guard.py
@@ -1,0 +1,114 @@
+"""Regression suite: every CTP default that consumes ``ssl_options`` must
+skip its ssl resolution step(s) when the field arrives as ``None``.
+
+Background: the data-collector serializes ``PluginConnectionSchema.ssl_options:
+Optional[dict] = None`` straight into the credential payload. For customers
+without SSL configured, the field arrives at the agent as the literal Python
+``None``. Jinja2 considers ``None`` to be ``is defined`` (the value exists in
+the namespace, even if it is None), and attribute access on ``None`` returns
+``Undefined``, so guard expressions of the form
+``raw.ssl_options is defined and raw.ssl_options.X is not defined`` evaluate
+True on ``None`` — the step fires, the ``{{ raw.ssl_options }}`` template
+renders to None, and the downstream transform rejects the non-dict input.
+
+Each ``when`` clause that references ``raw.ssl_options`` must explicitly check
+mapping-ness (e.g. ``raw.ssl_options is mapping``), so missing / None / non-dict
+values short-circuit before any field traversal.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from apollo.integrations.ctp.defaults.db2 import DB2_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.git import GIT_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.http import HTTP_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.mysql import MYSQL_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.postgres import POSTGRES_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.redshift import REDSHIFT_DEFAULT_CTP
+from apollo.integrations.ctp.defaults.starburst_enterprise import (
+    STARBURST_ENTERPRISE_DEFAULT_CTP,
+)
+from apollo.integrations.ctp.defaults.starburst_galaxy import (
+    STARBURST_GALAXY_DEFAULT_CTP,
+)
+from apollo.integrations.ctp.defaults.teradata import TERADATA_DEFAULT_CTP
+from apollo.integrations.ctp.models import CtpConfig
+from apollo.integrations.ctp.pipeline import CtpPipeline
+
+
+_MYSQL_FLAT = {
+    "host": "db.example.com",
+    "port": "3306",
+    "user": "admin",
+    "password": "secret",
+}
+_POSTGRES_FLAT = {
+    "host": "db.example.com",
+    "port": "5432",
+    "user": "admin",
+    "password": "secret",
+    "database": "appdb",
+}
+_REDSHIFT_FLAT = {
+    "host": "rs.example.com",
+    "port": "5439",
+    "user": "admin",
+    "password": "secret",
+    "database": "dev",
+}
+_GIT_FLAT = {
+    "repo_url": "git@github.com:foo/bar.git",
+    "ssh_key": "ZmFrZQ==",
+}
+_HTTP_FLAT: dict[str, str] = {}
+_STARBURST_FLAT = {
+    "host": "trino.example.com",
+    "port": "443",
+    "user": "admin",
+    "password": "secret",
+    "catalog": "hive",
+}
+_DB2_FLAT = {
+    "host": "db2.example.com",
+    "port": "50000",
+    "user": "admin",
+    "password": "secret",
+    "database": "appdb",
+}
+_TERADATA_FLAT = {
+    "host": "td.example.com",
+    "port": "1025",
+    "user": "admin",
+    "password": "secret",
+}
+
+
+# Each tuple: (label, ctp_config, base_flat_credentials).
+# Tests run the pipeline with ssl_options=None added to base credentials and
+# assert the pipeline completes — i.e. the ssl-resolution step(s) skipped.
+_DEFAULTS_WITH_SSL_OPTIONS: list[tuple[str, CtpConfig, dict[str, Any]]] = [
+    ("mysql", MYSQL_DEFAULT_CTP, _MYSQL_FLAT),
+    ("postgres", POSTGRES_DEFAULT_CTP, _POSTGRES_FLAT),
+    ("redshift", REDSHIFT_DEFAULT_CTP, _REDSHIFT_FLAT),
+    ("git", GIT_DEFAULT_CTP, _GIT_FLAT),
+    ("http", HTTP_DEFAULT_CTP, _HTTP_FLAT),
+    ("starburst_enterprise", STARBURST_ENTERPRISE_DEFAULT_CTP, _STARBURST_FLAT),
+    ("starburst_galaxy", STARBURST_GALAXY_DEFAULT_CTP, _STARBURST_FLAT),
+    ("db2", DB2_DEFAULT_CTP, _DB2_FLAT),
+    ("teradata", TERADATA_DEFAULT_CTP, _TERADATA_FLAT),
+]
+
+
+@pytest.mark.parametrize(
+    "ctp,base",
+    [(ctp, base) for _, ctp, base in _DEFAULTS_WITH_SSL_OPTIONS],
+    ids=[label for label, _, _ in _DEFAULTS_WITH_SSL_OPTIONS],
+)
+def test_ssl_options_none_is_skipped(ctp: CtpConfig, base: dict[str, Any]) -> None:
+    """Pipeline must tolerate ``ssl_options: None`` (DC's serialized default
+    for customers without SSL) without raising."""
+    creds = {**base, "ssl_options": None}
+    CtpPipeline().execute(ctp, creds)


### PR DESCRIPTION
## Summary

- The data-collector serializes `PluginConnectionSchema.ssl_options: Optional[dict] = None` straight into the credential payload — for any customer without SSL configured, the field arrives at the agent as the literal Python `None`.
- Jinja2's `is defined` returns True for None (a value of None is considered "defined"), and attribute access on None returns `Undefined` — so guards of the form `raw.ssl_options is defined and raw.ssl_options.X is not defined` evaluate True on None, the ssl-resolution step fires with `{{ raw.ssl_options }}` rendering to None, and the downstream transform's strict type check raises `'ssl_options' must resolve to a dict, got NoneType`. Observed in dev for MySQL.
- Fix: switch every `raw.ssl_options` guard to `is mapping` (a Jinja2 built-in for `abc.Mapping`-like values). This correctly handles missing keys, None, and non-dict types in one expression — vulnerable defaults now skip the step cleanly, and already-safe defaults gain a consistent convention.

## Scope

| File | Was vulnerable? | Change |
|---|---|---|
| `defaults/mysql.py` | Yes (2nd step) | both `when` clauses |
| `defaults/postgres.py` | Yes | `when` clause |
| `defaults/redshift.py` | Yes | `when` clause |
| `defaults/git.py` | Yes | `when` clause |
| `defaults/http.py` | Yes (mapper-side) | `when` clause + mapper field_map |
| `defaults/starburst_enterprise.py` | Yes | `when` clause |
| `defaults/starburst_galaxy.py` | Yes | `when` clause |
| `defaults/db2.py` | Safe by accident | hardened for consistency |
| `defaults/teradata.py` | Safe by accident | hardened for consistency |
| `tests/ctp/test_ssl_options_none_guard.py` | — | NEW — parametrized regression over 9 defaults |

## Test plan

- [x] New regression test `tests/ctp/test_ssl_options_none_guard.py` — 7 of 9 parametrized cases fail before the fix (exactly the vulnerable defaults: mysql, postgres, redshift, git, http, starburst_enterprise, starburst_galaxy); all 9 pass after
- [x] Full CTP test suite: 512 passed, 0 failed
- [x] Related proxy-client tests (`test_proxy_client_factory`, `test_redshift_client`, `test_http_client`, `test_ms_fabric_client`): 119 passed
- [x] `black --check` clean on changed files
- [x] `pyright` clean on changed files (0 errors, 0 warnings)
- [ ] Verify in dev environment: connection validation for a MySQL connection without SSL configured no longer raises

## Out of scope

- DC's `plugin_mysql.py:50` (`credentials.get("ssl_options", {})`) returns None when the key exists with value None — a defense-in-depth fix (`credentials.get("ssl_options") or {}`) is worth a follow-up PR but the agent-side fix here is the right primary defense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)