### PR TITLE
fix(azure): clear phantom SBOM CVEs + bump aiohttp on azure image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -223,7 +223,10 @@ RUN pip install --no-cache-dir \
     --target=/home/site/wwwroot/.python_packages/lib/site-packages \
     -r /requirements.txt -r /requirements-azure.txt \
     && chown -R mcdagent:mcdagent /home/site/wwwroot/.python_packages \
-    && rm -rf /opt/python/3/_manifest
+    && rm -rf /opt/python/3/_manifest \
+    # Drop the SBOM the azure-functions-durable wheel bundles at the site-packages
+    # root: it lists stale versions that aren't installed, tripping scout false positives.
+    && rm -rf /home/site/wwwroot/.python_packages/lib/site-packages/_manifest
 
 COPY --chown=mcdagent:mcdagent apollo /home/site/wwwroot/apollo
 

--- a/requirements-azure.in
+++ b/requirements-azure.in
@@ -4,7 +4,7 @@ azure-functions-durable==1.2.9
 azure-mgmt-resource==23.0.1
 azure-monitor-opentelemetry==1.8.8  # <1.4 pulls opentelemetry-instrumentation 0.46b0, which imports pkg_resources and crashes on py3.13; newer uses importlib.metadata
 azure-monitor-query==1.2.1
-aiohttp==3.13.3
+aiohttp==3.14.1  # clears aiohttp CVEs flagged on latest-azure; azure-only dep (transitive via azure-functions-durable)
 deprecated==1.2.18 # Added VULN-620
 opentelemetry-api==1.40.0 # VULN-620; exact pin MUST equal requirements-cloudrun.in's opentelemetry-api pin (tests/linter install cloudrun+azure together); also the version azure-monitor-opentelemetry resolves to
 viztracer==0.17.1 # Added VULN-620

--- a/requirements-azure.txt
+++ b/requirements-azure.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.13.3
+aiohttp==3.14.1
     # via
     #   -r requirements-azure.in
     #   azure-functions-durable


### PR DESCRIPTION
## What

Two scoped fixes for HIGH/CRITICAL + MEDIUM/LOW vulns the daily scan flags **only on `latest-azure`**. Two separate commits:

1. **Remove stale `azure-functions-durable` SBOM** (`585854a`)
   The `azure-functions-durable` wheel bundles its build-time SBOM (`_manifest/manifest.spdx.json`) as a data file that pip `--target` drops at the site-packages root (`/home/site/wwwroot/.python_packages/lib/site-packages/_manifest`). That SBOM pins the **old** versions durable was built against — urllib3 1.25.11, aiohttp 3.7.4, cryptography 42.0.2, azure-core 1.30.0, virtualenv 20.25.0, urllib3 2.2.0, aiohttp 3.9.3 — **none of which are actually installed** (our resolved deps are clean). docker scout reads the stale SBOM and reports ~16 phantom HIGH/CRITICAL CVEs. We delete it after install, matching the two sibling SBOM removals already in this stage (`/opt/python/3/_manifest`, `/usr/local/_manifest`).

2. **Bump `aiohttp` 3.13.3 → 3.14.1** (`9094a75`)
   azure-only dep (transitive via `azure-functions-durable`, which requires only `>=3.6.2`; apollo does not import aiohttp directly). 3.14.1 is the current latest and clears the 11 MEDIUM + 10 LOW aiohttp CVEs on the azure image. Re-locked with pip-compile (Python 3.13) — only the aiohttp pin changed, no transitive churn.

## Why

The base image and our resolved deps are already clean; these findings were either a phantom SBOM artifact or a single transitive pin. Both are azure-image-only and don't affect aws/cloudrun/generic/lambda.

## Out of scope (tracked separately)

- **MessagePack** (`CVE-2026-48109`, `CVE-2026-48506`) — base-image, separate effort.
- **debian/perl, xvfb, libnss3** — no upstream fix available; separate effort.

## Verification

- Fresh `--target azure` build + `docker scout cves`: all phantom HIGH findings gone; aiohttp reports **0 vulnerabilities**; only the (separate) MessagePack base-image CVEs remain in the fixable HIGH/CRITICAL bucket.
- `--target tests` build: **1349 passed**.

## Checklist

- [x] Tests pass locally (1349 passed)
- [x] Image scanned with docker scout to confirm findings cleared
- [na] New tests — dependency/Dockerfile change only; verification is the scout scan + existing suite
- [na] Docs — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)