### PR TITLE
use 'connection_name' from etl manifest not 'name'

### DIFF
--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -169,7 +169,7 @@ class CustomEtlProxyClient(BaseProxyClient):
             result.append(
                 {
                     "type": connection_type,
-                    "name": manifest.get("name", connection_type),
+                    "name": manifest.get("connection_name", connection_type),
                 }
             )
         return result

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -38,7 +38,7 @@ def _create_mock_etl_connector_dir(
 
     manifest = {
         "connection_type": connection_type,
-        "name": name,
+        "connection_name": name,
     }
     if terminology is not None:
         manifest["terminology"] = terminology
@@ -906,7 +906,7 @@ class TestGetConnectionManifests(TestCase):
             self.assertEqual(
                 aaa["manifest"]["connection_type"], "custom-etl-connector-aaa"
             )
-            self.assertEqual(aaa["manifest"]["name"], "adf")
+            self.assertEqual(aaa["manifest"]["connection_name"], "adf")
             self.assertEqual(
                 aaa["manifest"]["terminology"],
                 {"group": "Factory", "job": "Pipeline"},


### PR DESCRIPTION
MC backend expects and validates that ETL manifest uses 'connection_name' not 'name' for the friendly name. This PR fixes an issue where we were showing connection_type as the friendly name in the discover-connectors validation