### PR TITLE
feat(custom-etl): guard nested group + tasks wire shape in proxy serializer (YET-1427)

### DIFF
--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -13,6 +13,21 @@ class that inherits from `BaseEtlConnector`).
   connector's `fetch_metadata` and `fetch_run_details` methods, serializing the model objects
   (EtlAsset/EtlRunEvent) to dicts for the data-collector.
 
+## Wire serialization (`_serialize`)
+
+The proxy is **decoupled from the model definitions** — those ship inside the connector
+bundle (pycarlo), not this repo. `_serialize` is therefore generic and
+**field-name-agnostic**: it recurses through dataclasses (`dataclasses.asdict`), objects with
+`__dict__`, dicts, and lists, preserving whatever nested structure the connector returns and
+stripping `None` values. New fields a connector adds are carried through automatically.
+
+Per the pycarlo PR #1527 ETL metadata contract, this means the emitted shape is the **nested
+`group` object** and **`tasks` array** (NOT flat `group_*` keys), with `*_source_ids`
+reference fields, `schedule.event_trigger`/`attributes`/`raw` as dicts, and `asset_ref`
+without a `metadata` field. `Enum` members serialize to their `.value` (e.g. `schedule.kind`,
+`asset_ref.asset_type`/`role`) and `datetime`/`date` to ISO-8601 strings (e.g.
+`schedule.next_run_at`). Because the wire carries SOURCE ids, the backend mints global ids.
+
 ## Opt-in gating
 
 Custom ETL connectors share the same gate as custom connectors: the env var

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -1,6 +1,7 @@
 import dataclasses
 import logging
-from datetime import timedelta
+from datetime import date, datetime, timedelta
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from apollo.integrations.base_proxy_client import BaseProxyClient
@@ -22,11 +23,27 @@ def _serialize(obj: Any) -> Any:
     and primitive/collection types.  ``None`` values are stripped from the
     top-level dict so the response stays compact — downstream consumers treat
     absent keys as null anyway.
+
+    Serialization is fully recursive and field-name-agnostic: it preserves the
+    nested structure of whatever the connector returns.  For ETL metadata this
+    means the nested ``group`` object and the ``tasks`` array (each with its own
+    nested ``inputs``/``outputs``/``*_source_ids``) come through unflattened, and
+    ``schedule.event_trigger``/``attributes``/``raw`` dicts are emitted as dicts.
+    Because it never references model field names, new fields added by a
+    connector are carried through automatically rather than dropped.
+
+    ``Enum`` members serialize to their ``.value`` (e.g. ``schedule.kind``,
+    ``asset_ref.asset_type``/``role``) and ``datetime``/``date`` to ISO-8601
+    strings (e.g. ``schedule.next_run_at``).
     """
     if obj is None:
         return None
+    if isinstance(obj, Enum):
+        return _serialize(obj.value)
     if isinstance(obj, (str, int, float, bool)):
         return obj
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
     if isinstance(obj, list):
         return [_serialize(item) for item in obj]
     if isinstance(obj, dict):

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -253,6 +253,285 @@ class TestSerialize(TestCase):
         self.assertEqual(_serialize(42), 42)
         self.assertIsNone(_serialize(None))
 
+    def test_serialize_enum_uses_value(self):
+        import enum
+
+        class Kind(enum.Enum):
+            CRON = "cron"
+
+        self.assertEqual(_serialize(Kind.CRON), "cron")
+
+    def test_serialize_str_enum_uses_value(self):
+        import enum
+
+        class Role(str, enum.Enum):
+            INPUT = "INPUT"
+
+        # str-Enum is also an Enum — must emit the bare value, not the member.
+        self.assertEqual(_serialize(Role.INPUT), "INPUT")
+
+    def test_serialize_datetime_isoformat(self):
+        from datetime import datetime, timezone
+
+        dt = datetime(2026, 6, 8, 12, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(_serialize(dt), "2026-06-08T12:30:00+00:00")
+
+    def test_serialize_date_isoformat(self):
+        from datetime import date
+
+        self.assertEqual(_serialize(date(2026, 6, 8)), "2026-06-08")
+
+
+# ---------------------------------------------------------------------------
+# ETL wire-contract serialization (pycarlo PR #1527 nested shape)
+#
+# These dataclasses mirror the connector-side model shape (which lives in the
+# runtime-loaded connector bundle, not this repo). They pin the wire shape the
+# proxy emits: a nested ``group`` object and a ``tasks`` array — NOT flat
+# ``group_*`` keys — with ``*_source_ids`` reference fields, ``event_trigger``
+# as a dict, and ``asset_ref`` without a ``metadata`` field.
+# ---------------------------------------------------------------------------
+
+
+class TestEtlWireContractSerialization(TestCase):
+    def _build_asset(self):
+        import dataclasses
+        import enum
+        from datetime import datetime, timezone
+        from typing import Dict, List, Optional
+
+        class ScheduleKind(str, enum.Enum):
+            CRON = "cron"
+
+        class AssetType(str, enum.Enum):
+            TABLE = "TABLE"
+
+        class Role(str, enum.Enum):
+            INPUT = "INPUT"
+            OUTPUT = "OUTPUT"
+
+        @dataclasses.dataclass
+        class AssetRef:
+            asset_type: AssetType
+            role: Role
+            mcon: Optional[str] = None
+            fully_qualified_name: Optional[str] = None
+
+        @dataclasses.dataclass
+        class EtlGroup:
+            source_id: str
+            name: Optional[str] = None
+            group_type: Optional[str] = None
+            schedule: Optional[str] = None
+            attributes: Optional[Dict] = None
+
+        @dataclasses.dataclass
+        class EtlSchedule:
+            kind: ScheduleKind
+            cron_expression: Optional[str] = None
+            timezone: Optional[str] = None
+            next_run_at: Optional[datetime] = None
+            event_trigger: Optional[Dict] = None
+            upstream_job_source_ids: Optional[List[str]] = None
+            raw: Optional[Dict] = None
+
+        @dataclasses.dataclass
+        class EtlTask:
+            task_source_id: str
+            name: str
+            task_type: Optional[str] = None
+            inputs: Optional[List[AssetRef]] = None
+            outputs: Optional[List[AssetRef]] = None
+            upstream_task_source_ids: Optional[List[str]] = None
+            triggered_job_source_ids: Optional[List[str]] = None
+            attributes: Optional[Dict] = None
+
+        @dataclasses.dataclass
+        class EtlAsset:
+            job_source_id: str
+            name: str
+            group: EtlGroup
+            schedule: Optional[EtlSchedule] = None
+            inputs: Optional[List[AssetRef]] = None
+            outputs: Optional[List[AssetRef]] = None
+            triggered_job_source_ids: Optional[List[str]] = None
+            tasks: Optional[List[EtlTask]] = None
+
+        return EtlAsset(
+            job_source_id="job-1",
+            name="Daily load",
+            group=EtlGroup(
+                source_id="grp-1",
+                name="Factory A",
+                group_type="factory",
+                attributes={"region": "us-east"},
+            ),
+            schedule=EtlSchedule(
+                kind=ScheduleKind.CRON,
+                cron_expression="0 * * * *",
+                timezone="UTC",
+                next_run_at=datetime(2026, 6, 8, 12, 0, 0, tzinfo=timezone.utc),
+                event_trigger={"type": "blob_created", "path": "/in"},
+                upstream_job_source_ids=["job-0"],
+            ),
+            inputs=[
+                AssetRef(asset_type=AssetType.TABLE, role=Role.INPUT, mcon="mcon-in")
+            ],
+            outputs=[
+                AssetRef(
+                    asset_type=AssetType.TABLE,
+                    role=Role.OUTPUT,
+                    fully_qualified_name="db.schema.out",
+                )
+            ],
+            triggered_job_source_ids=["job-2"],
+            tasks=[
+                EtlTask(
+                    task_source_id="task-1",
+                    name="copy activity",
+                    task_type="copy",
+                    inputs=[
+                        AssetRef(asset_type=AssetType.TABLE, role=Role.INPUT, mcon="m1")
+                    ],
+                    outputs=[
+                        AssetRef(
+                            asset_type=AssetType.TABLE, role=Role.OUTPUT, mcon="m2"
+                        )
+                    ],
+                    upstream_task_source_ids=["task-0"],
+                    triggered_job_source_ids=["job-3"],
+                    attributes={"retry": 3},
+                )
+            ],
+        )
+
+    def test_group_is_nested_not_flattened(self):
+        result = _serialize(self._build_asset())
+
+        # Nested group object — NOT flat group_source_id / group_name / group_type.
+        self.assertIn("group", result)
+        self.assertNotIn("group_source_id", result)
+        self.assertNotIn("group_name", result)
+        self.assertNotIn("group_type", result)
+        self.assertEqual(result["group"]["source_id"], "grp-1")
+        self.assertEqual(result["group"]["name"], "Factory A")
+        self.assertEqual(result["group"]["group_type"], "factory")
+        self.assertEqual(result["group"]["attributes"], {"region": "us-east"})
+
+    def test_tasks_array_preserved_with_nested_fields(self):
+        result = _serialize(self._build_asset())
+
+        self.assertIn("tasks", result)
+        self.assertEqual(len(result["tasks"]), 1)
+        task = result["tasks"][0]
+        self.assertEqual(task["task_source_id"], "task-1")
+        self.assertEqual(task["name"], "copy activity")
+        self.assertEqual(task["upstream_task_source_ids"], ["task-0"])
+        self.assertEqual(task["triggered_job_source_ids"], ["job-3"])
+        self.assertEqual(task["attributes"], {"retry": 3})
+        # Nested asset refs inside the task come through too.
+        self.assertEqual(task["inputs"][0]["mcon"], "m1")
+        self.assertEqual(task["outputs"][0]["role"], "OUTPUT")
+
+    def test_source_id_reference_fields(self):
+        result = _serialize(self._build_asset())
+
+        self.assertEqual(result["triggered_job_source_ids"], ["job-2"])
+        self.assertEqual(result["schedule"]["upstream_job_source_ids"], ["job-0"])
+
+    def test_schedule_kind_enum_and_event_trigger_dict(self):
+        result = _serialize(self._build_asset())
+
+        schedule = result["schedule"]
+        # kind enum -> bare value
+        self.assertEqual(schedule["kind"], "cron")
+        # event_trigger is a dict (was a str in the prior contract)
+        self.assertEqual(
+            schedule["event_trigger"], {"type": "blob_created", "path": "/in"}
+        )
+        # datetime -> ISO-8601
+        self.assertEqual(schedule["next_run_at"], "2026-06-08T12:00:00+00:00")
+
+    def test_asset_ref_has_no_metadata_and_uses_enums(self):
+        result = _serialize(self._build_asset())
+
+        out_ref = result["outputs"][0]
+        self.assertNotIn("metadata", out_ref)
+        self.assertEqual(out_ref["asset_type"], "TABLE")
+        self.assertEqual(out_ref["role"], "OUTPUT")
+        self.assertEqual(out_ref["fully_qualified_name"], "db.schema.out")
+        # ≥1 of mcon/fqn present; absent one is stripped (None).
+        self.assertNotIn("mcon", out_ref)
+
+    def test_fetch_etl_assets_emits_contract_shape(self):
+        with patch(
+            "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+            return_value={},
+        ), patch(
+            "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+        ) as mock_load_module:
+            module = MagicMock()
+            connector = MagicMock()
+            module.Connector.return_value = connector
+            mock_load_module.return_value = module
+            connector.fetch_metadata.return_value = [self._build_asset()]
+
+            client = CustomEtlProxyClient(
+                credentials={"connect_args": {}},
+                connector_dir="/opt/custom-etl-connectors/adf",
+            )
+            result = client.fetch_etl_assets(limit=10, offset=0)
+
+        asset = result["all_results"][0]
+        self.assertEqual(asset["group"]["source_id"], "grp-1")
+        self.assertEqual(asset["tasks"][0]["task_source_id"], "task-1")
+        self.assertEqual(asset["schedule"]["kind"], "cron")
+
+    def test_run_event_requires_error_message_and_nested_tasks(self):
+        import dataclasses
+        import enum
+        from typing import List, Optional
+
+        class RunStatus(str, enum.Enum):
+            FAILED = "failed"
+
+        @dataclasses.dataclass
+        class EtlError:
+            message: str  # REQUIRED in the updated runs contract
+
+        @dataclasses.dataclass
+        class EtlTaskRun:
+            task_source_id: str
+            status: RunStatus
+            error: Optional[EtlError] = None
+
+        @dataclasses.dataclass
+        class EtlRunEvent:
+            job_source_id: str
+            run_source_id: str
+            status: RunStatus
+            error: Optional[EtlError] = None
+            tasks: Optional[List[EtlTaskRun]] = None
+
+        run = EtlRunEvent(
+            job_source_id="job-1",
+            run_source_id="run-1",
+            status=RunStatus.FAILED,
+            error=EtlError(message="boom"),
+            tasks=[
+                EtlTaskRun(
+                    task_source_id="task-1",
+                    status=RunStatus.FAILED,
+                    error=EtlError(message="task boom"),
+                )
+            ],
+        )
+
+        result = _serialize(run)
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["error"]["message"], "boom")
+        self.assertEqual(result["tasks"][0]["error"]["message"], "task boom")
+
 
 # ---------------------------------------------------------------------------
 # Proxy client tests


### PR DESCRIPTION
## What & why

YET-1427 scope #5a. [pycarlo PR #1527](https://github.com/monte-carlo-data/python-sdk/pull/1527) reshaped the ETL metadata wire contract:

- nested `group` object — replaces flat `group_source_id`/`group_name`/`group_type`
- new `tasks` array (with nested `inputs`/`outputs`/`upstream_task_source_ids`/`triggered_job_source_ids`)
- `*_source_ids` reference fields (renamed from `*_global_ids`); wire carries SOURCE ids, backend mints global ids
- `schedule.event_trigger` is now a dict (was a str); `schedule.upstream_job_source_ids`
- `asset_ref.metadata` removed (≥1 of `mcon`/`fqn` required)
- runs: `EtlError.message` now required

This PR makes `custom_etl_proxy_client.py` serialize connector output through that nested shape and guards it with tests.

## Approach

The proxy is **decoupled from the model definitions** — the ETL model classes ship inside the runtime-loaded connector bundle (pycarlo), not this repo. `_serialize` is therefore generic and **field-name-agnostic**: it recurses through dataclasses (`dataclasses.asdict`), objects with `__dict__`, dicts, and lists, so it **already preserves the nested `group` object and `tasks` array unflattened** — no flat→nested mapping is needed, and new fields a connector adds pass through automatically. Hardcoding a flat-to-nested mapping would couple the proxy to the model and risk silently dropping new connector fields.

Mirrors the sibling test-only guard in [data-collector PR #2398](https://github.com/monte-carlo-data/data-collector/pull/2398) ("guard new nested-group + tasks wire shape pass-through").

## Changes

- **`_serialize`**: add `Enum` → `.value` (e.g. `schedule.kind`, `asset_ref.asset_type`/`role`) and `datetime`/`date` → ISO-8601 (e.g. `schedule.next_run_at`) handling, so the new contract's enum/datetime fields serialize correctly on the wire.
- **Tests** (`tests/test_custom_etl_proxy_client.py`, +11): pin the full new contract — nested `group` (asserts flat `group_*` keys are absent), `tasks` array with nested fields, `*_source_ids` names, `event_trigger` as dict, `asset_ref` without `metadata`, enum/datetime serialization, and run events with required `EtlError.message` + nested task errors.
- **Docs**: document the wire serialization contract in `apollo/integrations/custom_etl/CLAUDE.md`.

## Test coverage

`tests/test_custom_etl_proxy_client.py`: **51 passed** (was 40). New `TestEtlWireContractSerialization` builds dataclasses mirroring the connector-side model and asserts the emitted wire shape; new `TestSerialize` cases cover enum/str-enum/datetime/date. `black` + `pyright` clean.

## Checklist

- [x] Tests added/updated and passing (51 passed)
- [x] Lint (`black`) and typecheck (`pyright`) pass
- [x] Docs updated (subsystem `CLAUDE.md`)
- [na] DB migrations
- [na] Feature flag / config changes
- [na] Backwards-incompatible API change (serializer is additive; nested pass-through was already produced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)