### PR TITLE
fix(db2): accept ODBC-spelled credential keys in CTP mapper

### DIFF
--- a/apollo/integrations/ctp/defaults/db2.py
+++ b/apollo/integrations/ctp/defaults/db2.py
@@ -21,9 +21,10 @@ class Db2ClientArgs(TypedDict):
     SSLServerCertificate: NotRequired[str]  # path to CA PEM file
 
 
-# DB2 self-hosted credentials schema mirrors the docs accordion. The CTP also
-# accepts host/user/password/db_name as alternate spellings on the DC pre-shape
-# path, but customer self-hosted JSON is expected to follow the docs.
+# DB2 self-hosted credentials schema mirrors the docs accordion: the DC pre-shape
+# path (clients/plugins/plugin_db2.py) sends connect_args with IBM ODBC key names
+# (hostname/uid/pwd/database). The mapper below also accepts the flat spellings
+# (host/user/password/db_name) so direct flat credentials resolve too.
 DB2_CREDENTIALS_SCHEMA = {
     "connect_args": {
         "type": "dict",
@@ -75,11 +76,11 @@ DB2_DEFAULT_CTP = CtpConfig(
         name="db2_client_args",
         schema=Db2ClientArgs,
         field_map={
-            "HOSTNAME": "{{ raw.host }}",
+            "HOSTNAME": "{{ raw.host | default(raw.hostname) }}",
             "PORT": "{{ raw.port | default(50000) }}",
             "DATABASE": "{{ raw.db_name | default(raw.database) }}",
-            "UID": "{{ raw.user | default(raw.username) }}",
-            "PWD": "{{ raw.password }}",
+            "UID": "{{ raw.user | default(raw.username) | default(raw.uid) }}",
+            "PWD": "{{ raw.password | default(raw.pwd) }}",
             "PROTOCOL": "TCPIP",
             "querytimeout": "{{ raw.query_timeout_in_seconds | default(none) }}",
             "connecttimeout": "{{ raw.connect_timeout | default(none) }}",

--- a/tests/ctp/test_db2_ctp.py
+++ b/tests/ctp/test_db2_ctp.py
@@ -65,6 +65,54 @@ class TestDb2Ctp(TestCase):
         )
         self.assertEqual("bob", args["UID"])
 
+    # ── ODBC-spelled aliases (data-collector pre-shape path) ───────────
+    # plugin_db2.py builds connect_args with the IBM ODBC key names
+    # (hostname/uid/pwd/database); the mapper must accept those too.
+
+    def test_hostname_field_alias(self):
+        args = _resolve(
+            {"hostname": "odbc-host", "db_name": "d", "user": "u", "password": "p"}
+        )
+        self.assertEqual("odbc-host", args["HOSTNAME"])
+
+    def test_uid_field_alias(self):
+        args = _resolve(
+            {"host": "h", "db_name": "d", "uid": "db2inst1", "password": "p"}
+        )
+        self.assertEqual("db2inst1", args["UID"])
+
+    def test_pwd_field_alias(self):
+        args = _resolve({"host": "h", "db_name": "d", "user": "u", "pwd": "secret"})
+        self.assertEqual("secret", args["PWD"])
+
+    def test_dc_preshaped_connect_args_path(self):
+        """Replicates the data-collector agent path (plugin_db2.py): ODBC-spelled
+        credentials wrapped in connect_args, resolved through the registry (which
+        unwraps connect_args before running the pipeline). Regression for the
+        "'host' is undefined" failure — the mapper read raw.host/raw.user/
+        raw.password, none of which exist on this path.
+        """
+        resolved = CtpRegistry.resolve(
+            "db2",
+            {
+                "connect_args": {
+                    "hostname": "db2.example.com",
+                    "port": 50000,
+                    "database": "testdb",
+                    "uid": "admin",
+                    "pwd": "secret",
+                },
+                "ssl_options": {},
+            },
+        )
+        args = resolved["connect_args"]
+        self.assertEqual("db2.example.com", args["HOSTNAME"])
+        self.assertEqual(50000, args["PORT"])
+        self.assertEqual("testdb", args["DATABASE"])
+        self.assertEqual("admin", args["UID"])
+        self.assertEqual("secret", args["PWD"])
+        self.assertEqual("TCPIP", args["PROTOCOL"])
+
     # ── Optional timeout fields ────────────────────────────────────────
 
     def test_query_timeout_maps_to_querytimeout(self):


### PR DESCRIPTION
## What
Adding Db2 connections to agents was failing with this error:
<img width="475" height="329" alt="image" src="https://github.com/user-attachments/assets/9e9d602c-7a73-4049-b040-bcffb5ac1126" />


The Db2 CTP mapper only read the **flat** credential spellings (`raw.host`, `raw.user`, `raw.password`), but the data-collector agent path (`clients/plugins/plugin_db2.py`) pre-shapes credentials into `connect_args` using IBM **ODBC** key names (`hostname`/`uid`/`pwd`/`database`). The registry unwraps `connect_args` before running the pipeline, so `raw.host` was undefined and integration validation failed with **`'host' is undefined`**.

This fix adds the ODBC spellings as fallbacks in the mapper, mirroring how `DATABASE` already handled `db_name` → `database`. The misleading schema comment (which had the DC path's spellings backwards) is also corrected.

## Why it shipped broken

The existing `tests/ctp/test_db2_ctp.py` tests only exercised flat creds via `CtpPipeline().execute()` **directly** — they never went through the registry's `connect_args` unwrap path that the real agent uses. So the mismatch was never caught.

## Repro

Add a Db2 integration via an agent → "Test Db2 integration" → "Connect to Db2" fails with Cause `'host' is undefined`. Confirmed not a monolith-django or frontend issue (both consistently send `host`); the rename to ODBC keys happens in data-collector's pre-shape, and the agent's CTP mapper couldn't find them.

## Tests

- 3 ODBC-alias tests (`hostname`/`uid`/`pwd`) matching the existing alias-test style.
- 1 end-to-end `test_dc_preshaped_connect_args_path` resolving through `CtpRegistry.resolve` — replicates `plugin_db2.py` exactly (the true regression test).
- **Test-first verified:** all 4 new tests failed with the undefined error before the fix.
- After fix: 17/17 in the db2 file; **522/522** across `tests/ctp` + `tests/test_db2_client.py`. `black --check` clean, `pyright` 0 errors.

## Notes

- Fixed at the CTP mapper layer (accept both spellings) — the robust layer. Alternative would be to stop renaming keys in `plugin_db2.py` (data-collector), but that's riskier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)