### PR TITLE
fix(docker): bump system-base to python:3.13.14-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 # Published as `<version>-system-base` so downstream consumers (e.g. hermes-agent)
 # can build their own venv against the same native libs without inheriting
 # apollo's pip-installed dependencies.
-FROM python:3.13.13-slim AS system-base
+FROM python:3.13.14-slim AS system-base
 
 ENV APP_HOME=/app
 WORKDIR $APP_HOME
 
 # Refresh apt index and upgrade base-image packages so OS-level security fixes
 # (glibc, openssh, nghttp2, etc.) land on every rebuild rather than waiting for
-# the upstream python:3.13.13-slim tag to be republished.
+# the upstream python:3.13.14-slim tag to be republished.
 RUN apt-get update && apt-get upgrade -y
 # install git as we need it for the direct oscrypto dependency
 # this is a temporary workaround and it should be removed once we update oscrypto to 1.3.1+


### PR DESCRIPTION
## What

Bump the `system-base` base image from `python:3.13.13-slim` to `python:3.13.14-slim` (`Dockerfile:5`, plus the matching comment on line 12). This propagates to every stage derived from it: `base`, `generic`, `aws_proxied`, `cloudrun`. (`lambda` and `azure` use their own AWS/MS base images and are unaffected.)

## Why

docker scout flags the prior tag as carrying fixable HIGH/CRITICAL CVEs; the 3.13.14-slim tag introduces no new vulnerabilities and removes ~18, including those fixable highs. Same OS (Debian trixie, glibc), similar size — a clean patch-level refresh.

## Downstream consumers

`system-base` is also published as `montecarlodata/agent:<version>-system-base` and consumed by **hermes-agent** (`hermes-agent/Dockerfile`: `FROM montecarlodata/agent:1.9.0-system-base`). hermes pins a **specific older tag**, so this bump does not reach it automatically — hermes only picks up 3.13.14 when its maintainers bump that pinned tag (their Dockerfile has a reminder to coordinate the apollo Python pin at that time). No action required on hermes for this PR.

## Not in scope

The scout **"unapproved base images"** health-score warning is a separate, org-level *Approved Base Images* policy/allowlist config — not a version-currency issue. This bump does not (and cannot) clear that warning; it needs the base image allowlisted in the Scout policy. Tracked separately.

The **"No default non-root user"** warning on the published `system-base` tag is by design: `system-base` intentionally ships without a `USER` because downstream consumers (hermes-agent) create their own `mcdagent` user; apollo's own runtime stages set `USER mcdagent` in the `base` stage.

## Verification

- Fresh `--target generic` build + `docker scout cves --only-fixed --only-severity critical,high`: **0 fixable critical/high**.
- `--target tests` build green; **6 full-suite runs (3 on each of 3.13.13 and 3.13.14): all 1349 passed**.
- Note: one rare, base-independent flake observed in `tests/ctp/test_registry_concurrent_init.py::test_transform_registry_does_not_expose_partial_state` (passes in isolation on both bases; not caused by this change). Pre-existing — worth a separate look but not a blocker here.

## Checklist

- [x] Tests pass locally (repeated full-suite runs)
- [x] Image scanned with docker scout (0 fixable C/H on generic)
- [x] Verified downstream impact (hermes-agent pins an older system-base tag; unaffected)
- [na] New tests — base-image patch bump only
- [na] Docs — no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)