### PR TITLE
chore(security): bump teradatasql 20.0.0.60 -> 20.0.0.61

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -50,7 +50,7 @@ tableauserverclient==0.25 ; python_version < "3.10"
 tableauserverclient==0.38 ; python_version >= "3.10"
 urllib3~=2.7  # CVE-2026-44431, CVE-2026-44432
 
-teradatasql>=20.0.0.60  # 20.0.0.60 bumps embedded golang.org/x/crypto 0.47.0->0.52.0 (closes CVE-2026-39829/-39830/-39831/-39832/-39833/-39834/-42508/-46595/-46597) and golang.org/x/net 0.49.0->0.54.0 (closes CVE-2026-33814); Go stdlib still 1.26.3. Still bundled at vulnerable versions: x/net 0.54.0 (CVE-2026-39821 needs >=0.55.0) + thrift 0.22.0 (CVE-2026-41602 needs >=0.23.0), pending upstream
+teradatasql>=20.0.0.61  # 20.0.0.61 resolves the last teradata-bundled HIGH/CRITICAL from the daily scan: drops the standalone golang.org/x/net (was 0.54.0, CVE-2026-39821) and github.com/apache/thrift (was 0.22.0, CVE-2026-41602 — module now entirely absent from the .so) deps, and bumps the Go toolchain 1.26.3->1.26.4 (closes stdlib CVE-2026-42504); golang.org/x/crypto stays 0.52.0. Verified by extracting the wheel and diffing teradatasql.arm.fips.so build info
 
 impyla==0.22.0
 werkzeug==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -359,7 +359,7 @@ sortedcontainers==2.4.0
     # via snowflake-connector-python
 tableauserverclient==0.38 ; python_version >= "3.10"
     # via -r requirements.in
-teradatasql==20.0.0.60
+teradatasql==20.0.0.61
     # via -r requirements.in
 thrift==0.16.0
     # via


### PR DESCRIPTION
## What

Bumps `teradatasql` from `20.0.0.60` to `20.0.0.61` (published 2026-06-05). This clears the **last three teradata-attributed HIGH/CRITICAL findings** in the daily Apollo Agent vuln scan (`#collection-agent-vuln-scans`), which were pending an upstream Teradata refresh as of #313.

## Why these were blocked on us

These CVEs live in Go modules embedded in the closed-source `.so` files Teradata ships in the wheel — we can't patch them, only ride a new driver release.

## Verified

Downloaded both the `20.0.0.60` and `20.0.0.61` wheels and diffed the Go build info embedded in the bundled `.so` files (`teradatasql.arm.fips.so` — the one the scanner flags — and `teradatasql.so`):

| CVE | Component | 20.0.0.60 | 20.0.0.61 |
|-----|-----------|-----------|-----------|
| **CVE-2026-41602** (HIGH) | `github.com/apache/thrift` | dep `v0.22.0` (779 refs) | **module removed — 0 references** |
| **CVE-2026-39821** (CRITICAL) | `golang.org/x/net` | dep `v0.54.0` (1584 refs) | standalone module dep **dropped**; only toolchain-vendored copy remains, no version record |
| **CVE-2026-42504** (HIGH) | Go `stdlib` | `go1.26.3` | **`go1.26.4`** (documented fix) |

`golang.org/x/crypto` stays at `0.52.0` (already non-vulnerable since #313).

teradatasql is dependency-free, so only its pin changes in `requirements.txt`. The unrelated `thrift==0.16.0` Python package is a different dependency and is untouched.

## Checklist
- [x] Verified the fix by extracting and diffing the wheel build info
- [x] Scoped to a single pin bump (`requirements.in` + `requirements.txt`)
- [na] Unit tests — deps-only pin bump, no code change; CI runs the full suite
- [ ] Post-merge: confirm the three CVEs clear in the next daily docker scout / Aikido scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)