### PR TITLE
fix(salesforce-data-cloud): don't label getAllMetadata failures as token-exchange errors (YET-1631)

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -372,6 +372,32 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
             except SalesforceCDPError as e:
                 body = _redact_body(capturing.last_exchange_body if capturing else None)
                 status = capturing.last_exchange_status if capturing else None
+                # The CDP library raises SalesforceCDPError for BOTH the a360 token exchange AND
+                # the subsequent getAllMetadata query. A post-exchange metadata-query failure
+                # (the token was obtained, then e.g. a transient DEADLINE_EXCEEDED) must NOT be
+                # reported as a token-exchange / permission problem — that sends triage down the
+                # wrong path (YET-1631).
+                err_text = str(e)
+                is_metadata_query_failure = (
+                    "executing metadata query" in err_text.lower()
+                    or "getallmetadata" in err_text.lower()
+                )
+                if is_metadata_query_failure:
+                    logger.warning(
+                        "Salesforce Data Cloud: metadata query failed for dataspace '%s' "
+                        "(token exchange succeeded)",
+                        dataspace,
+                        extra={
+                            "dataspace": dataspace,
+                            "exchange_status_code": status,
+                            "metadata_query_error": err_text[:500],
+                            "exchange_response_body": body,
+                        },
+                    )
+                    detail = f" (Salesforce response: {body})" if body else ""
+                    raise RuntimeError(
+                        f"Metadata query failed for dataspace '{dataspace}': {e}{detail}"
+                    ) from e
                 logger.warning(
                     "Salesforce Data Cloud: a360/token exchange failed for dataspace '%s'",
                     dataspace,

--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -381,11 +381,16 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                 # reported as a token-exchange / permission problem — that sends triage down the
                 # wrong path (YET-1631).
                 err_text = str(e)
+                err_text_lower = err_text.lower()
                 is_metadata_query_failure = (
-                    "executing metadata query" in err_text.lower()
-                    or "getallmetadata" in err_text.lower()
+                    "executing metadata query" in err_text_lower
+                    or "getallmetadata" in err_text_lower
                 )
                 if is_metadata_query_failure:
+                    # The token exchange succeeded, so the captured `body` is the token-exchange
+                    # response — NOT the metadata-query response. Don't append it to this message
+                    # (it would misrepresent what the body is); it's still logged below as
+                    # `exchange_response_body`, where the label is accurate.
                     logger.warning(
                         "Salesforce Data Cloud: metadata query failed for dataspace '%s' "
                         "(token exchange succeeded)",
@@ -397,9 +402,8 @@ class SalesforceDataCloudProxyClient(BaseDbProxyClient):
                             "exchange_response_body": body,
                         },
                     )
-                    detail = f" (Salesforce response: {body})" if body else ""
                     raise RuntimeError(
-                        f"Metadata query failed for dataspace '{dataspace}': {e}{detail}"
+                        f"Metadata query failed for dataspace '{dataspace}': {e}"
                     ) from e
                 logger.warning(
                     "Salesforce Data Cloud: a360/token exchange failed for dataspace '%s'",

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -350,6 +350,40 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         # Should see a clear token exchange error
         self.assertIn("Token exchange failed", error_message)
 
+    def test_list_tables_metadata_query_failure_not_labeled_token_exchange(self):
+        """A post-token-exchange getAllMetadata failure (e.g. a transient DEADLINE_EXCEEDED) is
+        reported as a metadata-query error, NOT 'Token exchange failed ... verify permission'
+        (YET-1631) — the token exchange succeeded; only the metadata query failed."""
+        from salesforcecdpconnector.exceptions import Error as SalesforceCDPError
+
+        metadata_err = SalesforceCDPError(
+            "Failed executing metadata query in server : status=500, message="
+            "TranslationMetadataHelper.getAllMetadata Error fetching data source entities - "
+            "DEADLINE_EXCEEDED: CallOptions deadline exceeded after 9.9s"
+        )
+        operation = {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [{"method": "list_tables", "kwargs": {"dataspace": "default"}}],
+        }
+        with patch(
+            "apollo.integrations.db.salesforce_data_cloud_proxy_client."
+            "SalesforceDataCloudConnection.list_tables",
+            side_effect=metadata_err,
+        ):
+            response = self.agent.execute_operation(
+                connection_type="salesforce-data-cloud",
+                operation_name="test_metadata_query_failure",
+                operation_dict=operation,
+                credentials=self.credentials,
+            )
+
+        self.assertTrue(response.is_error)
+        msg = str(response.result)
+        self.assertIn("Metadata query failed for dataspace 'default'", msg)
+        self.assertNotIn("Token exchange failed", msg)
+        self.assertNotIn("verify the dataspace name", msg)
+
     def test_list_tables_with_invalid_dataspace_raises_clear_error_clean_path(self):
         """
         Older versions of salesforce-cdp-connector raise KeyError('access_token') when the


### PR DESCRIPTION
#### What's new?
- `SalesforceDataCloudProxyClient.list_tables` wrapped **both** the a360 token exchange **and** the subsequent `getAllMetadata` query in one `except SalesforceCDPError`, labeling every failure `Token exchange failed for dataspace '…' … verify the dataspace name and that the connected app's Run-As user has permission`. That mis-attributes a **post-exchange metadata-query failure** (the token was obtained, then e.g. a transient `DEADLINE_EXCEEDED`) as a token/permission problem — sending triage to check permissions/dataspace config when the real cause is a transient Salesforce timeout.
- Now distinguishes the two: a metadata-query failure (`getAllMetadata` / "executing metadata query" in the error) raises `Metadata query failed for dataspace '…': …` (no permission hint); a genuine token-exchange failure keeps the original message. The `KeyError` (missing `access_token`) branch is a real token-exchange failure and is unchanged.

#### Related issues and PRs
- [YET-1631](https://linear.app/montecarloai/issue/YET-1631/fix-misleading-token-exchange-failed-for-dataspace-label-on-sfdc)
- Sibling: [YET-1630](https://linear.app/montecarloai/issue/YET-1630/retry-sfdc-list-tables-on-transient-salesforce-metadata-query-timeout) / data-collector [#2461](https://github.com/monte-carlo-data/data-collector/pull/2461) — adds a retry for these transient metadata-query failures. This PR only fixes the misleading label so on-call/logs see the real cause.

#### Testing
- New unit test `test_list_tables_metadata_query_failure_not_labeled_token_exchange`: a `getAllMetadata` `SalesforceCDPError` (DEADLINE_EXCEEDED) now surfaces as "Metadata query failed", not "Token exchange failed" / "verify the dataspace name".
- Full apollo SFDC suite: **30 passed** (existing token-exchange / invalid-dataspace tests unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)