### PR TITLE
refactor(cloudrun): pin stdout StructuredLogHandler for logging

### DIFF
--- a/apollo/interfaces/cloudrun/logging_setup.py
+++ b/apollo/interfaces/cloudrun/logging_setup.py
@@ -1,0 +1,30 @@
+import logging
+
+from google.cloud.logging import Client
+from google.cloud.logging.handlers import StructuredLogHandler, setup_logging
+
+
+def setup_cloud_run_logging(client: Client, is_debug_log: bool) -> None:
+    """Install the stdout-based ``StructuredLogHandler`` for Cloud Run.
+
+    We pin ``StructuredLogHandler`` explicitly rather than relying on
+    ``Client.setup_logging()``'s environment auto-detection. For the
+    ``cloud_run_revision`` resource type the library already selects this same
+    handler (see ``get_default_handler()`` in
+    ``google/cloud/logging_v2/client.py``), so this is behavior-preserving.
+
+    Pinning it makes the log path unambiguous: records are written to stdout and
+    ingested out-of-process by Cloud Run, never held in an in-process gRPC buffer
+    (as the API-based ``CloudLoggingHandler`` would). This avoids any chance of
+    falling back to the buffered handler if resource detection fails, and
+    documents for future reviewers that we do not buffer logs in-process.
+
+    :param client: the GCP logging client, used to resolve the project id for
+        the structured-log trace fields.
+    :param is_debug_log: when True, the root logger is set to ``DEBUG`` level;
+        otherwise ``INFO``.
+    """
+    setup_logging(
+        StructuredLogHandler(project_id=client.project),
+        log_level=logging.DEBUG if is_debug_log else logging.INFO,
+    )

--- a/apollo/interfaces/cloudrun/main.py
+++ b/apollo/interfaces/cloudrun/main.py
@@ -14,6 +14,7 @@ from apollo.common.agent.redact import AgentRedactUtilities
 from apollo.common.agent.redact_formatter import RedactFormatterWrapper
 from apollo.agent.utils import AgentUtils
 from apollo.interfaces.generic.log_context import BaseLogContext
+from apollo.interfaces.cloudrun.logging_setup import setup_cloud_run_logging
 from apollo.interfaces.cloudrun.platform import CloudRunPlatformProvider
 
 # CloudRun specific application that adds support for structured logging
@@ -21,9 +22,7 @@ from apollo.interfaces.cloudrun.platform import CloudRunPlatformProvider
 # initialize CloudRun logging
 gcp_logging_client = google.cloud.logging.Client()
 is_debug_log = os.getenv(DEBUG_LOG_ENV_VAR, "false").lower() == "true"
-gcp_logging_client.setup_logging(
-    log_level=logging.DEBUG if is_debug_log else logging.INFO
-)
+setup_cloud_run_logging(gcp_logging_client, is_debug_log)
 
 root_logger = logging.getLogger()
 for h in root_logger.handlers:

--- a/tests/test_cloud_run_logging_setup.py
+++ b/tests/test_cloud_run_logging_setup.py
@@ -1,0 +1,52 @@
+import logging
+from unittest import TestCase
+from unittest.mock import patch, create_autospec
+
+from google.cloud.logging import Client
+from google.cloud.logging.handlers import CloudLoggingHandler, StructuredLogHandler
+
+from apollo.interfaces.cloudrun.logging_setup import setup_cloud_run_logging
+
+
+class CloudRunLoggingSetupTests(TestCase):
+    """Guards the Cloud Run log path against silently switching to the buffered,
+    API-based ``CloudLoggingHandler``. A security review raised that an in-process
+    gRPC log buffer would let an attacker with RCE drop log records before
+    ingestion; we pin the stdout-based ``StructuredLogHandler`` so that risk does
+    not apply. These tests fail loudly if that pin is ever lost.
+    """
+
+    def _run_setup(self, is_debug_log: bool):
+        client = create_autospec(Client, instance=True)
+        client.project = "test-project-id"
+        # patch the module-level setup_logging so we capture the handler without
+        # mutating the global root logger state.
+        with patch(
+            "apollo.interfaces.cloudrun.logging_setup.setup_logging"
+        ) as setup_logging_mock:
+            setup_cloud_run_logging(client, is_debug_log)
+        setup_logging_mock.assert_called_once()
+        return setup_logging_mock.call_args
+
+    def test_installs_stdout_structured_log_handler(self):
+        handler = self._run_setup(is_debug_log=False).args[0]
+
+        # the handler must be the stdout/stream-based StructuredLogHandler ...
+        self.assertIsInstance(handler, StructuredLogHandler)
+        self.assertIsInstance(handler, logging.StreamHandler)
+        # ... and explicitly NOT the buffered, API-based CloudLoggingHandler.
+        self.assertNotIsInstance(handler, CloudLoggingHandler)
+        # the buffered handler is the one that carries an in-process transport.
+        self.assertFalse(hasattr(handler, "transport"))
+
+    def test_passes_project_id_from_client(self):
+        handler = self._run_setup(is_debug_log=False).args[0]
+        self.assertEqual(handler.project_id, "test-project-id")
+
+    def test_log_level_defaults_to_info(self):
+        call_args = self._run_setup(is_debug_log=False)
+        self.assertEqual(call_args.kwargs["log_level"], logging.INFO)
+
+    def test_log_level_debug_when_enabled(self):
+        call_args = self._run_setup(is_debug_log=True)
+        self.assertEqual(call_args.kwargs["log_level"], logging.DEBUG)


### PR DESCRIPTION
## What & why

A customer security review flagged (MEDIUM, CVSS 5.5) that Apollo's Cloud Run logs go through a buffered, API-based handler whose in-process gRPC buffer an attacker with RCE could drain before ingestion — deleting evidence of compromise.

The premise is **incorrect**. On Cloud Run, `Client.setup_logging()` auto-selects the handler from the detected resource type, and for `cloud_run_revision` the library already returns the **stdout-based `StructuredLogHandler`**, not the buffered `CloudLoggingHandler` (see `get_default_handler()` in `google/cloud/logging_v2/client.py:390-391`, `google-cloud-logging==3.12.1`). Logs are written to stdout and ingested **out-of-process** by Cloud Run — there is no in-process log buffer to tamper with.

This PR makes that explicit so the finding can't be re-raised by a future reviewer (or silently regress):

- Extracts logging setup into `setup_cloud_run_logging()` (own module, so it's testable without `main.py`'s import-time `Client()` + Flask construction).
- Pins `StructuredLogHandler` explicitly instead of relying on environment auto-detection. **Behavior-preserving** on Cloud Run; also removes the theoretical fallback to the buffered handler if resource detection ever failed.
- In-code docstring documents the stdout / out-of-process log path.

## Testing

- New `tests/test_cloud_run_logging_setup.py` (4 cases): asserts the installed handler **is** a stdout `StructuredLogHandler`/`StreamHandler`, **is not** a `CloudLoggingHandler`, has no `transport`, sources `project_id` from the client, and honors the debug log-level flag.
- Test-first proof: temporarily swapping the helper back to `CloudLoggingHandler` makes all 4 tests fail; reverting makes them pass.
- Full run green (new + `test_cloud_run_platform.py` + `test_cloud_run_updater.py` = 7 passed); `black` + `pyright` pre-commit hooks pass.

## Checklist

- [x] Tests added/updated
- [x] Lint/format (black) and type checks (pyright) pass
- [na] Docs — no user-facing/config changes; rationale captured in code + this PR
- [na] DB migrations
- [x] Behavior-preserving in production (same handler the library already selected on Cloud Run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)