### PR TITLE
feat: agent-side run status mapping for custom ETL connectors

### DIFF
--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -53,11 +53,29 @@ checks this before falling through to either custom connector path.
     "job": "Pipeline",
     "task": "Activity"
   },
-  "icon_url": "https://example.com/icon.png"
+  "icon_url": "https://example.com/icon.png",
+  "run_status_mapping": {
+    "Succeeded": "success",
+    "Failed": "error",
+    "Running": "running"
+  },
+  "task_run_status_mapping": {
+    "Completed": "success",
+    "Faulted": "error",
+    "InProgress": "running"
+  }
 }
 ```
 
 The optional `credentials_schema` key accepts a cerberus schema dict for self-hosted credential validation.
+
+## Run status normalization
+
+The optional `run_status_mapping` and `task_run_status_mapping` manifest keys let a connector
+declare how its source-specific status strings map to Monte Carlo's normalized status enum
+(e.g. `success`, `error`, `running`). When present, `fetch_etl_runs` applies the mapping
+post-fetch: the original value is preserved as `raw_status` and the normalized value is written
+to `status`. When absent the mapping is a no-op and statuses pass through unchanged.
 
 ## Connector interface
 

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -16,6 +16,31 @@ logger = logging.getLogger(__name__)
 _ATTR_CONNECT_ARGS = "connect_args"
 
 
+def _apply_status_mapping(event: Dict[str, Any], mapping: Dict[str, str]) -> None:
+    """Normalize a run/task-run event's status using the manifest mapping.
+
+    Preserves the original vendor status as ``raw_status``. Case-insensitive
+    key lookup. Unmapped statuses normalize to ``"unknown"``.
+
+    Mapping values are validated at build time (generate_agent_image.py) and
+    at monolith registration time — no runtime validation here.
+    """
+    vendor_status = event.get("status", "")
+    if not vendor_status:
+        return
+
+    # Case-insensitive lookup
+    lowered = vendor_status.lower()
+    normalized = "unknown"
+    for key, value in mapping.items():
+        if key.lower() == lowered:
+            normalized = value.lower()
+            break
+
+    event["raw_status"] = vendor_status
+    event["status"] = normalized
+
+
 def _serialize(obj: Any) -> Any:
     """Serialize connector model objects to JSON-compatible dicts.
 
@@ -134,6 +159,13 @@ class CustomEtlProxyClient(BaseProxyClient):
         ``timedelta``, ``job_run_ids`` maps to ``run_ids``.  When
         ``job_ids`` is provided, results are post-filtered to include
         only runs whose ``job_source_id`` is in the set.
+
+        When the manifest declares ``run_status_mapping``, vendor statuses
+        are normalized post-fetch: the original vendor value is preserved
+        as ``raw_status`` and ``status`` is replaced with the canonical MC
+        value.  Unmapped statuses normalize to ``"unknown"``.  This is
+        Option A (agent-side normalization) — diverges from native
+        integrations which normalize in the monolith.
         """
         lookback = timedelta(minutes=lookback_min)
         runs = self._connector.fetch_run_details(
@@ -145,6 +177,15 @@ class CustomEtlProxyClient(BaseProxyClient):
         if job_ids:
             allowed = set(job_ids)
             runs = [r for r in runs if r.get("job_source_id") in allowed]
+
+        run_mapping = self._manifest.get("run_status_mapping")
+        task_mapping = self._manifest.get("task_run_status_mapping") or run_mapping
+        if run_mapping:
+            for run in runs:
+                _apply_status_mapping(run, run_mapping)
+                for task_run in run.get("task_runs", []):
+                    _apply_status_mapping(task_run, task_mapping or run_mapping)
+
         return {"all_results": [_serialize(r) for r in runs]}
 
     def get_manifest(self) -> Dict:

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -13,6 +13,7 @@ from apollo.integrations.custom_etl.custom_etl_connector_loader import (
 from apollo.agent.agent import Agent
 from apollo.integrations.custom_etl.custom_etl_proxy_client import (
     CustomEtlProxyClient,
+    _apply_status_mapping,
     _serialize,
 )
 
@@ -1184,3 +1185,145 @@ class TestProxyClientFactory(TestCase):
                 credentials={"connect_args": {}},
                 platform="generic",
             )
+
+
+# ---------------------------------------------------------------------------
+# Status mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStatusMapping(TestCase):
+    """Unit tests for _apply_status_mapping helper."""
+
+    def test_mapping_applied_correctly(self):
+        """(a) Vendor status is normalized via the mapping."""
+        event = {"status": "Succeeded", "job_source_id": "j1"}
+        _apply_status_mapping(event, {"Succeeded": "success", "Failed": "failed"})
+        self.assertEqual(event["status"], "success")
+        self.assertEqual(event["raw_status"], "Succeeded")
+
+    def test_unmapped_status_normalizes_to_unknown(self):
+        """(b) Vendor status not in mapping normalizes to 'unknown'."""
+        event = {"status": "Suspended"}
+        _apply_status_mapping(event, {"Succeeded": "success"})
+        self.assertEqual(event["status"], "unknown")
+        self.assertEqual(event["raw_status"], "Suspended")
+
+    def test_raw_status_preserved(self):
+        """(c) raw_status preserves the original vendor value."""
+        event = {"status": "InProgress"}
+        _apply_status_mapping(event, {"InProgress": "in_progress"})
+        self.assertEqual(event["raw_status"], "InProgress")
+        self.assertEqual(event["status"], "in_progress")
+
+    def test_case_insensitive_key_matching(self):
+        """(f) Case-insensitive: manifest has 'Succeeded', event has 'succeeded'."""
+        event = {"status": "succeeded"}
+        _apply_status_mapping(event, {"Succeeded": "success"})
+        self.assertEqual(event["status"], "success")
+        self.assertEqual(event["raw_status"], "succeeded")
+
+    def test_empty_status_is_noop(self):
+        """Empty status string is a no-op."""
+        event = {"status": ""}
+        _apply_status_mapping(event, {"Succeeded": "success"})
+        self.assertNotIn("raw_status", event)
+        self.assertEqual(event["status"], "")
+
+
+class TestFetchEtlRunsStatusMapping(TestCase):
+    """Integration tests for status mapping in fetch_etl_runs."""
+
+    def setUp(self):
+        self._mock_module = MagicMock()
+        self._mock_connector = MagicMock()
+        self._mock_module.Connector.return_value = self._mock_connector
+
+    def _create_client(self, manifest):
+        with patch(
+            "apollo.integrations.custom_etl.custom_etl_proxy_client.load_manifest",
+            return_value=manifest,
+        ), patch(
+            "apollo.integrations.custom_etl.custom_etl_proxy_client.load_connector_module"
+        ) as mock_load_module:
+            mock_load_module.return_value = self._mock_module
+            return CustomEtlProxyClient(
+                credentials={"connect_args": {}},
+                connector_dir="/opt/custom-etl-connectors/test",
+            )
+
+    def test_no_mapping_noop(self):
+        """(d) No mapping in manifest — status unchanged, no raw_status added."""
+        self._mock_connector.fetch_run_details.return_value = [
+            {"job_source_id": "j1", "run_source_id": "r1", "status": "Succeeded"},
+        ]
+        client = self._create_client({})
+        result = client.fetch_etl_runs(lookback_min=60)
+
+        run = result["all_results"][0]
+        self.assertEqual(run["status"], "Succeeded")
+        self.assertNotIn("raw_status", run)
+
+    def test_mapping_applied_to_runs(self):
+        """Mapping normalizes run statuses and preserves raw_status."""
+        self._mock_connector.fetch_run_details.return_value = [
+            {"job_source_id": "j1", "run_source_id": "r1", "status": "Succeeded"},
+            {"job_source_id": "j1", "run_source_id": "r2", "status": "Failed"},
+        ]
+        manifest = {"run_status_mapping": {"Succeeded": "success", "Failed": "failed"}}
+        client = self._create_client(manifest)
+        result = client.fetch_etl_runs(lookback_min=60)
+
+        self.assertEqual(result["all_results"][0]["status"], "success")
+        self.assertEqual(result["all_results"][0]["raw_status"], "Succeeded")
+        self.assertEqual(result["all_results"][1]["status"], "failed")
+        self.assertEqual(result["all_results"][1]["raw_status"], "Failed")
+
+    def test_task_run_status_mapping_used_when_present(self):
+        """(e) task_run_status_mapping used for task runs when present."""
+        self._mock_connector.fetch_run_details.return_value = [
+            {
+                "job_source_id": "j1",
+                "run_source_id": "r1",
+                "status": "Succeeded",
+                "task_runs": [
+                    {
+                        "job_source_id": "j1",
+                        "run_source_id": "t1",
+                        "status": "Completed",
+                    },
+                ],
+            },
+        ]
+        manifest = {
+            "run_status_mapping": {"Succeeded": "success"},
+            "task_run_status_mapping": {"Completed": "success"},
+        }
+        client = self._create_client(manifest)
+        result = client.fetch_etl_runs(lookback_min=60)
+
+        run = result["all_results"][0]
+        self.assertEqual(run["status"], "success")
+        task = run["task_runs"][0]
+        self.assertEqual(task["status"], "success")
+        self.assertEqual(task["raw_status"], "Completed")
+
+    def test_task_runs_fall_back_to_run_mapping(self):
+        """(e) task runs fall back to run_status_mapping when no task mapping."""
+        self._mock_connector.fetch_run_details.return_value = [
+            {
+                "job_source_id": "j1",
+                "run_source_id": "r1",
+                "status": "Failed",
+                "task_runs": [
+                    {"job_source_id": "j1", "run_source_id": "t1", "status": "Failed"},
+                ],
+            },
+        ]
+        manifest = {"run_status_mapping": {"Failed": "failed"}}
+        client = self._create_client(manifest)
+        result = client.fetch_etl_runs(lookback_min=60)
+
+        task = result["all_results"][0]["task_runs"][0]
+        self.assertEqual(task["status"], "failed")
+        self.assertEqual(task["raw_status"], "Failed")


### PR DESCRIPTION
## Summary

- Phase 2 of [YET-1495](https://linear.app/montecarloai/issue/YET-1495): agent-side status normalization for custom ETL connectors
- `CustomEtlProxyClient.fetch_etl_runs()` reads `run_status_mapping` from the loaded manifest, normalizes vendor statuses post-fetch, and preserves the original as `raw_status`
- Case-insensitive key lookup; unmapped statuses normalize to `"unknown"`; `task_run_status_mapping` falls back to `run_status_mapping` when absent; no-op when manifest has no mapping
- Tests cover all enumerated cases: mapping applied, unmapped → unknown, raw_status preserved, no-op, task mapping with fallback, case-insensitive matching

## Context

- **Phase 1** (custom-connector-setup): [PR #47](https://github.com/monte-carlo-data/custom-connector-setup/pull/47) — manifest schema, test framework, connector base class
- **Phase 3** (monolith-django): manifest validation + `CustomEtlConnectorManifest` property extraction — next

## Test plan

- [ ] `pytest tests/test_custom_etl_proxy_client.py` — all new and existing tests pass
- [ ] Verify no-op behavior when manifest has no `run_status_mapping` (existing connectors unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)