### PR TITLE
feat(credentials): support custom connector schema validation

### DIFF
--- a/apollo/credentials/schema/__init__.py
+++ b/apollo/credentials/schema/__init__.py
@@ -1,11 +1,13 @@
 """Self-hosted credentials schema framework.
 
 Each integration declares a raw cerberus schema dict next to the code that
-consumes the credentials — either on its CtpConfig (for CTP-enrolled
-connectors) or as a class attribute on the proxy client (for non-CTP).
-The validator and registry then just route a dict through cerberus; there
-is no wrapper type because cerberus alone can express everything we need
-(including ``oneof_schema`` for multi-auth-mode connectors).
+consumes the credentials — on its CtpConfig (for CTP-enrolled connectors),
+as a class attribute on the proxy client (for non-CTP), or as a
+``credentials_schema`` key in the connector's ``manifest.json`` (for custom
+connectors). The validator and registry then just route a dict through
+cerberus; there is no wrapper type because cerberus alone can express
+everything we need (including ``oneof_schema`` for multi-auth-mode
+connectors).
 
 The validator is invoked by ``POST /api/v1/self-hosted-credentials/validate/<connection_type>``
 after the secret has been fetched from the customer's secret store.

--- a/apollo/credentials/schema/registry.py
+++ b/apollo/credentials/schema/registry.py
@@ -51,19 +51,32 @@ _NON_CTP_PROXY_RESOLVERS: dict[str, _NonCtpResolver] = {
 }
 
 
-def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
-    """Return ``credentials_schema`` from a custom warehouse connector's manifest."""
-    try:
-        from apollo.integrations.custom.custom_connector_loader import (
-            get_custom_connector_registry,
-            load_manifest,
-        )
+def _resolve_custom_schema(
+    connection_type: str,
+    get_registry_fn: Callable[[], dict[str, str]],
+    load_manifest_fn: Callable[[str], dict[str, Any]],
+    label: str,
+) -> dict[str, Any] | None:
+    """Shared helper: look up ``credentials_schema`` from a custom connector manifest.
 
-        registry = get_custom_connector_registry()
+    Parameters
+    ----------
+    connection_type:
+        The connection type to resolve.
+    get_registry_fn:
+        Callable that returns ``{connection_type: connector_dir, ...}``.
+    load_manifest_fn:
+        Callable that reads and returns the manifest dict from a connector dir.
+    label:
+        Human-readable label for log messages (e.g. "custom connector").
+    """
+    try:
+        registry = get_registry_fn()
         connector_dir = registry.get(connection_type)
     except Exception:
         logger.debug(
-            "Failed to load custom connector registry for %s",
+            "Failed to load %s registry for %s",
+            label,
             connection_type,
             exc_info=True,
         )
@@ -73,7 +86,7 @@ def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
         return None
 
     # Connector is registered — failures here are real errors, not "not found".
-    manifest = load_manifest(connector_dir)
+    manifest = load_manifest_fn(connector_dir)
     schema = manifest.get("credentials_schema")
     if isinstance(schema, dict):
         return schema
@@ -84,41 +97,36 @@ def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
             type(schema).__name__,
         )
     return None
+
+
+def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
+    """Return ``credentials_schema`` from a custom warehouse connector's manifest."""
+    from apollo.integrations.custom.custom_connector_loader import (
+        get_custom_connector_registry,
+        load_manifest,
+    )
+
+    return _resolve_custom_schema(
+        connection_type,
+        get_registry_fn=get_custom_connector_registry,
+        load_manifest_fn=load_manifest,
+        label="custom connector",
+    )
 
 
 def _resolve_custom_etl_connector(connection_type: str) -> dict[str, Any] | None:
     """Return ``credentials_schema`` from a custom ETL connector's manifest."""
-    try:
-        from apollo.integrations.custom_etl.custom_etl_connector_loader import (
-            get_custom_etl_connector_registry,
-            load_manifest,
-        )
+    from apollo.integrations.custom_etl.custom_etl_connector_loader import (
+        get_custom_etl_connector_registry,
+        load_manifest,
+    )
 
-        registry = get_custom_etl_connector_registry()
-        connector_dir = registry.get(connection_type)
-    except Exception:
-        logger.debug(
-            "Failed to load custom ETL connector registry for %s",
-            connection_type,
-            exc_info=True,
-        )
-        return None
-
-    if connector_dir is None:
-        return None
-
-    # Connector is registered — failures here are real errors, not "not found".
-    manifest = load_manifest(connector_dir)
-    schema = manifest.get("credentials_schema")
-    if isinstance(schema, dict):
-        return schema
-    if schema is not None:
-        logger.warning(
-            "credentials_schema for %s is not a dict (got %s); ignoring",
-            connection_type,
-            type(schema).__name__,
-        )
-    return None
+    return _resolve_custom_schema(
+        connection_type,
+        get_registry_fn=get_custom_etl_connector_registry,
+        load_manifest_fn=load_manifest,
+        label="custom ETL connector",
+    )
 
 
 def get_credentials_schema(connection_type: str) -> dict[str, Any] | None:

--- a/apollo/credentials/schema/registry.py
+++ b/apollo/credentials/schema/registry.py
@@ -1,6 +1,6 @@
 """Lookup for a connection type's self-hosted credentials schema.
 
-Two paths:
+Three paths:
 
 1. **CTP-enrolled connectors** (the vast majority): the schema lives on
    the registered :class:`apollo.integrations.ctp.models.CtpConfig` as the
@@ -12,11 +12,21 @@ Two paths:
    ``salesforce-data-cloud``): the schema lives on the proxy client class
    as a ``SELF_HOSTED_CREDENTIALS_SCHEMA`` class attribute. Lazy imports
    avoid pulling heavyweight drivers into this module's import path.
+
+3. **Custom connectors** (``custom-connector-*`` and
+   ``custom-etl-connector-*``): the schema is declared as an optional
+   ``credentials_schema`` key in the connector's ``manifest.json``, read
+   from disk at ``/opt/custom-connectors/<name>/`` or
+   ``/opt/custom-etl-connectors/<name>/``. The lookup reuses the existing
+   connector loader registries and ``load_manifest()`` helpers.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 _NonCtpResolver = Callable[[], type]
 
@@ -41,6 +51,56 @@ _NON_CTP_PROXY_RESOLVERS: dict[str, _NonCtpResolver] = {
 }
 
 
+def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
+    """Return ``credentials_schema`` from a custom warehouse connector's manifest."""
+    try:
+        from apollo.integrations.custom.custom_connector_loader import (
+            get_custom_connector_registry,
+            load_manifest,
+        )
+
+        registry = get_custom_connector_registry()
+        connector_dir = registry.get(connection_type)
+        if connector_dir is None:
+            return None
+        manifest = load_manifest(connector_dir)
+        schema = manifest.get("credentials_schema")
+        if isinstance(schema, dict):
+            return schema
+    except Exception:
+        logger.warning(
+            "Failed to resolve credentials schema for custom connector %s",
+            connection_type,
+            exc_info=True,
+        )
+    return None
+
+
+def _resolve_custom_etl_connector(connection_type: str) -> dict[str, Any] | None:
+    """Return ``credentials_schema`` from a custom ETL connector's manifest."""
+    try:
+        from apollo.integrations.custom_etl.custom_etl_connector_loader import (
+            get_custom_etl_connector_registry,
+            load_manifest,
+        )
+
+        registry = get_custom_etl_connector_registry()
+        connector_dir = registry.get(connection_type)
+        if connector_dir is None:
+            return None
+        manifest = load_manifest(connector_dir)
+        schema = manifest.get("credentials_schema")
+        if isinstance(schema, dict):
+            return schema
+    except Exception:
+        logger.warning(
+            "Failed to resolve credentials schema for custom ETL connector %s",
+            connection_type,
+            exc_info=True,
+        )
+    return None
+
+
 def get_credentials_schema(connection_type: str) -> dict[str, Any] | None:
     """Return the cerberus schema dict for ``connection_type``, or ``None``.
 
@@ -51,15 +111,26 @@ def get_credentials_schema(connection_type: str) -> dict[str, Any] | None:
     """
     from apollo.integrations.ctp.registry import CtpRegistry
 
+    # Path 1: CTP-enrolled connectors
     ctp_config = CtpRegistry.get(connection_type)
     if ctp_config is not None and ctp_config.raw_credentials_schema is not None:
         return ctp_config.raw_credentials_schema
 
+    # Path 2: Non-CTP proxy clients with class-level schemas
     resolver = _NON_CTP_PROXY_RESOLVERS.get(connection_type)
     if resolver is not None:
         proxy_class = resolver()
         schema = getattr(proxy_class, "SELF_HOSTED_CREDENTIALS_SCHEMA", None)
         if isinstance(schema, dict):
             return schema
+
+    # Path 3: Custom connectors (manifest-declared schemas)
+    schema = _resolve_custom_connector(connection_type)
+    if schema is not None:
+        return schema
+
+    schema = _resolve_custom_etl_connector(connection_type)
+    if schema is not None:
+        return schema
 
     return None

--- a/apollo/credentials/schema/registry.py
+++ b/apollo/credentials/schema/registry.py
@@ -62,7 +62,7 @@ def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
         registry = get_custom_connector_registry()
         connector_dir = registry.get(connection_type)
     except Exception:
-        logger.warning(
+        logger.debug(
             "Failed to load custom connector registry for %s",
             connection_type,
             exc_info=True,
@@ -97,7 +97,7 @@ def _resolve_custom_etl_connector(connection_type: str) -> dict[str, Any] | None
         registry = get_custom_etl_connector_registry()
         connector_dir = registry.get(connection_type)
     except Exception:
-        logger.warning(
+        logger.debug(
             "Failed to load custom ETL connector registry for %s",
             connection_type,
             exc_info=True,

--- a/apollo/credentials/schema/registry.py
+++ b/apollo/credentials/schema/registry.py
@@ -61,17 +61,27 @@ def _resolve_custom_connector(connection_type: str) -> dict[str, Any] | None:
 
         registry = get_custom_connector_registry()
         connector_dir = registry.get(connection_type)
-        if connector_dir is None:
-            return None
-        manifest = load_manifest(connector_dir)
-        schema = manifest.get("credentials_schema")
-        if isinstance(schema, dict):
-            return schema
     except Exception:
         logger.warning(
-            "Failed to resolve credentials schema for custom connector %s",
+            "Failed to load custom connector registry for %s",
             connection_type,
             exc_info=True,
+        )
+        return None
+
+    if connector_dir is None:
+        return None
+
+    # Connector is registered — failures here are real errors, not "not found".
+    manifest = load_manifest(connector_dir)
+    schema = manifest.get("credentials_schema")
+    if isinstance(schema, dict):
+        return schema
+    if schema is not None:
+        logger.warning(
+            "credentials_schema for %s is not a dict (got %s); ignoring",
+            connection_type,
+            type(schema).__name__,
         )
     return None
 
@@ -86,17 +96,27 @@ def _resolve_custom_etl_connector(connection_type: str) -> dict[str, Any] | None
 
         registry = get_custom_etl_connector_registry()
         connector_dir = registry.get(connection_type)
-        if connector_dir is None:
-            return None
-        manifest = load_manifest(connector_dir)
-        schema = manifest.get("credentials_schema")
-        if isinstance(schema, dict):
-            return schema
     except Exception:
         logger.warning(
-            "Failed to resolve credentials schema for custom ETL connector %s",
+            "Failed to load custom ETL connector registry for %s",
             connection_type,
             exc_info=True,
+        )
+        return None
+
+    if connector_dir is None:
+        return None
+
+    # Connector is registered — failures here are real errors, not "not found".
+    manifest = load_manifest(connector_dir)
+    schema = manifest.get("credentials_schema")
+    if isinstance(schema, dict):
+        return schema
+    if schema is not None:
+        logger.warning(
+            "credentials_schema for %s is not a dict (got %s); ignoring",
+            connection_type,
+            type(schema).__name__,
         )
     return None
 

--- a/apollo/integrations/custom/CLAUDE.md
+++ b/apollo/integrations/custom/CLAUDE.md
@@ -26,6 +26,8 @@ the custom connector path.
 └── templates/           # optional Jinja2 .j2 query templates
 ```
 
+The optional `credentials_schema` key in the manifest accepts a cerberus schema dict for self-hosted credential validation.
+
 ## Adding a new custom connector
 
 Custom connectors are not added to the codebase — they are user-provided and discovered at

--- a/apollo/integrations/custom/CLAUDE.md
+++ b/apollo/integrations/custom/CLAUDE.md
@@ -21,7 +21,7 @@ the custom connector path.
 
 ```
 /opt/custom-connectors/<name>/
-├── manifest.json        # connection_type, connection_name, capabilities, metrics
+├── manifest.json        # connection_type, connection_name, capabilities, metrics, credentials_schema (optional)
 ├── connector.py         # BaseConnector class (create_connection, execute_query, etc.)
 └── templates/           # optional Jinja2 .j2 query templates
 ```

--- a/apollo/integrations/custom/custom_proxy_client.py
+++ b/apollo/integrations/custom/custom_proxy_client.py
@@ -185,8 +185,10 @@ class CustomProxyClient(BaseProxyClient):
         registry = get_custom_connector_registry()
         result: Dict[str, Dict[str, Any]] = {}
         for connection_type, connector_dir in registry.items():
+            manifest = load_manifest(connector_dir)
+            manifest.pop("credentials_schema", None)
             result[connection_type] = {
-                "manifest": load_manifest(connector_dir),
+                "manifest": manifest,
                 "templates": load_templates(connector_dir),
             }
         return result

--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -38,7 +38,7 @@ checks this before falling through to either custom connector path.
 
 ```
 /opt/custom-etl-connectors/<name>/
-├── manifest.json        # connection_type, name, terminology, icon_url
+├── manifest.json        # connection_type, name, terminology, icon_url, credentials_schema (optional)
 └── connector.py         # Connector(BaseEtlConnector) class
 ```
 
@@ -53,7 +53,8 @@ checks this before falling through to either custom connector path.
     "job": "Pipeline",
     "task": "Activity"
   },
-  "icon_url": "https://example.com/icon.png"
+  "icon_url": "https://example.com/icon.png",
+  "credentials_schema": {}
 }
 ```
 

--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -53,10 +53,11 @@ checks this before falling through to either custom connector path.
     "job": "Pipeline",
     "task": "Activity"
   },
-  "icon_url": "https://example.com/icon.png",
-  "credentials_schema": {}
+  "icon_url": "https://example.com/icon.png"
 }
 ```
+
+The optional `credentials_schema` key accepts a cerberus schema dict for self-hosted credential validation.
 
 ## Connector interface
 

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -148,8 +148,10 @@ class CustomEtlProxyClient(BaseProxyClient):
         return {"all_results": [_serialize(r) for r in runs]}
 
     def get_manifest(self) -> Dict:
-        """Return the full manifest from manifest.json."""
-        return self._manifest
+        """Return the manifest from manifest.json (excluding credentials_schema)."""
+        result = dict(self._manifest)
+        result.pop("credentials_schema", None)
+        return result
 
     @staticmethod
     def get_custom_etl_connector_types() -> List[Dict[str, str]]:
@@ -194,8 +196,10 @@ class CustomEtlProxyClient(BaseProxyClient):
         registry = get_custom_etl_connector_registry()
         result: Dict[str, Dict[str, Any]] = {}
         for connection_type, connector_dir in registry.items():
+            manifest = load_manifest(connector_dir)
+            manifest.pop("credentials_schema", None)
             result[connection_type] = {
-                "manifest": load_manifest(connector_dir),
+                "manifest": manifest,
             }
         return result
 

--- a/tests/credentials/schema/test_endpoint.py
+++ b/tests/credentials/schema/test_endpoint.py
@@ -208,3 +208,49 @@ def test_salesforce_crm_no_variant_fails(client):
     # cerberus's oneof_schema flags the dict — every candidate variant is
     # listed under the connect_args error so the customer can see the choices.
     assert "connect_args" in payload["errors"]
+
+
+# -- custom connector tests ------------------------------------------------
+
+
+def _custom_connector_schema() -> dict[str, Any]:
+    """Schema returned by the platform for a hypothetical custom connector."""
+    return {
+        "connect_args": {
+            "type": "dict",
+            "required": True,
+            "schema": {
+                "host": {"type": "string", "required": True},
+                "port": {"type": "integer", "required": True},
+            },
+        }
+    }
+
+
+def test_custom_connector_valid_credentials(client):
+    with patch(
+        "apollo.agent.agent.get_credentials_schema_for_connection_type",
+        return_value=_custom_connector_schema(),
+    ):
+        payload = _post_validate(
+            client,
+            "custom-connector-abc1234",
+            {"connect_args": {"host": "db.example.com", "port": 5432}},
+        )
+    assert payload["valid"] is True
+    assert payload["connection_type"] == "custom-connector-abc1234"
+    assert payload["errors"] == {}
+
+
+def test_custom_connector_invalid_credentials(client):
+    with patch(
+        "apollo.agent.agent.get_credentials_schema_for_connection_type",
+        return_value=_custom_connector_schema(),
+    ):
+        payload = _post_validate(
+            client,
+            "custom-connector-abc1234",
+            {"connect_args": {"host": "db.example.com"}},
+        )
+    assert payload["valid"] is False
+    assert "connect_args" in payload["errors"]

--- a/tests/credentials/schema/test_registry.py
+++ b/tests/credentials/schema/test_registry.py
@@ -179,7 +179,27 @@ def test_custom_connector_not_in_registry_returns_none(
     assert get_credentials_schema("custom-connector-unknown") is None
 
 
-@patch.dict("os.environ", {}, clear=False)
+@patch(
+    f"{_CC_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-connector-abc1234",
+        "credentials_schema": ["not", "a", "dict"],
+    },
+)
+@patch(
+    f"{_CC_LOADER}.get_custom_connector_registry",
+    return_value={
+        "custom-connector-abc1234": "/fake/path",
+    },
+)
+def test_custom_connector_non_dict_credentials_schema_returns_none(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    """When credentials_schema is not a dict (e.g. a list), return None."""
+    assert get_credentials_schema("custom-connector-abc1234") is None
+
+
 @patch(
     f"{_CC_LOADER}.load_manifest",
     return_value={
@@ -197,12 +217,8 @@ def test_custom_connector_schema_works_without_feature_gate(
     _mock_registry: MagicMock,
     _mock_manifest: MagicMock,
 ) -> None:
-    # Credential validation is read-only and should work regardless of the
-    # MCD_CUSTOM_CONNECTORS_ENABLED proxy factory gate.  The schema lookup
-    # intentionally bypasses the feature flag so operators can validate
+    # Credential validation is read-only and intentionally bypasses
+    # MCD_CUSTOM_CONNECTORS_ENABLED — operators should be able to validate
     # credentials even when the connector is not yet enabled for collection.
-    import os
-
-    assert "MCD_CUSTOM_CONNECTORS_ENABLED" not in os.environ
     schema = get_credentials_schema("custom-connector-abc1234")
     assert schema == {"connect_args": {"type": "dict", "required": True}}

--- a/tests/credentials/schema/test_registry.py
+++ b/tests/credentials/schema/test_registry.py
@@ -9,6 +9,8 @@ CtpConfig (or the proxy client class attribute, for non-CTP) — see
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from apollo.credentials.schema import get_credentials_schema
@@ -74,3 +76,133 @@ def test_infrastructure_connectors_return_none() -> None:
             f"{ct} should not have a self-hosted-credentials schema "
             "(it is an infrastructure connector, not in the public docs)."
         )
+
+
+# ---------------------------------------------------------------------------
+# Custom connector registry tests
+#
+# The custom connector loaders read from /opt/custom-connectors at import
+# time and cache the result at module level.  We mock at the definition site
+# so the tests never touch the filesystem or interact with the cache.
+# ---------------------------------------------------------------------------
+
+_CC_LOADER = "apollo.integrations.custom.custom_connector_loader"
+_ETL_LOADER = "apollo.integrations.custom_etl.custom_etl_connector_loader"
+
+
+@patch(
+    f"{_CC_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-connector-abc1234",
+        "credentials_schema": {"connect_args": {"type": "dict", "required": True}},
+    },
+)
+@patch(
+    f"{_CC_LOADER}.get_custom_connector_registry",
+    return_value={
+        "custom-connector-abc1234": "/fake/path",
+    },
+)
+def test_custom_connector_with_credentials_schema(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    schema = get_credentials_schema("custom-connector-abc1234")
+    assert schema == {"connect_args": {"type": "dict", "required": True}}
+
+
+@patch(
+    f"{_CC_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-connector-abc1234",
+    },
+)
+@patch(
+    f"{_CC_LOADER}.get_custom_connector_registry",
+    return_value={
+        "custom-connector-abc1234": "/fake/path",
+    },
+)
+def test_custom_connector_without_credentials_schema_returns_none(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    assert get_credentials_schema("custom-connector-abc1234") is None
+
+
+@patch(
+    f"{_ETL_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-etl-connector-abc1234",
+        "credentials_schema": {"connect_args": {"type": "dict", "required": True}},
+    },
+)
+@patch(
+    f"{_ETL_LOADER}.get_custom_etl_connector_registry",
+    return_value={
+        "custom-etl-connector-abc1234": "/fake/etl/path",
+    },
+)
+def test_custom_etl_connector_with_credentials_schema(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    schema = get_credentials_schema("custom-etl-connector-abc1234")
+    assert schema == {"connect_args": {"type": "dict", "required": True}}
+
+
+@patch(
+    f"{_ETL_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-etl-connector-abc1234",
+    },
+)
+@patch(
+    f"{_ETL_LOADER}.get_custom_etl_connector_registry",
+    return_value={
+        "custom-etl-connector-abc1234": "/fake/etl/path",
+    },
+)
+def test_custom_etl_connector_without_credentials_schema_returns_none(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    assert get_credentials_schema("custom-etl-connector-abc1234") is None
+
+
+@patch(f"{_ETL_LOADER}.get_custom_etl_connector_registry", return_value={})
+@patch(f"{_CC_LOADER}.get_custom_connector_registry", return_value={})
+def test_custom_connector_not_in_registry_returns_none(
+    _mock_cc_registry: MagicMock,
+    _mock_etl_registry: MagicMock,
+) -> None:
+    assert get_credentials_schema("custom-connector-unknown") is None
+
+
+@patch.dict("os.environ", {}, clear=False)
+@patch(
+    f"{_CC_LOADER}.load_manifest",
+    return_value={
+        "connection_type": "custom-connector-abc1234",
+        "credentials_schema": {"connect_args": {"type": "dict", "required": True}},
+    },
+)
+@patch(
+    f"{_CC_LOADER}.get_custom_connector_registry",
+    return_value={
+        "custom-connector-abc1234": "/fake/path",
+    },
+)
+def test_custom_connector_schema_works_without_feature_gate(
+    _mock_registry: MagicMock,
+    _mock_manifest: MagicMock,
+) -> None:
+    # Credential validation is read-only and should work regardless of the
+    # MCD_CUSTOM_CONNECTORS_ENABLED proxy factory gate.  The schema lookup
+    # intentionally bypasses the feature flag so operators can validate
+    # credentials even when the connector is not yet enabled for collection.
+    import os
+
+    assert "MCD_CUSTOM_CONNECTORS_ENABLED" not in os.environ
+    schema = get_credentials_schema("custom-connector-abc1234")
+    assert schema == {"connect_args": {"type": "dict", "required": True}}

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -911,6 +911,36 @@ class TestGetConnectionManifests(TestCase):
 
             self.assertIn("custom-etl-connector-bbb", result)
 
+    def test_strips_credentials_schema_from_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            connector_dir = os.path.join(tmp_dir, "adf")
+            os.makedirs(connector_dir, exist_ok=True)
+            manifest = {
+                "connection_type": "custom-etl-connector-aaa",
+                "connection_name": "adf",
+                "credentials_schema": {"connect_args": {"type": "dict"}},
+            }
+            with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
+                json.dump(manifest, f)
+            # connector.py needed for discovery
+            with open(os.path.join(connector_dir, "connector.py"), "w") as f:
+                f.write("class Connector: pass\n")
+
+            with patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._CUSTOM_ETL_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom_etl.custom_etl_connector_loader._custom_etl_connector_registry",
+                None,
+            ):
+                result = CustomEtlProxyClient.get_connection_manifests()
+
+            aaa = result["custom-etl-connector-aaa"]
+            self.assertNotIn("credentials_schema", aaa["manifest"])
+            self.assertEqual(
+                aaa["manifest"]["connection_type"], "custom-etl-connector-aaa"
+            )
+
     def test_returns_empty_when_no_connectors(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with patch(
@@ -923,6 +953,37 @@ class TestGetConnectionManifests(TestCase):
                 result = CustomEtlProxyClient.get_connection_manifests()
 
             self.assertEqual(result, {})
+
+
+class TestGetManifestStripsCredentialsSchema(TestCase):
+    """Verify get_manifest() strips credentials_schema from the returned dict."""
+
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+        return_value={
+            "connection_type": "custom-etl-connector-abc",
+            "name": "adf",
+            "credentials_schema": {"connect_args": {"type": "dict"}},
+        },
+    )
+    @patch(
+        "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+    )
+    def test_get_manifest_strips_credentials_schema(
+        self, mock_load_module, mock_load_manifest
+    ):
+        mock_module = MagicMock()
+        mock_module.Connector.return_value = MagicMock()
+        mock_load_module.return_value = mock_module
+
+        client = CustomEtlProxyClient(
+            credentials={"connect_args": {}},
+            connector_dir="/opt/custom-etl-connectors/adf",
+        )
+        result = client.get_manifest()
+
+        self.assertNotIn("credentials_schema", result)
+        self.assertEqual(result["name"], "adf")
 
 
 class TestGetCustomEtlConnectorTypes(TestCase):

--- a/tests/test_custom_proxy_client.py
+++ b/tests/test_custom_proxy_client.py
@@ -584,6 +584,31 @@ class TestGetConnectionManifests(TestCase):
 
             self.assertEqual(result, {})
 
+    def test_strips_credentials_schema_from_manifest(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            connector_dir = os.path.join(tmp_dir, "db1")
+            os.makedirs(connector_dir, exist_ok=True)
+            manifest = {
+                "connection_type": "custom-connector-aaa",
+                "connection_name": "db1",
+                "credentials_schema": {"connect_args": {"type": "dict"}},
+            }
+            with open(os.path.join(connector_dir, "manifest.json"), "w") as f:
+                json.dump(manifest, f)
+
+            with patch(
+                "apollo.integrations.custom.custom_connector_loader._CUSTOM_CONNECTORS_BASE_PATH",
+                tmp_dir,
+            ), patch(
+                "apollo.integrations.custom.custom_connector_loader._custom_connector_registry",
+                None,
+            ):
+                result = CustomProxyClient.get_connection_manifests()
+
+            aaa = result["custom-connector-aaa"]
+            self.assertNotIn("credentials_schema", aaa["manifest"])
+            self.assertEqual(aaa["manifest"]["connection_type"], "custom-connector-aaa")
+
     def test_handles_missing_templates(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             _create_mock_connector_dir(


### PR DESCRIPTION
## Summary

- Add a third lookup path to `get_credentials_schema()` for custom connectors (`custom-connector-*` / `custom-etl-connector-*`) — reads `credentials_schema` from the connector's `manifest.json` via the existing loader registries
- Resolvers are wrapped in try/except to maintain the `None`-on-failure contract
- Unit tests for all custom connector registry paths (with/without schema, DW/ETL, feature gate bypass)
- E2e endpoint test for custom connector credential validation (valid + invalid credentials)

Part of [YET-1464](https://linear.app/montecarloai/issue/YET-1464/support-self-hosted-credentials-validation-for-custom-connectors). The companion custom-connector-setup PR ([#45](https://github.com/monte-carlo-data/custom-connector-setup/pull/45)) adds the `credentials_schema` field to the manifest scaffolding, export pipeline, and documentation.

## Test plan

- [ ] `pytest tests/credentials/schema/test_registry.py` — custom connector registry tests pass
- [ ] `pytest tests/credentials/schema/test_endpoint.py` — endpoint e2e tests pass
- [ ] Existing documented connector tests still pass (no regression)
- [ ] Custom connector without `credentials_schema` in manifest returns `None` (backwards compatible)
- [ ] Schema lookup works regardless of `MCD_CUSTOM_CONNECTORS_ENABLED` (intentional — read-only validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)