### PR TITLE
fix(deps): bump cryptography 48.0.0 -> 48.0.1 (GHSA-537c-gmf6-5ccf)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ brotli==1.2.0  # Upgrade transient dependency of flask-compress to address SEC-1
 cachetools==5.3.3  # Runtime dep for apollo/credentials/external_credentials_cache.py; pinned here so it shows up in install_requires for downstream consumers
 cerberus>=1.3.5
 clickhouse-connect==0.8.18
-cryptography>=46.0.5  # CVE-2026-26007
+cryptography>=48.0.1  # CVE-2026-26007; >=48.0.1 for GHSA-537c-gmf6-5ccf (bundled OpenSSL OOB read, fixed in 48.0.1)
 databricks-sql-connector==4.0.0
 databricks-sdk==0.39.0
 duckdb==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ click==8.1.7
     #   presto-python-client
 clickhouse-connect==0.8.18
     # via -r requirements.in
-cryptography==48.0.0
+cryptography==48.0.1
     # via
     #   -r requirements.in
     #   azure-identity


### PR DESCRIPTION
## What

Bumps `cryptography` from `48.0.0` to `48.0.1` to clear **GHSA-537c-gmf6-5ccf** (HIGH, CVSS 7.5), surfaced in the daily `#collection-agent-vuln-scans` report (2026-06-21) as a *shared* finding across all agent image tags.

The 48.0.0 PyPI wheels bundle a statically-linked OpenSSL with an out-of-bounds read (per OpenSSL's 2026-06-09 advisory). pyca/cryptography rebuilt its wheels against the patched OpenSSL in 48.0.1.

## Changes

- `requirements.in`: raise the floor `cryptography>=46.0.5` → `>=48.0.1`, documenting the advisory inline (prevents regression to a vulnerable wheel).
- `requirements.txt`: re-pin `cryptography==48.0.1`.

No other lockfile changes: on `main`, cryptography is only a direct entry in the base `requirements.txt` — the azure/cloudrun/lambda/dev lockfiles install it transitively via `-c requirements.txt`, so this single bump covers every tag.

## Verification

Regenerated `requirements.txt` with `pip-compile --strip-extras` in a clean **Python 3.12** venv (pip-tools 7.5.3, matching the lockfile header). Result was a **single-line diff** (`48.0.0` → `48.0.1`) with no transitive churn and no jump to the newly-released `49.0.0` — the bump is surgical and the lockfile is reproducible. CI image build + scan is the final gate.

## Key Decisions

- **Patch bump, not latest.** `49.0.0` is now out, but a CVE fix shouldn't drag in a major version. Re-pinning the lockfile to `48.0.1` before recompiling (no `--upgrade`) keeps pip-compile pinned to the patched version only.
- **Based on `main` (Python 3.12), not the in-flight 3.13 migration branch.** The 3.13 work (VULN-1230) also pins `cryptography==48.0.0` in its azure lockfile and will need the same 48.0.1 bump independently — this PR does not reach it.
- Other open scan findings (MessagePack `CVE-2026-48109` azure-only; Debian perl/xvfb/libnss3/libhttp-daemon CVEs) are either already in flight or have no upstream fix, and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)