### PR TITLE
fix(azure): chown /home/data and /home/LogFiles so non-root Functions host can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,9 +169,17 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 
 # Register mcdagent early so COPY --chown below lands files mcdagent-owned
 # without a later `chown -R` layer.
+#
+# /home/data must be mcdagent-owned too: the Functions host writes a secrets
+# sentinel under /home/data/Functions/secrets when it creates a host key on
+# cold start, and with WEBSITES_ENABLE_APP_SERVICE_STORAGE=false (our
+# deployments) /home is the root-owned local container layer, so a non-root
+# process gets EACCES there and the host fails to start. Pre-create and chown
+# it so the host can write.
 RUN groupadd --gid 1000 mcdagent \
     && useradd --uid 1000 --gid mcdagent --no-create-home --home-dir /home/site/wwwroot --shell /usr/sbin/nologin mcdagent \
-    && chown mcdagent:mcdagent /home/site/wwwroot
+    && mkdir -p /home/data \
+    && chown mcdagent:mcdagent /home/site/wwwroot /home/data
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends git

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,16 +170,17 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
 # Register mcdagent early so COPY --chown below lands files mcdagent-owned
 # without a later `chown -R` layer.
 #
-# /home/data must be mcdagent-owned too: the Functions host writes a secrets
-# sentinel under /home/data/Functions/secrets when it creates a host key on
-# cold start, and with WEBSITES_ENABLE_APP_SERVICE_STORAGE=false (our
-# deployments) /home is the root-owned local container layer, so a non-root
-# process gets EACCES there and the host fails to start. Pre-create and chown
-# it so the host can write.
+# /home/data and /home/LogFiles must be mcdagent-owned too. With
+# WEBSITES_ENABLE_APP_SERVICE_STORAGE=false (our deployments) /home is the
+# root-owned local container layer, so a non-root host process gets EACCES
+# writing the two sentinel files it maintains there: the secrets sentinel
+# under /home/data/Functions/secrets (fails host startup) and the debug
+# sentinel under /home/LogFiles/Application/Functions/Host (logged error).
+# Pre-create and chown both so the host can write them.
 RUN groupadd --gid 1000 mcdagent \
     && useradd --uid 1000 --gid mcdagent --no-create-home --home-dir /home/site/wwwroot --shell /usr/sbin/nologin mcdagent \
-    && mkdir -p /home/data \
-    && chown mcdagent:mcdagent /home/site/wwwroot /home/data
+    && mkdir -p /home/data /home/LogFiles \
+    && chown mcdagent:mcdagent /home/site/wwwroot /home/data /home/LogFiles
 
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends git

--- a/apollo/interfaces/azure/README.md
+++ b/apollo/interfaces/azure/README.md
@@ -1,3 +1,22 @@
+### Deployment assumptions / required app settings
+
+The agent image runs the Azure Functions host as a **non-root** user (`mcdagent`, uid/gid 1000).
+Deployments must use the following app settings:
+
+- **`WEBSITES_ENABLE_APP_SERVICE_STORAGE=false`** — the recommended (and assumed) value for
+  containerized Functions. When `false`, `/home` is the container's local, ephemeral filesystem,
+  so the image pre-creates and chowns `/home/data` and `/home/LogFiles` to `mcdagent` for the
+  non-root host to write its sentinel files (secrets sentinel under
+  `/home/data/Functions/secrets`, debug sentinel under `/home/LogFiles/Application/Functions/Host`).
+  If set to `true`, Azure mounts the storage account's file share over `/home` at startup — this
+  shadows the image's directories (the chowns become inert) but the share is writable so the host
+  still works; the trade-off is the mount must be reachable at startup (problematic over private
+  endpoints in a VNet) and adds latency, so prefer `false`.
+- **`WEBSITES_PORT`** — the image's Functions host (Kestrel) binds to `8080` (a non-root process
+  can't bind ports `<1024`). Leave `WEBSITES_PORT` **unset** so App Service auto-discovers the
+  `EXPOSE`d port `8080`, or set it explicitly to `8080`. A legacy value of `80` causes
+  `ContainerTimeout` after 230s.
+
 ### Required steps to manually deploy a new Azure Function
 Create resource group
 ```shell


### PR DESCRIPTION
## What

The non-root Azure image (#311, v1.8.0) chowned only `/home/site/wwwroot` to `mcdagent`. This pre-creates and chowns `/home/data` and `/home/LogFiles` so the non-root Azure Functions host can write the sentinel/state files it maintains under `/home`.

## Why

With `WEBSITES_ENABLE_APP_SERVICE_STORAGE=false` (our deployments), `/home` is the **root-owned local container layer** — no Azure Files mount — so the non-root `mcdagent` process gets `EACCES` when the host writes under `/home/data` or `/home/LogFiles`:

```
System.Private.CoreLib: Access to the path '/home/data' is denied. Permission denied.
Function host is not running.
```

### Failure surfaces (all bottom out at `/home/data`)
Two distinct host code paths trigger it — which is why the fix chowns the **parent** `/home/data`, not just one subdirectory:
- **Host init / secrets:** creating a host/system key (e.g. the `durabletask_extension` key for our Durable Functions) persists a secrets sentinel under `/home/data/Functions/secrets` — **fatal**, host fails to start.
- **`/admin/functions` list:** `GetTestData` lazily creates sample-data under `/home/data/Functions/sampledata` — surfaces as `An unhandled host error has occurred` on the functions-list call the portal/DC health-check hits.
- Plus a non-fatal debug sentinel under `/home/LogFiles/Application/Functions/Host` → recurring `Unable to update the debug sentinel file`.

### Why it hit only some customers — and how bad it actually is
- The discriminator is **not** VNet/private storage (the storage flag is `false` in working *and* failing deployments). It's whether the host must **create** state under `/home` on boot.
- Apps whose blob secrets store was already **primed** by a past **root-image** boot skip the secrets create-path and are unaffected.
- **Any fresh deployment** landing straight on the non-root image must create that state → `EACCES` → crash loop. **Confirmed this reproduces on fresh non-VNet deployments too** — it is not a VNet edge case; it affects every brand-new 1.8.x install regardless of network topology.

## Repro & verification

Validated against fresh Function Apps in dev with the patched image `pre-release-agent:1.8.6rc2938-azure`. Checked for clean host init (`ConsecutiveErrors=0`), functions indexed + requests served, and absence of `host error` / `/home/data` denial / `Unable to update the debug sentinel file`.

| Scenario | Unpatched 1.8.x | Patched |
|----------|-----------------|---------|
| Fresh install, VNet + private storage | ❌ crash-loop on `/home/data` | ✅ clean cold start (`StartupCount=1`), request served |
| Fresh install, **non-VNet** | ❌ crash-loop — host errors + debug-sentinel errors | ✅ clean — in a single log, failures stop the instant the patched image takes over (23:34:48 UTC), then serves cleanly (25 status calls, 8 `Succeeded`) |
| Upgrade **1.7.x (root) → latest** | — | ✅ clean restart, durable orchestrator running, async status served, no sentinel errors |
| Priming mechanism check | failing 1.8.x self-heals only after a root boot persists the key | — |
| dev golden-agent CI (build 2938) | — | ✅ Azure `update-and-validate-golden-agent` green on the built image |

## Checklist
- [x] Both proven paths covered: `/home/data` (fatal — secrets + sample-data) and `/home/LogFiles` (non-fatal — debug sentinel); chowns the parent dirs so any `Functions/*` subdir the host creates is writable
- [x] No CI changes — existing `--target azure` build still applies
- [na] Tests — Dockerfile/docs-only change, verified by deploy
- [x] Docs/README update — added a deployment-assumptions section to the Azure interface README
- [x] Ran `/code-review`