### PR TITLE
feat(salesforce-data-cloud): generic ssot_get agent op for SFDC SSOT reads (YET-1615)

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -1,5 +1,6 @@
 import http.client
 import logging
+import re
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
@@ -117,24 +118,26 @@ def _classify_exchange_status(status: int | None) -> str:
     return "other"
 
 
-import re as _re
-
-_ACCESS_TOKEN_PATTERN = _re.compile(r"('access_token'\s*:\s*)'[^']*'")
+_SENSITIVE_VALUE_PATTERN = re.compile(
+    r"(['\"](?:access_token|refresh_token|id_token|signature)['\"]\s*:\s*)['\"][^'\"]*['\"]"
+)
 
 
 def _redact_body(body: str | None) -> str | None:
     """
-    Redact access_token values from a captured a360/token response body string
-    before including it in error messages or log records.
+    Redact sensitive token values from a captured a360/token response body
+    string before including it in error messages or log records.
 
-    The body is stored as str(response.json()), so token values appear as
-    Python string literals: 'access_token': 'eyJ...'. Redacting prevents
-    accidental credential exposure when an unrelated error fires after a
-    successful token exchange.
+    The body may be stored as str(response.json()) (token values appear as
+    Python string literals: 'access_token': 'eyJ...') or as raw response.text
+    (double-quoted JSON: "access_token": "eyJ..."). Both single- and
+    double-quoted forms of access_token / refresh_token / id_token / signature
+    are masked. Redacting prevents accidental credential exposure when an
+    unrelated error fires after a successful token exchange.
     """
     if body is None:
         return None
-    return _ACCESS_TOKEN_PATTERN.sub(r"\1'[REDACTED]'", body)
+    return _SENSITIVE_VALUE_PATTERN.sub(r"\1'[REDACTED]'", body)
 
 
 def _attach_capturing_session(
@@ -620,10 +623,14 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 f"(HTTP {token_response.status_code}, Salesforce response: {body})"
             ) from e
 
-    def ssot_get(self, path: str) -> dict:
+    def ssot_get(self, path: str) -> dict | list:
         """
         Issue an authenticated GET against a Salesforce **core REST** path on the
         connection's My Domain and return the parsed JSON body.
+
+        The body is returned as-is from ``response.json()`` — usually a JSON
+        object (``dict``), but occasionally a top-level JSON list for some core
+        REST endpoints.
 
         This is the generic primitive the data-collector uses to read the
         Salesforce SSOT metadata endpoints
@@ -648,7 +655,12 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         (``code NNN`` format) on a non-200 or non-JSON response, with the
         response body redacted before it is surfaced.
         """
-        if not path.startswith("/") or path.startswith("//") or "://" in path:
+        if (
+            not isinstance(path, str)
+            or not path.startswith("/")
+            or path.startswith("//")
+            or "://" in path
+        ):
             raise ValueError(
                 f"Salesforce Data Cloud ssot_get: path must be a relative path "
                 f"beginning with '/' (no scheme or host), got: {path!r}"

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -498,42 +498,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         )
 
         # 1. Mint a core OAuth token via the client-credentials grant.
-        token_url = f"https://{domain}/services/oauth2/token"
-        token_response = session.post(
-            token_url,
-            data={
-                "grant_type": "client_credentials",
-                "client_id": self._credentials.client_id,
-                "client_secret": self._credentials.client_secret,
-            },
-            timeout=_DISCOVERY_REQUEST_TIMEOUT_SECONDS,
-        )
-        if token_response.status_code != 200:
-            body = _redact_body(session.last_exchange_body)
-            status = session.last_exchange_status
-            logger.warning(
-                "Salesforce Data Cloud: OAuth token mint failed during dataspace discovery",
-                extra={
-                    "exchange_status_code": status,
-                    "exchange_error_type": _classify_exchange_status(status),
-                    "exchange_response_body": body,
-                },
-            )
-            detail = f" (Salesforce response: {body})" if body else ""
-            raise RuntimeError(
-                f"Salesforce Data Cloud dataspace discovery: OAuth token mint "
-                f"failed with code {token_response.status_code}{detail}"
-            )
-
-        try:
-            access_token = token_response.json()["access_token"]
-        except (ValueError, KeyError) as e:
-            body = _redact_body(session.last_exchange_body)
-            raise RuntimeError(
-                f"Salesforce Data Cloud dataspace discovery: OAuth response missing "
-                f"access_token (HTTP {token_response.status_code}, "
-                f"Salesforce response: {body})"
-            ) from e
+        access_token = self._mint_core_token(session)
 
         # 2. Issue SOQL query for the Dataspace SObject; follow nextRecordsUrl pagination.
         dataspaces: list[str] = []
@@ -600,6 +565,138 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             },
         )
         return dataspaces
+
+    def _mint_core_token(self, session: _CapturingSession) -> str:
+        """
+        Mint a short-lived core OAuth token via the Salesforce client-credentials
+        grant (``POST /services/oauth2/token`` on the org's My Domain) and return
+        the access token.
+
+        This token authenticates Salesforce **core REST** calls
+        (``/services/data/...``) as the connected app's run-as user. The
+        ``salesforcecdpconnector`` library mints its own token internally for Data
+        Cloud query traffic but does not expose that flow for arbitrary core REST
+        calls, so dataspace discovery (:meth:`list_dataspaces`) and generic SSOT
+        reads (:meth:`ssot_get`) mint their own token here.
+
+        ``session`` is a :class:`_CapturingSession` so the caller can surface the
+        redacted response body on failure. Raises ``RuntimeError`` (``code NNN``
+        format) on a non-200 response or a payload missing ``access_token``. The
+        token itself is never logged.
+        """
+        domain = self._credentials.domain
+        token_url = f"https://{domain}/services/oauth2/token"
+        token_response = session.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": self._credentials.client_id,
+                "client_secret": self._credentials.client_secret,
+            },
+            timeout=_DISCOVERY_REQUEST_TIMEOUT_SECONDS,
+        )
+        if token_response.status_code != 200:
+            body = _redact_body(session.last_exchange_body)
+            status = session.last_exchange_status
+            logger.warning(
+                "Salesforce Data Cloud: OAuth core token mint failed",
+                extra={
+                    "exchange_status_code": status,
+                    "exchange_error_type": _classify_exchange_status(status),
+                    "exchange_response_body": body,
+                },
+            )
+            detail = f" (Salesforce response: {body})" if body else ""
+            raise RuntimeError(
+                f"Salesforce Data Cloud: OAuth core token mint failed with code "
+                f"{token_response.status_code}{detail}"
+            )
+        try:
+            return token_response.json()["access_token"]
+        except (ValueError, KeyError) as e:
+            body = _redact_body(session.last_exchange_body)
+            raise RuntimeError(
+                f"Salesforce Data Cloud: OAuth response missing access_token "
+                f"(HTTP {token_response.status_code}, Salesforce response: {body})"
+            ) from e
+
+    def ssot_get(self, path: str) -> dict:
+        """
+        Issue an authenticated GET against a Salesforce **core REST** path on the
+        connection's My Domain and return the parsed JSON body.
+
+        This is the generic primitive the data-collector uses to read the
+        Salesforce SSOT metadata endpoints
+        (``/services/data/{version}/ssot/*`` — data streams, catalogs, schemas,
+        ...). The data-collector supplies the path to append; the agent owns
+        building the URL from the connection's credentials and authenticating the
+        call, so the customer's token never leaves the agent — only the JSON body
+        is returned.
+
+        Authentication mirrors :meth:`list_dataspaces`: a short-lived core token
+        is minted via the client-credentials grant (:meth:`_mint_core_token`) and
+        sent as a Bearer credential. SSOT endpoints are core REST on the My Domain
+        authenticated with the **core token** — not the Data Cloud query token
+        obtained via the a360 exchange.
+
+        ``path`` must be a relative path beginning with ``/`` (e.g.
+        ``/services/data/v62.0/ssot/data-streams``). Absolute URLs and
+        protocol-relative values (carrying a scheme or host) are rejected so the
+        minted token is only ever sent to the connection's own My Domain.
+
+        Raises ``ValueError`` for an unsafe ``path`` and ``RuntimeError``
+        (``code NNN`` format) on a non-200 or non-JSON response, with the
+        response body redacted before it is surfaced.
+        """
+        if not path.startswith("/") or path.startswith("//") or "://" in path:
+            raise ValueError(
+                f"Salesforce Data Cloud ssot_get: path must be a relative path "
+                f"beginning with '/' (no scheme or host), got: {path!r}"
+            )
+
+        domain = self._credentials.domain
+        session = _CapturingSession()
+
+        logger.info(
+            "Salesforce Data Cloud: SSOT GET "
+            f"(domain={domain}, path={path}, "
+            f"client_id={self._credentials.client_id[:8]}...)",
+            extra={"ssot_path": path},
+        )
+
+        access_token = self._mint_core_token(session)
+
+        response = session.get(
+            f"https://{domain}{path}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=_DISCOVERY_REQUEST_TIMEOUT_SECONDS,
+        )
+        if response.status_code != 200:
+            body = _redact_body(session.last_exchange_body)
+            status = session.last_exchange_status
+            logger.warning(
+                "Salesforce Data Cloud: SSOT GET failed",
+                extra={
+                    "ssot_path": path,
+                    "exchange_status_code": status,
+                    "exchange_error_type": _classify_exchange_status(status),
+                    "exchange_response_body": body,
+                },
+            )
+            detail = f" (Salesforce response: {body})" if body else ""
+            raise RuntimeError(
+                f"Salesforce Data Cloud SSOT GET {path} failed with code "
+                f"{response.status_code}{detail}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as e:
+            body = _redact_body(session.last_exchange_body)
+            raise RuntimeError(
+                f"Salesforce Data Cloud SSOT GET {path}: non-JSON response "
+                f"(HTTP {response.status_code}, Salesforce response: {body})"
+            ) from e
 
     def _serialize_table(self, table: GenieTable) -> dict:
         fields: list[Field] = table.fields

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -1,6 +1,7 @@
 import http.client
 import logging
 import re
+import urllib.parse
 from dataclasses import dataclass
 from typing import Any, NoReturn
 
@@ -586,9 +587,9 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         reads (:meth:`ssot_get`) mint their own token here.
 
         ``session`` is a :class:`_CapturingSession` so the caller can surface the
-        redacted response body on failure. Raises ``RuntimeError`` (``code NNN``
-        format) on a non-200 response or a payload missing ``access_token``. The
-        token itself is never logged.
+        redacted response body on failure. Raises ``RuntimeError`` carrying
+        ``code NNN`` on a non-200 response, and ``HTTP NNN`` on a 200 payload
+        missing ``access_token``. The token itself is never logged.
         """
         domain = self._credentials.domain
         token_url = f"https://{domain}/services/oauth2/token"
@@ -650,33 +651,43 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         obtained via the a360 exchange.
 
         ``path`` must be a relative path beginning with ``/`` (e.g.
-        ``/services/data/v62.0/ssot/data-streams``). Absolute URLs and
-        protocol-relative values (carrying a scheme or host) are rejected so the
-        minted token is only ever sent to the connection's own My Domain.
+        ``/services/data/v62.0/ssot/data-streams``). Values carrying a scheme or
+        host (absolute or protocol-relative URLs) are rejected so the minted
+        token is only ever sent to the connection's own My Domain. Rejection is
+        based on the parsed URL structure, so a query string that merely embeds
+        a URL (e.g. a pagination cursor) is allowed.
 
-        Raises ``ValueError`` for an unsafe ``path`` and ``RuntimeError``
-        (``code NNN`` format) on a non-200 or non-JSON response, with the
-        response body redacted before it is surfaced.
+        Raises ``ValueError`` for an unsafe ``path``; ``RuntimeError`` carrying
+        ``code NNN`` on a non-200 response and ``HTTP NNN`` on a non-JSON 200
+        response, with the response body redacted before it is surfaced.
         """
+        try:
+            split = urllib.parse.urlsplit(path) if isinstance(path, str) else None
+        except ValueError:
+            split = None
         if (
-            not isinstance(path, str)
-            or not path.startswith("/")
-            or path.startswith("//")
-            or "://" in path
+            split is None
+            or split.scheme
+            or split.netloc
+            or not split.path.startswith("/")
         ):
             raise ValueError(
                 f"Salesforce Data Cloud ssot_get: path must be a relative path "
                 f"beginning with '/' (no scheme or host), got: {path!r}"
             )
+        # Query-string values (pagination cursors, filters) may be sensitive —
+        # logs and error messages only ever carry the path component.
+        log_path = split.path
+        has_query = bool(split.query)
 
         domain = self._credentials.domain
         session = _CapturingSession()
 
         logger.info(
             "Salesforce Data Cloud: SSOT GET "
-            f"(domain={domain}, path={path}, "
+            f"(domain={domain}, path={log_path}, has_query={has_query}, "
             f"client_id={self._credentials.client_id[:8]}...)",
-            extra={"ssot_path": path},
+            extra={"ssot_path": log_path, "ssot_has_query": has_query},
         )
 
         access_token = self._mint_core_token(session)
@@ -692,7 +703,8 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             logger.warning(
                 "Salesforce Data Cloud: SSOT GET failed",
                 extra={
-                    "ssot_path": path,
+                    "ssot_path": log_path,
+                    "ssot_has_query": has_query,
                     "exchange_status_code": status,
                     "exchange_error_type": _classify_exchange_status(status),
                     "exchange_response_body": body,
@@ -700,7 +712,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             )
             detail = f" (Salesforce response: {body})" if body else ""
             raise RuntimeError(
-                f"Salesforce Data Cloud SSOT GET {path} failed with code "
+                f"Salesforce Data Cloud SSOT GET {log_path} failed with code "
                 f"{response.status_code}{detail}"
             )
 
@@ -709,7 +721,7 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
         except ValueError as e:
             body = _redact_body(session.last_exchange_body)
             raise RuntimeError(
-                f"Salesforce Data Cloud SSOT GET {path}: non-JSON response "
+                f"Salesforce Data Cloud SSOT GET {log_path}: non-JSON response "
                 f"(HTTP {response.status_code}, Salesforce response: {body})"
             ) from e
 

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1331,6 +1331,104 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         self.assertIn("code 404", message)
         self.assertIn("NOT_FOUND", message)
 
+    def test_ssot_get_forwards_query_string(self):
+        """A path carrying a query string (`?limit=100`) is allowed by the guard
+        and forwarded to Salesforce verbatim — `responses` matches on the base
+        URL, so assert the actual request URL preserved the query string."""
+        path_with_query = "/services/data/v62.0/ssot/data-streams?limit=100"
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(return_value=(200, {}, json.dumps({"dataStreams": []}))),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_query_string",
+            operation_dict=self._ssot_get_operation(path_with_query),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        ssot_call = next(
+            c
+            for c in self.mock_responses.calls
+            if "/ssot/data-streams" in c.request.url
+        )
+        self.assertIn("limit=100", ssot_call.request.url)
+
+    def test_ssot_get_non_json_200_raises_runtime_error(self):
+        """A 200 response whose body is not JSON surfaces as a RuntimeError that
+        names the failure (`non-JSON`) rather than letting the ValueError from
+        response.json() propagate raw."""
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(return_value=(200, {}, "<html>not json</html>")),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_non_json",
+            operation_dict=self._ssot_get_operation(self._SSOT_PATH),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        self.assertIn("non-JSON", str(response.result))
+
+    def test_ssot_get_http_error_redacts_token_in_body(self):
+        """A non-200 whose body embeds a token has the token redacted before the
+        body is surfaced — `[REDACTED]` appears and the raw token does not."""
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(
+                return_value=(
+                    403,
+                    {},
+                    json.dumps(
+                        [{"errorCode": "X", "access_token": "secret-should-redact"}]
+                    ),
+                )
+            ),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_redacts_token",
+            operation_dict=self._ssot_get_operation(self._SSOT_PATH),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        message = str(response.result)
+        self.assertIn("[REDACTED]", message)
+        self.assertNotIn("secret-should-redact", message)
+
+    def test_redact_body_masks_sensitive_keys(self):
+        """`_redact_body` masks double-quoted access_token / id_token values (the
+        raw response.text form) while leaving non-sensitive fields intact."""
+        from apollo.integrations.db.salesforce_data_cloud_proxy_client import (
+            _redact_body,
+        )
+
+        body = json.dumps(
+            {
+                "access_token": "secret-access",
+                "id_token": "secret-id",
+                "instance_url": "https://test.salesforce.com",
+            }
+        )
+        redacted = _redact_body(body)
+        self.assertIsNotNone(redacted)
+        self.assertNotIn("secret-access", redacted)
+        self.assertNotIn("secret-id", redacted)
+        self.assertIn("[REDACTED]", redacted)
+        # Non-sensitive fields are preserved.
+        self.assertIn("instance_url", redacted)
+        self.assertIn("https://test.salesforce.com", redacted)
+
 
 class SalesforceDataCloudRetryTests(TestCase):
     """Cover the transient-network-error retry that wraps cursor and list_tables.

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1217,6 +1217,120 @@ class SalesforceDataCloudProxyClientTests(TestCase):
             f"expected a rate_limited classification in logs; got {logs.output}",
         )
 
+    # -- Generic SSOT reads (YET-1615) -----------------------------------------------
+
+    _SSOT_PATH = "/services/data/v62.0/ssot/data-streams"
+    _SSOT_URL = "https://test.salesforce.com/services/data/v62.0/ssot/data-streams"
+
+    def _ssot_get_operation(self, path: str) -> dict:
+        return {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [{"method": "ssot_get", "kwargs": {"path": path}}],
+        }
+
+    def test_ssot_get_returns_json_and_uses_minted_core_token(self):
+        """ssot_get mints a client-credentials core token and GETs the My Domain
+        core REST path with it as a Bearer credential, returning the parsed JSON.
+        The minted token is never returned to the caller (the data-collector)."""
+        ssot_body = {
+            "dataStreams": [
+                {"name": "Web_Engagement", "totalRecords": 42},
+                {"name": "Email_Engagement", "totalRecords": 7},
+            ],
+            "totalSize": 2,
+        }
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(return_value=(200, {}, json.dumps(ssot_body))),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get",
+            operation_dict=self._ssot_get_operation(self._SSOT_PATH),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        self.assertEqual(response.result[ATTRIBUTE_NAME_RESULT], ssot_body)
+
+        # A core token was minted via the client-credentials grant.
+        self.client_credentials_token_endpoint.assert_called()
+
+        # The /ssot GET carried the minted core token as a Bearer credential ...
+        ssot_call = next(
+            c
+            for c in self.mock_responses.calls
+            if "/ssot/data-streams" in c.request.url
+        )
+        self.assertEqual(
+            ssot_call.request.headers["Authorization"],
+            f"Bearer {self.client_credentials_token}",
+        )
+        # ... and the token never leaks back to the caller in the result.
+        self.assertNotIn(self.client_credentials_token, json.dumps(response.result))
+
+    def test_ssot_get_rejects_absolute_url(self):
+        """ssot_get must only ever target the connection's own My Domain. An
+        absolute URL (or any value carrying a scheme/host) is rejected before a
+        token is minted, so the customer's credential is never sent elsewhere."""
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_absolute_url",
+            operation_dict=self._ssot_get_operation("https://evil.example.com/steal"),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        # The guard fired before any network call (a network attempt would surface
+        # a connection error, not this message).
+        self.assertIn("must be a relative path", str(response.result))
+
+    def test_ssot_get_rejects_protocol_relative_url(self):
+        """A protocol-relative value (`//host/...`) is also rejected — it would
+        otherwise resolve to a different host."""
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_protocol_relative",
+            operation_dict=self._ssot_get_operation("//evil.example.com/steal"),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        self.assertIn("must be a relative path", str(response.result))
+
+    def test_ssot_get_http_error_surfaces_status_and_redacts_body(self):
+        """A non-200 from the SSOT endpoint surfaces as a RuntimeError carrying
+        `code NNN` (so the data-collector can extract the HTTP status), with the
+        Salesforce error body included and any access_token redacted."""
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(
+                return_value=(
+                    404,
+                    {},
+                    json.dumps(
+                        [{"errorCode": "NOT_FOUND", "message": "no such resource"}]
+                    ),
+                )
+            ),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_http_error",
+            operation_dict=self._ssot_get_operation(self._SSOT_PATH),
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        message = str(response.result)
+        self.assertIn("code 404", message)
+        self.assertIn("NOT_FOUND", message)
+
 
 class SalesforceDataCloudRetryTests(TestCase):
     """Cover the transient-network-error retry that wraps cursor and list_tables.

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -1357,6 +1357,55 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         )
         self.assertIn("limit=100", ssot_call.request.url)
 
+    def test_ssot_get_allows_url_valued_query_param(self):
+        """The path guard must reject values by their URL *structure* (scheme or
+        host present), not by substring — a relative path whose query string
+        merely embeds a URL (e.g. a pagination cursor) is safe and allowed."""
+        path_with_url_cursor = (
+            "/services/data/v62.0/ssot/data-streams"
+            "?next=https://api.salesforce.com/cursor/abc"
+        )
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(return_value=(200, {}, json.dumps({"dataStreams": []}))),
+        )
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_ssot_get_url_valued_query",
+            operation_dict=self._ssot_get_operation(path_with_url_cursor),
+            credentials=self.credentials,
+        )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+
+    def test_ssot_get_does_not_log_query_string_values(self):
+        """Query-string values (pagination cursors, filters) may carry sensitive
+        data — logs must only include the path component, never the query."""
+        path_with_query = (
+            "/services/data/v62.0/ssot/data-streams?cursor=sensitive-cursor-value"
+        )
+        self.mock_responses.add_callback(
+            method=responses.GET,
+            url=self._SSOT_URL,
+            callback=Mock(return_value=(200, {}, json.dumps({"dataStreams": []}))),
+        )
+
+        with self.assertLogs(self._PROXY_CLIENT_LOGGER, level="INFO") as logs:
+            response = self.agent.execute_operation(
+                connection_type="salesforce-data-cloud",
+                operation_name="test_ssot_get_query_not_logged",
+                operation_dict=self._ssot_get_operation(path_with_query),
+                credentials=self.credentials,
+            )
+
+        self.assertFalse(response.is_error, msg=str(response.result))
+        log_text = "\n".join(logs.output)
+        for record in logs.records:
+            self.assertNotIn("sensitive-cursor-value", str(record.__dict__))
+        self.assertNotIn("sensitive-cursor-value", log_text)
+
     def test_ssot_get_non_json_200_raises_runtime_error(self):
         """A 200 response whose body is not JSON surfaces as a RuntimeError that
         names the failure (`non-JSON`) rather than letting the ValueError from


### PR DESCRIPTION
## What & why

Adds a generic `ssot_get(path)` operation to the Salesforce Data Cloud proxy client so Monte Carlo's data-collector can read the Salesforce **SSOT** metadata endpoints (`/services/data/{v}/ssot/*` — data streams, calculated insights, catalogs, schemas) **through the agent**.

This is the apollo-agent side of [YET-1614](https://linear.app/montecarloai/issue/YET-1614) and unblocks [YET-1616](https://linear.app/montecarloai/issue/YET-1616) (the data-collector will route all agent `/ssot` traffic through this op). It lets a single code path serve **both** self-hosted and remote-agent connections: the agent builds the URL from the connection's own credentials, authenticates the call, and returns only the JSON body — the customer's token never leaves the agent.

Today self-hosted Data Cloud connections can't collect Data Streams freshness/volume because the `/ssot` GET needs a token the agent won't release to the DC; `ssot_get` closes that gap by keeping the token inside the agent.

## How it works

- `ssot_get(path)` → `GET https://{domain}{path}`, with `path` supplied verbatim by the DC (version-agnostic — the DC owns the API version and any pagination cursor).
- **Auth** mirrors the existing `list_dataspaces` core-REST call: mint a short-lived **client-credentials core token** (`POST /services/oauth2/token`) and send it as `Authorization: Bearer`. SSOT endpoints are core REST on the My Domain authed with the **core token** — *not* the Data Cloud query token from the a360 exchange (that exchange revokes the core token and targets a different host). The shared mint is extracted into `_mint_core_token`, now used by both `list_dataspaces` and `ssot_get`.
- **Security:** `path` must be a relative path beginning with `/`; absolute and protocol-relative values are rejected so the minted token is only ever sent to the connection's own My Domain. The token is never returned to the caller, and response bodies are redacted (`_redact_body`) before appearing in errors/logs.
- Non-200 / non-JSON responses surface as `RuntimeError` carrying `code NNN` (so the DC can extract the HTTP status) with a redacted body.
- Auto-dispatched by name via the agent's `_resolve_method` — no registry change.

## Testing

- **Unit:** 4 new `test_ssot_get_*` tests (token mint + authenticated GET, absolute-URL rejection, protocol-relative rejection, non-200 `code NNN` + redaction). Full file 33/33 green; pyright (basic) clean. The `list_dataspaces` refactor onto `_mint_core_token` is covered by its existing tests.
- **Live:** validated against a real Salesforce Data Cloud dev org — `ssot_get('/services/data/v62.0/ssot/data-streams?limit=100')` returned 10 real data streams; `…/ssot/calculated-insights` returned its collection; no credential/token leak in result or logs.

## Checklist
- [x] Tests added/updated (unit + live validation against a real org)
- [x] Types: pyright (basic) clean
- [x] No new dependencies
- [x] Token never leaves the agent; path-safety guard added
- [x] Deployed to dev
- [ ] Integration tested on dev

