### PR TITLE
Don't revoke SFDC core token on the client-credentials path (fix INVALID_SESSION_ID)

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -201,6 +201,9 @@ class SalesforceDataCloudConnection(SalesforceCDPConnection):
         if refresh_token == "required_but_not_used":
             refresh_token = None
 
+        def noop(*args: Any, **kwargs: Any) -> None:
+            pass
+
         if core_token is not None:
             # Old DC path: exchange the externally-provided core_token.
             # Pass a fake refresh_token so the library enters the exchange path.
@@ -216,9 +219,6 @@ class SalesforceDataCloudConnection(SalesforceCDPConnection):
                 refresh_token="required_but_not_used",
                 dataspace=dataspace,
             )
-
-            def noop(*args: Any, **kwargs: Any) -> None:
-                pass
 
             def raise_on_renewal(*args: Any, **kwargs: Any) -> NoReturn:
                 raise Exception(
@@ -241,13 +241,32 @@ class SalesforceDataCloudConnection(SalesforceCDPConnection):
         else:
             # New DC path: let the library handle OAuth + exchange via client credentials.
             # _token_by_client_creds_flow fetches a core token then exchanges it for
-            # a scoped Data Cloud token. No overrides needed.
+            # a scoped Data Cloud token.
             super().__init__(
                 login_url,
                 client_id=client_id,
                 client_secret=client_secret,
                 dataspace=dataspace,
             )
+
+            # Suppress _revoke_core_token (YET-1546). After the a360 exchange the library
+            # revokes the freshly minted core token (_exchange_token -> _revoke_core_token).
+            # Salesforce's client-credentials flow reuses a single platform session per
+            # connected app, so revoking it invalidates the session the data-collector
+            # reuses for its /ssot/* REST and SOAP Metadata calls -> INVALID_SESSION_ID,
+            # which silently drops DLO freshness/volume + federation lineage. The
+            # short-lived core token expires on its own; no explicit revoke is needed.
+            if (
+                hasattr(self, "authentication_helper")
+                and self.authentication_helper
+                and hasattr(self.authentication_helper, "_revoke_core_token")
+            ):
+                self.authentication_helper._revoke_core_token = noop
+            else:
+                raise Exception(
+                    "salesforce-cdp-connector library has changed. "
+                    "Cannot override _revoke_core_token()."
+                )
 
     def cursor(self) -> SalesforceCDPCursor:
         """Override to return a cursor that retries on transient network errors.

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -545,6 +545,46 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         self.assertIn("HTTP 200", error_message)
         self.assertIn("invalid_dataspace", error_message)
 
+    def test_client_credentials_flow_does_not_revoke_core_token(self):
+        """YET-1546: on the client-credentials (no core_token) path, the freshly minted
+        core token must NOT be revoked after the a360 exchange. Salesforce reuses one
+        platform session per connected app, so revoking it invalidates the session the
+        data-collector reuses for its /ssot/* + SOAP metadata calls (INVALID_SESSION_ID).
+        """
+        revoke_callback = Mock(return_value=(200, {}, ""))
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/oauth2/revoke"
+        )
+        self.mock_responses.add_callback(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/oauth2/revoke",
+            callback=revoke_callback,
+        )
+
+        operation = {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [
+                {"method": "list_tables", "kwargs": {"dataspace": "UnifiedKnowledge"}}
+            ],
+        }
+        credentials = {**self.credentials}
+        credentials["connect_args"] = {
+            k: v
+            for k, v in self.credentials["connect_args"].items()
+            if k != "core_token"
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_no_revoke_client_creds",
+            operation_dict=operation,
+            credentials=credentials,
+        )
+
+        self.assertFalse(response.is_error)
+        revoke_callback.assert_not_called()
+
     def test_classify_exchange_status(self):
         """_classify_exchange_status returns the right label for each HTTP status family."""
         from apollo.integrations.db.salesforce_data_cloud_proxy_client import (


### PR DESCRIPTION
## What

Stop revoking the Salesforce Data Cloud core/platform token on the **client-credentials** connection path (used for dataspace-scoped `list_tables`).

## Why ([YET-1546](https://linear.app/montecarloai/issue/YET-1546))

On agent-deployed SFDC Data Cloud collections, `/ssot/data-streams`, `/ssot/calculated-insights`, and the SOAP Metadata (OSTM) calls fail with Salesforce `INVALID_SESSION_ID` on nearly every collection (25+ errors/7d on the dev validation org). Those calls feed DLO **freshness/volume** (YET-1506) and **federation / DLO→DMO lineage** (YET-1452), so the collector silently emits DLOs without them (the `_safe` wrappers degrade gracefully) — DLO freshness/volume + lineage end up missing for SFDC agent customers.

**Root cause:** in `fetch_tables`, `list_tables` (the a360 token exchange) runs first. On the client-credentials path (`core_token=None`), the vendored `salesforcecdpconnector` revokes the freshly minted core token after the exchange (`_exchange_token` → `_revoke_core_token` → `POST /services/oauth2/revoke`). Salesforce's client-credentials flow reuses a single platform session per connected app, so the data-collector's subsequent `/ssot/*` + SOAP grants get back the **just-revoked** session → `INVALID_SESSION_ID`. (The SOAP fault is explicit: *"Session not found … usually occurs after a session expires or a user logs out"*.)

The `core_token`-supplied path already overrides `_revoke_core_token` to a no-op for exactly this reason; this PR applies the same override to the client-credentials path.

## Change

- `SalesforceDataCloudConnection.__init__`: hoist the `noop` helper and override `authentication_helper._revoke_core_token = noop` on the `core_token is None` branch, with the same "library changed" guard as the existing branch. The short-lived core token expires on its own; no explicit revoke is needed.

## Testing

- New unit test `test_client_credentials_flow_does_not_revoke_core_token`: drives `list_tables(dataspace=…)` on the client-credentials path and asserts `/services/oauth2/revoke` is **not** called. Red before the change (revoke called once), green after.
- Full `tests/test_salesforce_data_cloud_client.py`: **29 passed**.
- `black` + `pyright` clean.

## Rollout / verification

Will be applied to `dev` and verified on the next SFDC metadata collection of the dev "YET-1406 SFDC validation - agent" warehouse: confirm no `INVALID_SESSION_ID` in the data-collector logs and that DLO freshness/volume populate.

## Notes

- This relies on one Salesforce-side behavior (client-credentials re-issuing the same revoked session) that the `INVALID_SESSION_ID` symptom confirms empirically but isn't provable from code alone — the dev re-run is the final confirmation.
- The validation org is separately hitting `REQUEST_LIMIT_EXCEEDED` (daily API quota); that's an org-config issue, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
