### PR TITLE
Validate self-upgrade image: registry allowlist, platform match, version floor

### DIFF
--- a/apollo/agent/agent.py
+++ b/apollo/agent/agent.py
@@ -38,6 +38,10 @@ from apollo.common.agent.models import (
 from apollo.agent.proxy_client_factory import ProxyClientFactory
 from apollo.agent.settings import VERSION, BUILD_NUMBER
 from apollo.agent.updater import AgentUpdater
+from apollo.agent.upgrade_validation import (
+    get_configured_allowed_repos,
+    validate_upgrade_image,
+)
 from apollo.agent.utils import AgentUtils
 from apollo.credentials.factory import (
     CredentialsFactory,
@@ -322,6 +326,10 @@ class Agent:
         parameters.
         This method checks if there's an agent updater installed in `agent.updater` property and that
         the env var `MCD_AGENT_IS_REMOTE_UPGRADABLE` is set to `true`.
+        When an image is specified it must pass `validate_upgrade_image`: it has to come from the same
+        registry/namespace as the currently running image (widenable via `MCD_AGENT_UPGRADE_ALLOWED_REPOS`)
+        and must not be older than the running version. This prevents the upgrade path from being used to
+        deploy arbitrary or downgraded images.
         The returned response is a dictionary returned by the agent updater implementation.
         """
         with self._inject_log_context("update", trace_id):
@@ -467,6 +475,14 @@ class Agent:
         upgradable = os.getenv(IS_REMOTE_UPGRADABLE_ENV_VAR, "false").lower() == "true"
         if not upgradable:
             raise AgentConfigurationError("Remote upgrades are disabled for this agent")
+
+        if image:
+            validate_upgrade_image(
+                image=image,
+                current_image=updater.get_current_image(),
+                current_version=VERSION,
+                extra_allowed_repos=get_configured_allowed_repos(),
+            )
 
         log_payload = self._logging_utils.build_extra(
             trace_id=trace_id,

--- a/apollo/agent/upgrade_validation.py
+++ b/apollo/agent/upgrade_validation.py
@@ -1,0 +1,270 @@
+"""
+Validation for agent self-upgrade requests.
+
+The `/api/v1/upgrade` endpoint lets the Monte Carlo backend ask the agent to
+redeploy itself with a different container image. Without constraints, any
+caller authorized to invoke the agent can point it at an arbitrary image and
+obtain code execution with the agent's cloud identity. Two cheap, defense-in-
+depth controls are enforced here, at the single choke point in
+`Agent._perform_update`, so all platforms (CloudRun, Azure, Lambda) are covered:
+
+1. Registry/namespace allow-list  - the candidate image must come from the same
+   registry (and, for multi-tenant public registries, the same namespace) as the
+   image the agent is *currently* running. This turns "run any image" into "run
+   another image from the place we already trust", and removes the arbitrary-code
+   property that drives the High severity rating.
+
+2. Platform match                 - the candidate must target the same runtime as
+   the running image (Cloud Run / Azure / ECR-Lambda). Deploying an image built
+   for another platform would brick the service, so a cross-platform swap is
+   rejected.
+
+3. Version floor                  - the candidate image's version may not be
+   older than the running version. This blocks downgrade-to-known-vulnerable
+   attacks that the allow-list alone leaves open.
+"""
+
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+from packaging.version import InvalidVersion, Version
+
+from apollo.common.agent.models import AgentConfigurationError
+
+# Optional operator override: comma-separated "registry/namespace" or
+# "registry/repository" prefixes to permit in addition to the running image's
+# own registry+namespace. Normally empty - the running image is the trust anchor.
+UPGRADE_ALLOWED_REPOS_ENV_VAR = "MCD_AGENT_UPGRADE_ALLOWED_REPOS"
+
+# Public, multi-tenant registries where the namespace (first path segment) is the
+# tenant boundary and therefore must be pinned in addition to the host. For a
+# private registry (e.g. an ECR account host) the host itself is the boundary.
+_PUBLIC_MULTI_TENANT_REGISTRIES = frozenset({"docker.io"})
+
+_DEFAULT_REGISTRY = "docker.io"
+
+# Platform suffix appended to the version in the docker.io agent image tags that
+# this upgrade path supports, e.g. the "azure" in "1.8.6rc1234-azure". Only these
+# two deployments upgrade via a suffixed docker.io tag; it is stripped before PEP
+# 440 parsing. AWS Lambda pulls from ECR with plain "<semver>" tags (no suffix),
+# which parse directly. Other markers (e.g. the docker.io "-lambda" reference
+# image, or "-generic"/"-fargate") are not valid upgrade sources and are rejected
+# by the version floor since they don't parse as a version.
+# Splitting on a known suffix (rather than the first hyphen) also preserves a
+# hyphen that is part of the version itself (e.g. "1.8.6-rc1").
+_SUPPORTED_PLATFORM_TAG_SUFFIXES = frozenset({"cloudrun", "azure"})
+
+# AWS Lambda image URIs may contain "*" in the region segment, which the Lambda
+# updater later replaces with the current region. We normalize that segment away
+# before comparing hosts so the wildcard can't be used to dodge the host match.
+_ECR_HOST_SUFFIX = ".amazonaws.com"
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    """A parsed OCI image reference."""
+
+    registry: str  # normalized host, e.g. "docker.io" or "123.dkr.ecr.*.amazonaws.com"
+    repository: str  # full path, e.g. "montecarlodata/agent" or "mcd-agent"
+    tag: Optional[str]
+    digest: Optional[str]
+
+    @property
+    def namespace(self) -> Optional[str]:
+        """First path segment, the tenant namespace on public registries."""
+        return self.repository.split("/")[0] if "/" in self.repository else None
+
+    @property
+    def is_public_registry(self) -> bool:
+        return self.registry in _PUBLIC_MULTI_TENANT_REGISTRIES
+
+
+def get_configured_allowed_repos() -> List[str]:
+    """Read the optional operator-configured allow-list of extra repo prefixes."""
+    raw = os.getenv(UPGRADE_ALLOWED_REPOS_ENV_VAR, "")
+    return [prefix.strip() for prefix in raw.split(",") if prefix.strip()]
+
+
+def parse_image_ref(image: str) -> ImageRef:
+    """
+    Parse an image reference into (registry, repository, tag, digest), applying
+    Docker's default-registry normalization.
+
+    Deliberately strict: a component is only treated as a registry host if it
+    looks like one (contains "." or ":", or is "localhost"). This prevents
+    registry-confusion bypasses such as "montecarlodata/evil" being read as
+    host="montecarlodata".
+    """
+    ref = image.strip()
+    if not ref:
+        raise AgentConfigurationError("Upgrade rejected: empty image reference")
+
+    # Azure stores the image as a linuxFxVersion string ("DOCKER|<ref>"); strip
+    # that prefix so the current and candidate images parse to the same registry.
+    if ref.upper().startswith("DOCKER|"):
+        ref = ref[len("DOCKER|") :]
+
+    digest: Optional[str] = None
+    if "@" in ref:
+        ref, digest = ref.rsplit("@", 1)
+
+    first, _, rest = ref.partition("/")
+    if rest and ("." in first or ":" in first or first == "localhost"):
+        registry, remainder = first, rest
+    else:
+        registry, remainder = _DEFAULT_REGISTRY, ref
+
+    tag: Optional[str] = None
+    # A ":" after the last "/" is a tag separator (": " inside the host was already
+    # consumed as the port above).
+    repo_part, sep, maybe_tag = remainder.rpartition(":")
+    if sep and "/" not in maybe_tag:
+        repository, tag = repo_part, maybe_tag
+    else:
+        repository = remainder
+
+    if not repository:
+        raise AgentConfigurationError(
+            f"Upgrade rejected: unparseable image reference '{image}'"
+        )
+
+    return ImageRef(
+        registry=_normalize_registry(registry),
+        repository=repository,
+        tag=tag,
+        digest=digest or None,
+    )
+
+
+def _normalize_registry(registry: str) -> str:
+    """Collapse the ECR region segment to '*' so the Lambda wildcard and a
+    concrete region compare equal, and normalize the docker.io aliases."""
+    if registry in ("index.docker.io", "registry-1.docker.io"):
+        return "docker.io"
+    if registry.endswith(_ECR_HOST_SUFFIX) and ".dkr.ecr." in registry:
+        account, _, tail = registry.partition(".dkr.ecr.")
+        # tail looks like "<region>.amazonaws.com"; replace region with "*"
+        _, _, suffix = tail.partition(".")
+        return f"{account}.dkr.ecr.*.{suffix}"
+    return registry
+
+
+def _matches_allowed_source(candidate: ImageRef, current: ImageRef) -> bool:
+    if candidate.registry != current.registry:
+        return False
+    # On a public multi-tenant registry the namespace is the trust boundary and
+    # must match too; on a private registry the host already scopes it.
+    if current.is_public_registry:
+        return candidate.namespace == current.namespace
+    return True
+
+
+def _platform_tag_suffix(ref: ImageRef) -> Optional[str]:
+    """
+    The supported platform suffix on the tag ("cloudrun" or "azure"), or None for
+    a plain tag (e.g. ECR/Lambda "1.8.6", or "latest"). Splits on the LAST hyphen
+    so a hyphen inside the version (e.g. "1.8.6-rc1") is never mistaken for a
+    suffix, and an unsupported marker (e.g. "-lambda") reports as None.
+    """
+    if not ref.tag:
+        return None
+    base, sep, suffix = ref.tag.rpartition("-")
+    return suffix if sep and suffix in _SUPPORTED_PLATFORM_TAG_SUFFIXES else None
+
+
+def _extract_version(ref: ImageRef) -> Optional[Version]:
+    """
+    Best-effort PEP 440 version from a tag like "1.0.1-cloudrun" or
+    "0.0.1rc202-azure". Returns None if no version can be parsed (e.g. "latest",
+    a digest-only reference, or an unsupported suffix like "-lambda").
+    """
+    if not ref.tag:
+        return None
+    suffix = _platform_tag_suffix(ref)
+    candidate = ref.tag[: -(len(suffix) + 1)] if suffix else ref.tag
+    try:
+        return Version(candidate)
+    except InvalidVersion:
+        return None
+
+
+def validate_upgrade_image(
+    image: str,
+    current_image: Optional[str],
+    current_version: str,
+    *,
+    extra_allowed_repos: Optional[Sequence[str]] = None,
+    allow_unversioned: bool = False,
+) -> None:
+    """
+    Raise AgentConfigurationError if `image` is not a permitted upgrade target.
+
+    :param image: the requested image reference from the upgrade request.
+    :param current_image: the image the agent is currently running
+        (updater.get_current_image()); the trust anchor for the allow-list.
+    :param current_version: the running agent version (settings.VERSION);
+        "local" disables the version floor for dev images.
+    :param extra_allowed_repos: optional additional "registry/namespace" or
+        "registry/repository" prefixes to permit, from operator config.
+    :param allow_unversioned: if False (default), reject candidate images whose
+        tag carries no parseable version (e.g. "latest").
+    """
+    candidate = parse_image_ref(image)
+    current = parse_image_ref(current_image) if current_image else None
+
+    # --- Control 1: registry / namespace allow-list ---------------------------
+    allowed = False
+    if current:
+        allowed = _matches_allowed_source(candidate, current)
+    if not allowed and extra_allowed_repos:
+        cand_full = f"{candidate.registry}/{candidate.repository}"
+        allowed = any(cand_full.startswith(prefix) for prefix in extra_allowed_repos)
+    if not allowed:
+        raise AgentConfigurationError(
+            f"Upgrade rejected: image '{image}' is not from an allowed registry/namespace"
+        )
+
+    # --- Control 2: platform match -------------------------------------------
+    # Block a recognized cross-platform swap: an Azure image deployed onto a Cloud
+    # Run service (or vice versa) would not start. Only fires when both images
+    # carry a recognized suffix and they differ; unsuffixed candidates (ECR/Lambda
+    # semver, "latest", digests, unsupported suffixes) fall through to the version
+    # floor, which rejects the ones that aren't a real versioned image.
+    candidate_platform = _platform_tag_suffix(candidate)
+    current_platform = _platform_tag_suffix(current) if current else None
+    if (
+        candidate_platform
+        and current_platform
+        and candidate_platform != current_platform
+    ):
+        raise AgentConfigurationError(
+            f"Upgrade rejected: image '{image}' is a '{candidate_platform}' image but "
+            f"the agent is running a '{current_platform}' image"
+        )
+
+    # --- Control 3: version floor --------------------------------------------
+    if current_version == "local":
+        return  # dev build: no meaningful floor to enforce
+
+    candidate_version = _extract_version(candidate)
+    if candidate_version is None:
+        if allow_unversioned:
+            return
+        raise AgentConfigurationError(
+            f"Upgrade rejected: image '{image}' has no parseable version "
+            f"(expected '<version>', '<version>-cloudrun' or '<version>-azure')"
+        )
+
+    try:
+        running_version = Version(current_version)
+    except InvalidVersion:
+        # Unparseable running version: fail open on the floor only, the
+        # allow-list above still applies.
+        return
+
+    if candidate_version < running_version:
+        raise AgentConfigurationError(
+            f"Upgrade rejected: image version {candidate_version} is older than "
+            f"the running version {running_version} (downgrade blocked)"
+        )

--- a/examples/EXAMPLES.md
+++ b/examples/EXAMPLES.md
@@ -219,7 +219,7 @@ content-type: application/octet-stream
 ```
 
 ## Upgrade endpoint
-The agent can be requested to self-upgrade for those platforms supporting it, for now only CloudRun.
+The agent can be requested to self-upgrade on the platforms that support it: CloudRun, Azure and AWS Lambda.
 The following call requests the agent to upgrade to the given image:
 
 ```shell
@@ -228,3 +228,16 @@ curl http://localhost:8081/api/v1/upgrade -X POST -H "Content-Type: application/
     "image": "montecarlodata/pre-release-agent:0.0.1rc202-cloudrun"
 }'
 ```
+
+The requested image is validated before the agent redeploys; it is rejected unless it:
+- comes from the same registry and namespace as the currently running image (on a
+  private registry such as ECR, the same registry/account), so the upgrade can only
+  pull from an already-trusted source;
+- targets the same platform as the running agent (a CloudRun agent cannot be switched
+  to an Azure image, or vice versa);
+- carries a version no older than the running one (downgrades are rejected), expressed
+  as a parseable version — `latest` and other unversioned tags are not accepted.
+
+If you need to allow images from an additional registry/namespace, set the
+`MCD_AGENT_UPGRADE_ALLOWED_REPOS` environment variable to a comma-separated list of
+allowed `registry/namespace` (or `registry/repository`) prefixes.

--- a/tests/test_upgrade_validation.py
+++ b/tests/test_upgrade_validation.py
@@ -1,0 +1,305 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from apollo.agent.upgrade_validation import (
+    UPGRADE_ALLOWED_REPOS_ENV_VAR,
+    ImageRef,
+    get_configured_allowed_repos,
+    parse_image_ref,
+    validate_upgrade_image,
+)
+from apollo.common.agent.models import AgentConfigurationError
+
+# CloudRun/Azure carry a platform suffix on the docker.io tag; Lambda/ECR tags
+# are plain semver (no suffix), as stored in the ECR repository.
+_DOCKER_CURRENT = "montecarlodata/agent:1.8.6-cloudrun"
+_ECR_CURRENT = "111111111111.dkr.ecr.us-east-1.amazonaws.com/mcd-agent:1.8.6"
+
+
+class ParseImageRefTests(TestCase):
+    def test_docker_bare_reference(self):
+        ref = parse_image_ref("montecarlodata/agent:1.8.6-cloudrun")
+        self.assertEqual("docker.io", ref.registry)
+        self.assertEqual("montecarlodata/agent", ref.repository)
+        self.assertEqual("montecarlodata", ref.namespace)
+        self.assertEqual("1.8.6-cloudrun", ref.tag)
+        self.assertIsNone(ref.digest)
+        self.assertTrue(ref.is_public_registry)
+
+    def test_explicit_registry_with_port_is_not_a_repo_segment(self):
+        ref = parse_image_ref("localhost:5000/team/agent:tag")
+        self.assertEqual("localhost:5000", ref.registry)
+        self.assertEqual("team/agent", ref.repository)
+        self.assertEqual("tag", ref.tag)
+        self.assertFalse(ref.is_public_registry)
+
+    def test_digest_reference(self):
+        ref = parse_image_ref("montecarlodata/agent@sha256:abc123")
+        self.assertEqual("montecarlodata/agent", ref.repository)
+        self.assertIsNone(ref.tag)
+        self.assertEqual("sha256:abc123", ref.digest)
+
+    def test_docker_io_aliases_normalized(self):
+        self.assertEqual(
+            "docker.io",
+            parse_image_ref("index.docker.io/montecarlodata/agent:x").registry,
+        )
+
+    def test_ecr_region_collapsed_to_wildcard(self):
+        # a concrete region and the Lambda "*" wildcard must normalize equal
+        concrete = parse_image_ref(_ECR_CURRENT)
+        wildcard = parse_image_ref(
+            "111111111111.dkr.ecr.*.amazonaws.com/mcd-agent:1.9.0"
+        )
+        self.assertEqual(concrete.registry, wildcard.registry)
+        self.assertEqual("111111111111.dkr.ecr.*.amazonaws.com", concrete.registry)
+
+    def test_azure_linuxfxversion_prefix_stripped(self):
+        # Azure get_current_image() returns "DOCKER|<ref>"; it must parse like the
+        # bare candidate ref so a same-namespace upgrade is allowed.
+        ref = parse_image_ref(
+            "DOCKER|docker.io/montecarlodata/pre-release-agent:0.2.4rc674-azure"
+        )
+        self.assertEqual("docker.io", ref.registry)
+        self.assertEqual("montecarlodata/pre-release-agent", ref.repository)
+        self.assertEqual("montecarlodata", ref.namespace)
+
+    def test_azure_current_image_allows_same_namespace_upgrade(self):
+        validate_upgrade_image(
+            image="docker.io/montecarlodata/pre-release-agent:0.2.4rc675-azure",
+            current_image="DOCKER|docker.io/montecarlodata/pre-release-agent:0.2.4rc674-azure",
+            current_version="0.2.4rc674",
+        )
+
+    def test_empty_reference_rejected(self):
+        with self.assertRaises(AgentConfigurationError):
+            parse_image_ref("   ")
+
+
+class AllowlistTests(TestCase):
+    def test_same_namespace_allowed(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.9.0-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_sibling_repo_same_namespace_allowed(self):
+        # pre-release repo lives under the same docker.io namespace
+        validate_upgrade_image(
+            image="montecarlodata/pre-release-agent:1.9.0rc5-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_different_namespace_rejected(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "not from an allowed"):
+            validate_upgrade_image(
+                image="evil/agent:9.9.9-cloudrun",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_registry_confusion_rejected(self):
+        # attacker-controlled host with a look-alike namespace path
+        with self.assertRaisesRegex(AgentConfigurationError, "not from an allowed"):
+            validate_upgrade_image(
+                image="registry.evil.com/montecarlodata/agent:9.9.9-cloudrun",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_ecr_same_account_with_wildcard_allowed(self):
+        # ECR/Lambda tags are plain semver with no platform suffix
+        validate_upgrade_image(
+            image="111111111111.dkr.ecr.*.amazonaws.com/mcd-agent:1.9.0",
+            current_image=_ECR_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_ecr_different_account_rejected(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "not from an allowed"):
+            validate_upgrade_image(
+                image="222222222222.dkr.ecr.*.amazonaws.com/mcd-agent:1.9.0",
+                current_image=_ECR_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_no_current_image_rejected_without_override(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "not from an allowed"):
+            validate_upgrade_image(
+                image="montecarlodata/agent:1.9.0-cloudrun",
+                current_image=None,
+                current_version="1.8.6",
+            )
+
+    def test_extra_allowed_repos_widens(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.9.0-cloudrun",
+            current_image=None,
+            current_version="1.8.6",
+            extra_allowed_repos=["docker.io/montecarlodata"],
+        )
+
+
+class PlatformMatchTests(TestCase):
+    def test_cross_platform_swap_rejected(self):
+        # cloudrun agent must not be sent an azure image (would not start)
+        with self.assertRaisesRegex(
+            AgentConfigurationError, "is a 'azure' image but .* 'cloudrun'"
+        ):
+            validate_upgrade_image(
+                image="montecarlodata/agent:1.9.0-azure",
+                current_image=_DOCKER_CURRENT,  # ...-cloudrun
+                current_version="1.8.6",
+            )
+
+    def test_same_platform_allowed(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.9.0-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_ecr_plain_tags_match(self):
+        # both sides have no suffix -> same platform
+        validate_upgrade_image(
+            image="111111111111.dkr.ecr.*.amazonaws.com/mcd-agent:1.9.0",
+            current_image=_ECR_CURRENT,
+            current_version="1.8.6",
+        )
+
+
+class VersionFloorTests(TestCase):
+    def test_newer_allowed(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.9.0-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_older_rejected(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "downgrade"):
+            validate_upgrade_image(
+                image="montecarlodata/agent:1.8.5-cloudrun",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_prerelease_is_older_than_final(self):
+        # 1.8.6rc1234 < 1.8.6 per PEP 440
+        with self.assertRaisesRegex(AgentConfigurationError, "downgrade"):
+            validate_upgrade_image(
+                image="montecarlodata/agent:1.8.6rc1234-cloudrun",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_final_newer_than_running_prerelease_allowed(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.8.6-cloudrun",
+            current_image="montecarlodata/agent:1.8.6rc1234-cloudrun",
+            current_version="1.8.6rc1234",
+        )
+
+    def test_newer_prerelease_allowed(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.8.6rc1235-cloudrun",
+            current_image="montecarlodata/agent:1.8.6rc1234-cloudrun",
+            current_version="1.8.6rc1234",
+        )
+
+    def test_same_version_allowed(self):
+        # floor is strictly-less-than; re-deploying the same version is permitted
+        validate_upgrade_image(
+            image="montecarlodata/agent:1.8.6-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+        )
+
+    def test_unversioned_tag_rejected_by_default(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "no parseable version"):
+            validate_upgrade_image(
+                image="montecarlodata/agent:latest",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_unversioned_tag_allowed_when_opted_in(self):
+        validate_upgrade_image(
+            image="montecarlodata/agent:latest",
+            current_image=_DOCKER_CURRENT,
+            current_version="1.8.6",
+            allow_unversioned=True,
+        )
+
+    def test_digest_only_treated_as_unversioned(self):
+        with self.assertRaisesRegex(AgentConfigurationError, "no parseable version"):
+            validate_upgrade_image(
+                image="montecarlodata/agent@sha256:abc123",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_unsupported_platform_suffix_rejected(self):
+        # only "-cloudrun"/"-azure" suffixes are supported; "-lambda" (a docker.io
+        # reference-only tag) and "-fargate"/"-generic" are not upgrade sources and
+        # do not parse as a version, so they are rejected
+        for tag in ("1.9.0-lambda", "1.9.0-fargate", "1.9.0-generic"):
+            with self.subTest(tag=tag):
+                with self.assertRaisesRegex(
+                    AgentConfigurationError, "no parseable version"
+                ):
+                    validate_upgrade_image(
+                        image=f"montecarlodata/agent:{tag}",
+                        current_image=_DOCKER_CURRENT,
+                        current_version="1.8.6",
+                    )
+
+    def test_ecr_plain_semver_floor_enforced(self):
+        # plain ECR semver tags compare directly
+        with self.assertRaisesRegex(AgentConfigurationError, "downgrade"):
+            validate_upgrade_image(
+                image="111111111111.dkr.ecr.*.amazonaws.com/mcd-agent:1.8.5",
+                current_image=_ECR_CURRENT,
+                current_version="1.8.6",
+            )
+
+    def test_local_running_version_skips_floor(self):
+        # dev build: downgrade check cannot be meaningfully applied
+        validate_upgrade_image(
+            image="montecarlodata/agent:0.0.1-cloudrun",
+            current_image=_DOCKER_CURRENT,
+            current_version="local",
+        )
+
+    def test_hyphenated_prerelease_suffix_not_truncated(self):
+        # guards the rpartition-on-known-suffix behavior: "1.8.6-rc1" must not be
+        # read as "1.8.6"
+        with self.assertRaisesRegex(AgentConfigurationError, "downgrade"):
+            validate_upgrade_image(
+                image="montecarlodata/agent:1.8.6-rc1-cloudrun",
+                current_image=_DOCKER_CURRENT,
+                current_version="1.8.6",
+            )
+
+
+class ConfiguredAllowedReposTests(TestCase):
+    def test_empty_when_unset(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop(UPGRADE_ALLOWED_REPOS_ENV_VAR, None)
+            self.assertEqual([], get_configured_allowed_repos())
+
+    def test_parses_comma_separated(self):
+        with patch.dict(
+            "os.environ",
+            {
+                UPGRADE_ALLOWED_REPOS_ENV_VAR: "docker.io/montecarlodata, docker.io/other "
+            },
+        ):
+            self.assertEqual(
+                ["docker.io/montecarlodata", "docker.io/other"],
+                get_configured_allowed_repos(),
+            )


### PR DESCRIPTION
## What & why

A security review flagged the `/api/v1/upgrade` endpoint as a post-authentication RCE path: it accepted **any** image, so an authenticated caller could redeploy the agent with arbitrary code under the agent's cloud identity. The endpoint is reachable by the normal invoker and is enabled by default in the deployment terraform modules (`remote_upgradable = true`), so "disabled by default" did not hold.

This adds agent-side validation of the requested image. It does **not** rely on the backend — it independently constrains a direct, post-auth call to the endpoint (the attacker in the finding), and it complements what `monolith` already enforces when it builds the image.

## What it does

Validation runs at the single choke point in `Agent._perform_update`, so all four updaters (CloudRun, Azure, Lambda direct + CFN) are covered. Three checks:

1. **Registry/namespace allowlist** — the candidate must come from the same registry as the running image (and, on multi-tenant registries like docker.io, the same namespace); on a private registry such as ECR the account/host is the boundary. Removes the "arbitrary code" property. Widenable via `MCD_AGENT_UPGRADE_ALLOWED_REPOS`.
2. **Platform match** — rejects a recognized cross-platform swap (`cloudrun`↔`azure`) that would fail to boot. Availability/foot-gun guard.
3. **Version floor** — rejects downgrades (blocks downgrade-to-known-vulnerable); unversioned tags (`latest`, digest-only) are rejected by default. Pre-release ordering follows PEP 440 (`1.8.6rc1234 < 1.8.6`).

Parsing is registry-confusion resistant (anchored host parse), normalizes the ECR region wildcard (`*`), and strips the Azure `DOCKER|` linuxFxVersion prefix.

Verified against the authoritative backend path (`monolith/service/agents/agent.py::_get_image`): it never sends `latest`, forces the platform variant to match the agent, and sends AWS images as plain-semver ECR URIs with the `*` region wildcard — all of which the validator accepts.

## Testing

- New `tests/test_upgrade_validation.py` — parsing, allowlist bypass matrix (registry confusion, ECR account/wildcard, namespace lookalikes), platform match, version floor (rc/final ordering, downgrade, unversioned, dev `local`).
- Full suite: 1302 passed. `black --check` clean, `pyright` 0 errors.

## Notes for reviewers

- This does not change the deployment modules' `remote_upgradable` default or the Azure Contributor role grant — those live in the `terraform-*` repos and are tracked separately.
- Signature/attestation verification was discussed and intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)