### PR TITLE
feat(http-proxy): add response_format=text option to do_request (YET-1511)

### DIFF
--- a/apollo/integrations/databricks/databricks_rest_proxy_client.py
+++ b/apollo/integrations/databricks/databricks_rest_proxy_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from apollo.agent.utils import AgentUtils
 from apollo.integrations.base_proxy_client import BaseProxyClient
@@ -47,15 +47,19 @@ class DatabricksRestProxyClient(BaseProxyClient):
         url = AgentUtils.normalize_url(
             self._databricks_workspace_url, url
         )  # url is actually the path
-        return self._http_client.do_request(
-            url=url,
-            http_method=http_method,
-            payload=payload,
-            timeout=timeout,
-            user_agent=user_agent,
-            additional_headers=additional_headers,
-            params=params,
-            retry_status_code_ranges=retry_status_code_ranges,
+        # This client never requests response_format="text", so the proxy always returns a dict.
+        return cast(
+            Dict,
+            self._http_client.do_request(
+                url=url,
+                http_method=http_method,
+                payload=payload,
+                timeout=timeout,
+                user_agent=user_agent,
+                additional_headers=additional_headers,
+                params=params,
+                retry_status_code_ranges=retry_status_code_ranges,
+            ),
         )
 
     def get_error_type(self, error: Exception) -> Optional[str]:

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -136,7 +136,8 @@ class HttpProxyClient(BaseProxyClient):
         verify_ssl: Optional[Union[bool, str]] = None,
         retry_status_code_ranges: Optional[List[Tuple]] = None,
         data: Optional[str] = None,
-    ) -> Dict:
+        response_format: str = "json",
+    ) -> Union[Dict, str]:
         """
         Executes a single request with no retry, intended to be used for JSON request/response endpoints.
         If the status code is included in `retry_status_code_ranges` then `HttpRetryableError` will be raised.
@@ -166,7 +167,12 @@ class HttpProxyClient(BaseProxyClient):
         use ``download_bytes`` instead, which wraps the request in
         ``safety_policy(url, strict_ip_policy=True, https_only=True)``.
 
-        :return: the JSON result of the request
+        :param data: optional raw request body (e.g. a SOAP/XML envelope); sent as-is.
+        :param response_format: "json" (default) decodes the response body as JSON;
+            "text" returns the raw response body string (for non-JSON APIs such as SOAP/XML
+            that the caller parses itself).
+        :return: the JSON-decoded response (response_format="json") or the raw body string
+            (response_format="text")
         """
 
         request_args = {}
@@ -210,6 +216,10 @@ class HttpProxyClient(BaseProxyClient):
                 raise HttpClientError(text) from err
             raise type(err)(text) from err
 
+        # `text` returns the raw response body (e.g. SOAP/XML APIs that the DC parses
+        # itself); default `json` preserves the historical JSON-decoded behavior.
+        if response_format == "text":
+            return response.text
         return response.json()
 
     @contextmanager
@@ -574,12 +584,15 @@ class HttpProxyClient(BaseProxyClient):
         params: Optional[Dict] = None,
         retry_status_code_ranges: Optional[List[Tuple]] = None,
         retry_args: Optional[Dict] = None,
-    ) -> Dict:
+        data: Optional[str] = None,
+        response_format: str = "json",
+    ) -> Union[Dict, str]:
         """
         Same as `do_request` but retrying based on the status codes defined by `retry_status_code_ranges` and
         `retry_args`.
         `retry_status_code_args` defaults to 429 and 5xx errors
         `retry_args` defaults to: tries=2, delay=2, backoff=2, max_delay=10
+        `data` (raw request body) and `response_format` ("json"|"text") are forwarded to `do_request`.
         """
 
         retry_status_code_ranges = (
@@ -598,6 +611,8 @@ class HttpProxyClient(BaseProxyClient):
                 "additional_headers": additional_headers,
                 "params": params,
                 "retry_status_code_ranges": retry_status_code_ranges,
+                "data": data,
+                "response_format": response_format,
             },
             exceptions=HttpRetryableError,
             **retry_params,  # type: ignore

--- a/apollo/integrations/http/http_proxy_client.py
+++ b/apollo/integrations/http/http_proxy_client.py
@@ -217,9 +217,15 @@ class HttpProxyClient(BaseProxyClient):
             raise type(err)(text) from err
 
         # `text` returns the raw response body (e.g. SOAP/XML APIs that the DC parses
-        # itself); default `json` preserves the historical JSON-decoded behavior.
+        # itself); default `json` preserves the historical JSON-decoded behavior. Reject
+        # anything else so a misspelled option fails loudly here instead of as a confusing
+        # JSON decode error on a non-JSON body.
         if response_format == "text":
             return response.text
+        if response_format != "json":
+            raise ValueError(
+                f"Unsupported response_format '{response_format}'; expected 'json' or 'text'"
+            )
         return response.json()
 
     @contextmanager

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -123,6 +123,24 @@ class TestHttpClient(TestCase):
         )
 
     @patch("requests.request")
+    def test_http_request_unsupported_response_format_raises(self, mock_request):
+        # An unsupported response_format must fail loudly rather than silently falling back
+        # to JSON-decoding a (possibly non-JSON) body (YET-1511).
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+
+        client = HttpProxyClient(credentials=_HTTP_CREDENTIALS)
+        with self.assertRaises(ValueError) as ctx:
+            client.do_request(
+                url="https://test.com/path",
+                http_method="GET",
+                response_format="xml",
+            )
+        self.assertIn("xml", str(ctx.exception))
+        # The body is never JSON-decoded for an unsupported format.
+        mock_response.json.assert_not_called()
+
+    @patch("requests.request")
     @patch("apollo.agent.agent.logger.info")
     def test_http_request_data_redacted(self, mock_info, mock_request):
         mock_response = create_autospec(Response)

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -80,6 +80,49 @@ class TestHttpClient(TestCase):
         self.assertEqual(expected_result, response.result.get(ATTRIBUTE_NAME_RESULT))
 
     @patch("requests.request")
+    def test_http_request_text_response_format(self, mock_request):
+        # response_format="text" returns the raw response body (e.g. a SOAP/XML response the
+        # caller parses itself) instead of JSON-decoding, and a raw `data` body + content_type
+        # are forwarded to the request (YET-1511).
+        mock_response = create_autospec(Response)
+        mock_request.return_value = mock_response
+        mock_response.text = "<soapenv:Envelope>resp</soapenv:Envelope>"
+        operation = {
+            "trace_id": "1234",
+            "commands": [
+                {
+                    "method": "do_request",
+                    "kwargs": {
+                        "url": "https://test.com/services/Soap/m/64.0",
+                        "http_method": "POST",
+                        "data": "<soapenv:Envelope>req</soapenv:Envelope>",
+                        "content_type": "text/xml; charset=UTF-8",
+                        "additional_headers": {"SOAPAction": ""},
+                        "response_format": "text",
+                    },
+                }
+            ],
+        }
+        response = self._agent.execute_operation(
+            "http",
+            "do_request",
+            operation,
+            _HTTP_CREDENTIALS,
+        )
+        # Raw XML body + content type are forwarded to the underlying request.
+        _, kwargs = mock_request.call_args
+        self.assertEqual(kwargs["data"], "<soapenv:Envelope>req</soapenv:Envelope>")
+        self.assertEqual(kwargs["headers"]["Content-Type"], "text/xml; charset=UTF-8")
+        self.assertEqual(kwargs["headers"]["SOAPAction"], "")
+        # Response returned as raw text, NOT JSON-decoded.
+        mock_response.raise_for_status.assert_called_once()
+        mock_response.json.assert_not_called()
+        self.assertEqual(
+            "<soapenv:Envelope>resp</soapenv:Envelope>",
+            response.result.get(ATTRIBUTE_NAME_RESULT),
+        )
+
+    @patch("requests.request")
     @patch("apollo.agent.agent.logger.info")
     def test_http_request_data_redacted(self, mock_info, mock_request):
         mock_response = create_autospec(Response)


### PR DESCRIPTION
## What

Adds a `response_format` option (`"json"` default | `"text"`) to the generic HTTP proxy's `do_request` (and `do_request_with_retry`). `"text"` returns the raw response body string instead of JSON-decoding it; `do_request_with_retry` also now forwards the raw `data` body + `response_format`. Default behavior is unchanged.

## Why

The HTTP proxy always did `return response.json()`, so the data-collector could only route JSON APIs through the agent. The Salesforce **SOAP Metadata API** (used for SFDC Data Cloud DLO→DMO lineage) returns XML, so `response.json()` raised — meaning agent-mode SFDC connections got no DLO→DMO lineage ([YET-1510](https://linear.app/montecarloai/issue/YET-1510)). The request side already supported a raw `data` body + `content_type`; this closes the response side.

This is generic and reusable for any XML/non-JSON proxied API — not SFDC-specific.

## Enables
[YET-1510](https://linear.app/montecarloai/issue/YET-1510) (data-collector): build the SOAP request + parse the XML in the DC, calling the proxy with `response_format="text"`. The DC gates on this agent version, so older agents are unaffected and simply skip DLO→DMO (as today). **This must deploy before YET-1510 can be validated end-to-end.**

## Testing
- `tests/test_http_client.py::test_http_request_text_response_format` — asserts the raw `data` body + `content_type`/`SOAPAction` are forwarded and the response is returned as raw text (not JSON-decoded).
- Full `test_http_client.py` suite green (94 passed); pyright clean; black formatted.