### PR TITLE
fix(custom-etl): accept pinned window_start/window_end in fetch_etl_runs (YET-1690)

### DIFF
--- a/apollo/integrations/custom_etl/CLAUDE.md
+++ b/apollo/integrations/custom_etl/CLAUDE.md
@@ -84,7 +84,7 @@ The `connector.py` module must define a `Connector` class with:
 - `setup_connection()` — establish connection using credentials
 - `close_connection()` — clean up resources
 - `fetch_metadata(limit, offset)` → `List[EtlAsset]`
-- `fetch_run_details(run_ids, lookback, limit, offset)` → `List[EtlRunEvent]`
+- `fetch_run_details(run_ids, window_start, window_end, limit, offset)` → `List[EtlRunEvent]` — `window_start`/`window_end` are the pinned collection window (tz-aware `datetime`s; the proxy parses them from the ISO-8601 UTC wire strings) the connector filters against, `window_start <= t < window_end` (YET-1690)
 
 ## How it differs from custom (warehouse) connectors
 

--- a/apollo/integrations/custom_etl/custom_etl_proxy_client.py
+++ b/apollo/integrations/custom_etl/custom_etl_proxy_client.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -146,7 +146,8 @@ class CustomEtlProxyClient(BaseProxyClient):
 
     def fetch_etl_runs(
         self,
-        lookback_min: int,
+        window_start: str,
+        window_end: str,
         job_ids: Optional[List[str]] = None,
         job_run_ids: Optional[List[str]] = None,
         limit: int = 1000,
@@ -154,11 +155,16 @@ class CustomEtlProxyClient(BaseProxyClient):
     ) -> Dict[str, Any]:
         """Fetch ETL run events from the connector.
 
-        Translates the DC-facing parameters into the connector's
-        ``fetch_run_details`` interface: ``lookback_min`` becomes a
-        ``timedelta``, ``job_run_ids`` maps to ``run_ids``.  When
-        ``job_ids`` is provided, results are post-filtered to include
-        only runs whose ``job_source_id`` is in the set.
+        ``window_start``/``window_end`` are the pinned run-collection window
+        (YET-1690). They arrive as ISO-8601 UTC strings (the wire is JSON, which
+        has no datetime type) and are deserialized here into tz-aware ``datetime``
+        objects for the connector's ``fetch_run_details``, which filters
+        ``window_start <= t < window_end`` against those fixed bounds — the pin is
+        what stops the window sliding across paginated invocations. The
+        data-collector owns and validates the wire format, so this is a plain
+        parse, not re-validation.  ``job_run_ids`` maps to ``run_ids``.  When
+        ``job_ids`` is provided, results are post-filtered to include only runs
+        whose ``job_source_id`` is in the set.
 
         When the manifest declares ``run_status_mapping``, vendor statuses
         are normalized post-fetch: the original vendor value is preserved
@@ -167,10 +173,10 @@ class CustomEtlProxyClient(BaseProxyClient):
         Option A (agent-side normalization) — diverges from native
         integrations which normalize in the monolith.
         """
-        lookback = timedelta(minutes=lookback_min)
         runs = self._connector.fetch_run_details(
             run_ids=job_run_ids,
-            lookback=lookback,
+            window_start=datetime.fromisoformat(window_start),
+            window_end=datetime.fromisoformat(window_end),
             limit=limit,
             offset=offset,
         )

--- a/tests/test_custom_etl_proxy_client.py
+++ b/tests/test_custom_etl_proxy_client.py
@@ -1,7 +1,7 @@
 import json
 import os
 import tempfile
-from datetime import timedelta
+from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
@@ -16,6 +16,13 @@ from apollo.integrations.custom_etl.custom_etl_proxy_client import (
     _apply_status_mapping,
     _serialize,
 )
+
+# Pinned run-collection window (YET-1690): the DC threads ISO-8601 UTC strings on
+# the wire; the proxy deserializes them to tz-aware datetimes for fetch_run_details.
+_WIN_START = "2026-06-22T08:00:00+00:00"
+_WIN_END = "2026-06-22T09:10:00+00:00"
+_WIN_START_DT = datetime.fromisoformat(_WIN_START)
+_WIN_END_DT = datetime.fromisoformat(_WIN_END)
 
 
 class _FakeModel:
@@ -62,7 +69,9 @@ class Connector:
     def fetch_metadata(self, limit=1000, offset=0):
         return []
 
-    def fetch_run_details(self, run_ids=None, lookback=None, limit=100, offset=0):
+    def fetch_run_details(
+        self, run_ids=None, window_start=None, window_end=None, limit=100, offset=0
+    ):
         return []
 """
     with open(os.path.join(connector_dir, "connector.py"), "w") as f:
@@ -662,11 +671,14 @@ class TestCustomEtlProxyClient(TestCase):
             credentials={"connect_args": {}},
             connector_dir="/opt/custom-etl-connectors/adf",
         )
-        result = client.fetch_etl_runs(lookback_min=1440, limit=100, offset=0)
+        result = client.fetch_etl_runs(
+            window_start=_WIN_START, window_end=_WIN_END, limit=100, offset=0
+        )
 
         self._mock_connector.fetch_run_details.assert_called_once_with(
             run_ids=None,
-            lookback=timedelta(minutes=1440),
+            window_start=_WIN_START_DT,
+            window_end=_WIN_END_DT,
             limit=100,
             offset=0,
         )
@@ -695,7 +707,8 @@ class TestCustomEtlProxyClient(TestCase):
             connector_dir="/opt/custom-etl-connectors/adf",
         )
         result = client.fetch_etl_runs(
-            lookback_min=720,
+            window_start=_WIN_START,
+            window_end=_WIN_END,
             job_run_ids=["run-1"],
             limit=50,
             offset=10,
@@ -703,7 +716,8 @@ class TestCustomEtlProxyClient(TestCase):
 
         self._mock_connector.fetch_run_details.assert_called_once_with(
             run_ids=["run-1"],
-            lookback=timedelta(minutes=720),
+            window_start=_WIN_START_DT,
+            window_end=_WIN_END_DT,
             limit=50,
             offset=10,
         )
@@ -730,7 +744,8 @@ class TestCustomEtlProxyClient(TestCase):
             connector_dir="/opt/custom-etl-connectors/adf",
         )
         result = client.fetch_etl_runs(
-            lookback_min=1440,
+            window_start=_WIN_START,
+            window_end=_WIN_END,
             job_ids=["job-1"],
             limit=100,
             offset=0,
@@ -755,7 +770,9 @@ class TestCustomEtlProxyClient(TestCase):
             credentials={"connect_args": {}},
             connector_dir="/opt/custom-etl-connectors/adf",
         )
-        result = client.fetch_etl_runs(lookback_min=1440, limit=100, offset=0)
+        result = client.fetch_etl_runs(
+            window_start=_WIN_START, window_end=_WIN_END, limit=100, offset=0
+        )
 
         self.assertEqual(result, {"all_results": []})
 
@@ -1258,7 +1275,7 @@ class TestFetchEtlRunsStatusMapping(TestCase):
             {"job_source_id": "j1", "run_source_id": "r1", "status": "Succeeded"},
         ]
         client = self._create_client({})
-        result = client.fetch_etl_runs(lookback_min=60)
+        result = client.fetch_etl_runs(window_start=_WIN_START, window_end=_WIN_END)
 
         run = result["all_results"][0]
         self.assertEqual(run["status"], "Succeeded")
@@ -1272,7 +1289,7 @@ class TestFetchEtlRunsStatusMapping(TestCase):
         ]
         manifest = {"run_status_mapping": {"Succeeded": "success", "Failed": "failed"}}
         client = self._create_client(manifest)
-        result = client.fetch_etl_runs(lookback_min=60)
+        result = client.fetch_etl_runs(window_start=_WIN_START, window_end=_WIN_END)
 
         self.assertEqual(result["all_results"][0]["status"], "success")
         self.assertEqual(result["all_results"][0]["raw_status"], "Succeeded")
@@ -1300,7 +1317,7 @@ class TestFetchEtlRunsStatusMapping(TestCase):
             "task_run_status_mapping": {"Completed": "success"},
         }
         client = self._create_client(manifest)
-        result = client.fetch_etl_runs(lookback_min=60)
+        result = client.fetch_etl_runs(window_start=_WIN_START, window_end=_WIN_END)
 
         run = result["all_results"][0]
         self.assertEqual(run["status"], "success")
@@ -1322,7 +1339,7 @@ class TestFetchEtlRunsStatusMapping(TestCase):
         ]
         manifest = {"run_status_mapping": {"Failed": "failed"}}
         client = self._create_client(manifest)
-        result = client.fetch_etl_runs(lookback_min=60)
+        result = client.fetch_etl_runs(window_start=_WIN_START, window_end=_WIN_END)
 
         task = result["all_results"][0]["task_runs"][0]
         self.assertEqual(task["status"], "failed")


### PR DESCRIPTION
#### What's new?

Companion change for [YET-1690](https://linear.app/montecarloai/issue/YET-1690) (data-collector #2475), which pins the ETL run-collection window so paginated Lambda invocations query a **fixed** `[window_start, window_end)` instead of a `now()`-derived window that slides between pages (causing skipped/duplicated runs).

The data-collector proxy now sends `window_start`/`window_end` instead of `lookback_min`. This updates the custom-ETL proxy to match:

- `CustomEtlProxyClient.fetch_etl_runs` takes `window_start`/`window_end`. The wire carries them as **ISO-8601 UTC strings** (JSON has no datetime type); the proxy **deserializes them to tz-aware `datetime`s** and hands those to the connector's `fetch_run_details(window_start, window_end, …)` — dropping the old `lookback_min → timedelta` conversion.
- The connector filters `window_start <= t < window_end` against the fixed bounds. Propagating the window all the way through (rather than converting it back to a lookback here) is what actually stops the slide for custom connectors, which currently compute `since = now() - lookback` internally.
- The DC owns and validates the wire format, so the proxy does a plain parse — no re-validation.
- Updated the connector-interface note in `apollo/integrations/custom_etl/CLAUDE.md`.

#### ⚠️ Coordinated breaking change

The wire contract (`lookback_min` → `window_start`/`window_end`) is breaking and moves together with:
- **data-collector #2475** (sender) — under review.
- **custom-connector-setup** (the `fetch_run_details` author contract + example connectors, and likely `pycarlo`'s `BaseEtlConnector`) — **follow-up PR**. Until it lands, connector bundles still expose `fetch_run_details(lookback=…)`, so **this must not reach any environment exercising the custom-connector path before the connector bundles are updated**. Custom ETL connectors are not customer-live yet, so the blast radius is internal/dev.

#### Related issues and PRs
- [YET-1690](https://linear.app/montecarloai/issue/YET-1690)
- data-collector #2475 (sender side)
- custom-connector-setup — connector `fetch_run_details` contract (follow-up)

#### Key decisions
- **Connector contract is `datetime`, not string.** The wire is necessarily ISO strings (JSON), but the in-process `fetch_run_details` contract takes tz-aware `datetime`s — more idiomatic for connector authors and avoids 7 connectors each re-parsing. The proxy is the natural place to deserialize at the wire boundary (it already did int→`timedelta` before).
- **Parse, don't re-validate.** The DC validates the format before sending; the proxy does a bare `datetime.fromisoformat()` (no defensive guards) — deserialization, not redundant validation.
- **Propagate the window to the connector** rather than converting back to a lookback in the agent — only the fixed bounds reaching the connector actually close the sliding-window bug.

#### Testing
- Updated `test_custom_etl_proxy_client.py`: `fetch_etl_runs` receives the ISO strings and asserts `fetch_run_details` is called with the parsed `datetime` bounds. **62 tests pass** locally.
