### PR TITLE
fix(docker): bump Python base images 3.12 → 3.13 (VULN-1230)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # Published as `<version>-system-base` so downstream consumers (e.g. hermes-agent)
 # can build their own venv against the same native libs without inheriting
 # apollo's pip-installed dependencies.
-FROM python:3.12-slim AS system-base
+FROM python:3.13.13-slim AS system-base
 
 ENV APP_HOME=/app
 WORKDIR $APP_HOME
 
 # Refresh apt index and upgrade base-image packages so OS-level security fixes
 # (glibc, openssh, nghttp2, etc.) land on every rebuild rather than waiting for
-# the upstream python:3.12-slim tag to be republished.
+# the upstream python:3.13.13-slim tag to be republished.
 RUN apt-get update && apt-get upgrade -y
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+
@@ -108,7 +108,7 @@ RUN . $VENV_DIR/bin/activate && pip install --no-cache-dir -r requirements-cloud
 CMD . $VENV_DIR/bin/activate && \
     gunicorn --timeout 930 --bind :$PORT apollo.interfaces.cloudrun.main:app
 
-FROM public.ecr.aws/lambda/python:3.12 AS lambda-builder
+FROM public.ecr.aws/lambda/python:3.13 AS lambda-builder
 
 RUN dnf update -y
 # install git as we need it for the direct oscrypto dependency
@@ -122,7 +122,7 @@ RUN pip install --no-cache-dir --target "${LAMBDA_TASK_ROOT}" \
     -r requirements.txt \
     -r requirements-lambda.txt
 
-FROM public.ecr.aws/lambda/python:3.12 AS lambda
+FROM public.ecr.aws/lambda/python:3.13 AS lambda
 
 # Create non-root user up front so the cross-stage COPY below can use --chown
 # and so the final container runs as mcdagent. The Amazon Linux 2023 minimal
@@ -162,7 +162,7 @@ USER mcdagent
 
 CMD [ "apollo.interfaces.lambda_function.handler.lambda_handler" ]
 
-FROM mcr.microsoft.com/azure-functions/python:4-python3.12 AS azure
+FROM mcr.microsoft.com/azure-functions/python:4-python3.13 AS azure
 
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true


### PR DESCRIPTION
## Summary

Bumps the `apollo-agent` Docker base images from Python **3.12 → 3.13** across all build stages, to clear two CVEs present in the published `montecarlodata/agent` image.

Customer-reported via **Zendesk #27890 (CenterPoint Energy)** — parent ticket SEC-1960, vuln ticket VULN-1230.

| Stage | Before | After |
|---|---|---|
| cloudrun / generic / aws / tests | `python:3.12-slim` | `python:3.13.13-slim` |
| lambda (builder + runtime) | `public.ecr.aws/lambda/python:3.12` | `…/python:3.13` |
| azure | `azure-functions/python:4-python3.12` | `…:4-python3.13` |

## CVEs addressed

- **[CVE-2025-13462](https://nvd.nist.gov/vuln/detail/CVE-2025-13462)** (tarfile normalization, Low) — fixed in Python **3.13.13**.
- **[CVE-2026-7210](https://nvd.nist.gov/vuln/detail/CVE-2026-7210)** (expat hash-flooding, PSF Medium) — fixed via **libexpat ≥ 2.8.0**, which ships with the rebuilt 3.13 base. The currently-published image carries expat 2.7.4 (statically linked into CPython) and OS `libexpat1` 2.7.1; `apt-get upgrade` alone cannot lift either past the threshold, so a base-image bump is required.

> The CVE record's "fix requires Python 3.15.0" is **not yet actionable** — Python 3.15 is unreleased (GA ~Oct 2026). Targeting 3.13.13 clears the actionable tarfile CVE today; the expat fix lands with the rebuilt base.

Both CVEs were confirmed present but **not reachable** through apollo's own code (apollo imports neither stdlib `xml`/`pyexpat` nor `tarfile`; XML goes through `lxml` + `defusedxml`) — see the full triage on SEC-1960. This is base-image hygiene, not an active exploit path.

## Testing notes / reviewer checklist

This is a minor runtime bump (3.12 → 3.13), not just a tag patch. Before merge/publish please confirm:
- [ ] `pip install` succeeds against `requirements*.txt` under 3.13 (no wheels missing for 3.13)
- [ ] integration/test matrix passes (Snowflake, Looker, Azure SQL / pyodbc + msodbcsql17, IBM DB2)
- [ ] built image reports `expat ≥ 2.8.0` and `Python 3.13.13`
- [ ] `lambda/python:3.13` and `azure-functions:4-python3.13` tags resolve in CI

Lockfiles (`requirements*.txt`) still carry a "compiled with Python 3.12" header comment — intentionally **not** regenerated here to keep this PR minimal; regenerate under 3.13 in a follow-up if any transitive pins need to shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)