### PR TITLE
fix(deps): bump agent-base to v0.0.3 — redact credentials from error responses

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.2
+agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.3
 
 azure-identity==1.18.0
 azure-core==1.38.2  # YET-463

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras requirements.in
 #
-agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.2
+agent-base @ git+https://github.com/monte-carlo-data/agent-base.git@v0.0.3
     # via -r requirements.in
 asn1crypto==1.5.1
     # via snowflake-connector-python

--- a/tests/test_sql_server_client.py
+++ b/tests/test_sql_server_client.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 from typing import (
     Iterable,
     List,
@@ -7,6 +8,7 @@ from typing import (
 )
 from unittest import TestCase
 from unittest.mock import Mock, call, patch
+import pyodbc
 from psycopg2.errors import InsufficientPrivilege  # noqa
 
 from apollo.agent.agent import Agent
@@ -281,3 +283,62 @@ class SqlServerClientTests(TestCase):
         response = SqlServerProxyClient._handle_datetimeoffset(datetimeoffset_as_binary)
 
         self.assertEqual(response, expected_datetime)
+
+
+class SqlServerCredentialSafetyTests(TestCase):
+    """The SQL Server client passes credentials as a single ODBC connection string
+    (``UID=...;PWD=...``) straight to ``pyodbc.connect``, so it is the structurally-
+    exposed client: if that string surfaces in a connection exception, the password
+    must be stripped before the error reaches the SaaS. Regression for the
+    error-response credential-leak finding (HIGH, CVSS 7.5)."""
+
+    _SERVER = "tcp:db.example.com,1433"
+    _PASSWORD = "S3cr3tMsSqlPwd"
+
+    _CONNECTION_STRING = (
+        "DRIVER={ODBC Driver 17 for SQL Server};"
+        f"SERVER={_SERVER};"
+        "DATABASE=prod;"
+        "UID=alice;"
+        f"PWD={_PASSWORD}"
+    )
+
+    _OPERATION = {
+        "trace_id": "ctp-safety-test",
+        "skip_cache": True,
+        "commands": [
+            {"method": "cursor", "store": "_cursor"},
+        ],
+    }
+
+    def setUp(self) -> None:
+        self._agent = Agent(LoggingUtils())
+
+    @patch("pyodbc.connect")
+    def test_connection_string_in_exception_does_not_leak_credentials(
+        self, mock_connect
+    ):
+        # Fail the connection with an exception that echoes the ODBC connection string
+        # back (UID/PWD included) — the worst case if pyodbc or a wrapper surfaces the DSN.
+        def _raise_echoing_connection_string(connection_string, *args, **kwargs):
+            raise pyodbc.OperationalError(
+                "08001",
+                f"[08001] Login timeout expired; connection string: {connection_string}",
+            )
+
+        mock_connect.side_effect = _raise_echoing_connection_string
+
+        response = self._agent.execute_operation(
+            "sql-server",
+            "run_query",
+            self._OPERATION,
+            {"connect_args": self._CONNECTION_STRING},
+        )
+
+        serialized = json.dumps(response.result, default=str)
+        # safe: the password value never reaches the SaaS, anywhere in the response
+        self.assertNotIn(self._PASSWORD, serialized)
+        # actionable: the server and the error context survive for debugging
+        error = response.result.get(ATTRIBUTE_NAME_ERROR, "")
+        self.assertIn(self._SERVER, error)
+        self.assertIn("Login timeout expired", error)


### PR DESCRIPTION
## What & why

A security review found (**HIGH, CVSS 7.5** — unintentional inclusion of sensitive data in network messages):

> Any exceptions that occur in executing a command are sent to the MCD SaaS … If these exception tracebacks contain sensitive data (e.g. a database connect string), that entire string, including credentials, will be sent to the SaaS [and] logged in the customer account.

Error responses serialize the exception into `__mcd_error__` / `__mcd_exception__` / `__mcd_stack_trace__` with no redaction, so any credential that reaches an exception message or traceback is sent to the SaaS verbatim. This is most acute for the pyodbc clients (SQL Server, Azure SQL, MS Fabric), which assemble credentials into a single ODBC connection string (`UID=...;PWD=...`); kwargs-based clients like Postgres don't carry the secret as one string. The reviewer flagged this for connect-string-based databases. This change strips connect-string-shaped secrets from error responses regardless of the exact path.

**Caveat on reproducibility:** the leak is conditional on the driver (or a wrapper) actually surfacing the connection string in its exception. We could not reproduce it with our current drivers — psycopg2 is called with kwargs and never includes the password in its exception/traceback, and pyodbc did not echo the connection string on the failure paths we could test. So this lands as **defense-in-depth** against that class of leak rather than a fix for a confirmed live exposure.

The fix lives in agent-base ([PR #8](https://github.com/monte-carlo-data/agent-base/pull/8), released as **v0.0.3**): `_response_for_error()` now strips secret *values* inline (URL userinfo, `key=value`/JSON connect-string pairs, `Bearer`/`Basic` headers, bare high-entropy tokens) while leaving the surrounding message intact, so errors stay actionable.

## This PR

- Bumps the `agent-base` pin `v0.0.2` → `v0.0.3` (`requirements.in` + regenerated `requirements.txt`; only the pin changed, no transitive churn).
- Adds a regression test on the SQL Server (pyodbc) client — the structurally-exposed one — that fails the connection with an exception carrying the ODBC connection string (`PWD=...`) and asserts the password is stripped from the response while the server/error context survive. **Fails on v0.0.2, passes on v0.0.3.**

The existing `*CredentialSafetyTests` (actionable-and-safe contract) continue to pass — the inline redactor was chosen specifically so it doesn't clobber messages like `"authentication failed for user"`.

## Tests

Full suite green against the real v0.0.3 dependency. `black` + `pyright` clean.

## Checklist
- [x] Tests added/updated
- [x] `black` + `pyright` pass
- [na] Docs — dependency bump + internal redaction, no user-facing docs