### PR TITLE
Fix Custom ETL JobSourceID filtering

### DIFF
--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -144,7 +144,7 @@ class CustomEtlProxyClient(BaseProxyClient):
         )
         if job_ids:
             allowed = set(job_ids)
-            runs = [r for r in runs if getattr(r, "job_source_id", None) in allowed]
+            runs = [r for r in runs if r.get("job_source_id") in allowed]
         return {"all_results": [_serialize(r) for r in runs]}
 
     def get_manifest(self) -> Dict:

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -719,13 +719,10 @@ class TestCustomEtlProxyClient(TestCase):
         self, mock_load_module, mock_load_manifest
     ):
         mock_load_module.return_value = self._mock_module
-        run1 = _FakeModel(
-            job_source_id="job-1", run_source_id="run-1", status="success"
-        )
-        run2 = _FakeModel(
-            job_source_id="job-2", run_source_id="run-2", status="success"
-        )
-        self._mock_connector.fetch_run_details.return_value = [run1, run2]
+        self._mock_connector.fetch_run_details.return_value = [
+            {"job_source_id": "job-1", "run_source_id": "run-1", "status": "success"},
+            {"job_source_id": "job-2", "run_source_id": "run-2", "status": "success"},
+        ]
 
         client = CustomEtlProxyClient(
             credentials={"connect_args": {}},


### PR DESCRIPTION
The custom etl connector code returns dicts not models so attempting to filter by job_source_id using `getattr` was always returning None. Use `get()` instead. 