### PR TITLE
fix(redshift): accept IAM-federated secrets in self-hosted credential validation [SUP-532]

### DIFF
--- a/apollo/integrations/ctp/defaults/redshift.py
+++ b/apollo/integrations/ctp/defaults/redshift.py
@@ -1,4 +1,4 @@
-from typing import Any, NotRequired, Required, TypedDict
+from typing import NotRequired, Required, TypedDict
 
 from apollo.credentials.schema.common import SSL_OPTIONS_FIELD
 from apollo.integrations.ctp.models import CtpConfig, MapperConfig, TransformStep
@@ -28,27 +28,66 @@ class RedshiftClientArgs(TypedDict):
     keepalives_count: NotRequired[int]
 
 
-# Redshift self-hosted credentials schema. Docs require all five fields but
-# the CTP defaults `port` to 5439 and `user` to "awsuser"; the validator
-# matches the more forgiving code shape and only requires host/dbname/password.
-# Port is documented as a string ("5439") but the connector accepts both
-# string and integer; we accept either to avoid spurious type errors.
+# Connection fields shared by both Redshift auth modes. Spread into each
+# ``oneof_schema`` variant below so each variant is a complete,
+# independently-valid schema (a requirement for ``oneof_schema``).
+#
+# db-name: the mapper reads ``db_name`` first, falling back to ``dbname`` /
+# ``database`` (see mapper field_map below). All three are accepted as optional
+# aliases so a secret authored with any spelling passes; a genuinely missing
+# database name surfaces at connect time rather than as a schema error (avoids
+# rejecting existing ``dbname``-keyed secrets while accepting the documented
+# ``db_name``). ``port`` is documented as a string ("5439") but the connector
+# accepts both string and integer; CTP defaults to 5439.
+_REDSHIFT_COMMON_CONNECT_ARGS = {
+    "host": {"type": "string", "required": True, "empty": False},
+    "db_name": {"type": "string"},
+    "dbname": {"type": "string"},
+    "database": {"type": "string"},
+    "user": {"type": "string"},  # CTP defaults to "awsuser"
+    "port": {"type": ["string", "integer"]},
+    "connect_timeout": {"type": "integer"},
+    "query_timeout_in_seconds": {"type": "integer"},
+    "ssl_mode": {"type": "string"},
+}
+
+# Redshift self-hosted credentials schema. Two auth modes, expressed as
+# ``oneof_schema`` variants (see snowflake.py for the canonical pattern):
+#   1. Monte Carlo-managed / password auth: username + static password.
+#   2. IAM-federated auth (Connection Auth Rules): the agent mints temporary
+#      credentials via GetClusterCredentials, so there is NO static password —
+#      the secret carries cluster_identifier / db_user / aws_region instead
+#      (consumed by the resolve_redshift_credentials transform in the custom
+#      CTP config). Requiring `password` here previously forced federated
+#      customers to add a dummy password. See SUP-532.
+# Cerberus picks the matching variant; zero matches (no auth field) or more
+# than one (ambiguous) fails with a diagnostic listing every candidate.
 REDSHIFT_CREDENTIALS_SCHEMA = {
     "connect_args": {
         "type": "dict",
         "required": True,
-        "schema": {
-            "host": {"type": "string", "required": True, "empty": False},
-            "dbname": {"type": "string", "required": True, "empty": False},
-            "user": {"type": "string"},  # CTP defaults to "awsuser"
-            "password": {"type": "string", "required": True, "empty": False},
-            # Port is documented as a string ("5439"); the connector
-            # accepts both; CTP defaults to 5439.
-            "port": {"type": ["string", "integer"]},
-            "connect_timeout": {"type": "integer"},
-            "query_timeout_in_seconds": {"type": "integer"},
-            "ssl_mode": {"type": "string"},
-        },
+        "oneof_schema": [
+            # Password auth.
+            {
+                **_REDSHIFT_COMMON_CONNECT_ARGS,
+                "password": {"type": "string", "required": True, "empty": False},
+            },
+            # IAM-federated auth (GetClusterCredentials). No static password;
+            # temporary DbUser/DbPassword are resolved at connect time.
+            {
+                **_REDSHIFT_COMMON_CONNECT_ARGS,
+                "cluster_identifier": {
+                    "type": "string",
+                    "required": True,
+                    "empty": False,
+                },
+                "db_user": {"type": "string", "required": True, "empty": False},
+                "aws_region": {"type": "string", "required": True, "empty": False},
+                "assumable_role": {"type": "string"},
+                "external_id": {"type": "string"},
+                "duration_seconds": {"type": ["string", "integer"]},
+            },
+        ],
     },
     "ssl_options": SSL_OPTIONS_FIELD,
     # Top-level autocommit per docs example.

--- a/apollo/integrations/ctp/defaults/redshift.py
+++ b/apollo/integrations/ctp/defaults/redshift.py
@@ -10,6 +10,10 @@ class RedshiftClientArgs(TypedDict):
     port: Required[int]
     dbname: Required[str]
     user: Required[str]
+    # Present for password auth. For IAM-federated auth the secret carries no
+    # static password — it's supplied at connect time by the auth-rule's
+    # resolve_redshift_credentials step (minted via GetClusterCredentials) and
+    # merged into these client args before the connector runs. See SUP-532.
     password: Required[str]
     # SSL
     sslmode: NotRequired[str]

--- a/tests/credentials/schema/test_endpoint.py
+++ b/tests/credentials/schema/test_endpoint.py
@@ -210,6 +210,60 @@ def test_salesforce_crm_no_variant_fails(client):
     assert "connect_args" in payload["errors"]
 
 
+def test_redshift_password_variant(client):
+    # Monte Carlo-managed / username+password auth.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                "dbname": "analytics",
+                "user": "mc_user",
+                "password": "pwd",
+            }
+        },
+    )
+    assert payload["valid"] is True
+    assert payload["connection_type"] == "redshift"
+    assert payload["errors"] == {}
+
+
+def test_redshift_federated_variant_no_password(client):
+    # IAM-federated (Connection Auth Rules): no static password — the agent
+    # mints temporary credentials via GetClusterCredentials. Uses db_name
+    # (the documented key) rather than dbname. This is the SUP-532 shape that
+    # previously failed validation.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                "db_name": "analytics",
+                "cluster_identifier": "mc-cluster",
+                "db_user": "mc_user",
+                "aws_region": "eu-west-1",
+            }
+        },
+    )
+    assert payload["valid"] is True
+    assert payload["errors"] == {}
+
+
+def test_redshift_no_auth_variant_fails(client):
+    # Neither a password nor the federated fields — matches no variant.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {"connect_args": {"host": "cluster.abc.eu-west-1.redshift.amazonaws.com"}},
+    )
+    assert payload["valid"] is False
+    assert "connect_args" in payload["errors"]
+
+
 # -- custom connector tests ------------------------------------------------
 
 

--- a/tests/credentials/schema/test_endpoint.py
+++ b/tests/credentials/schema/test_endpoint.py
@@ -264,6 +264,94 @@ def test_redshift_no_auth_variant_fails(client):
     assert "connect_args" in payload["errors"]
 
 
+def test_redshift_ambiguous_both_variants_fails(client):
+    # A secret carrying BOTH a static password and the federated fields matches
+    # both oneof_schema variants — cerberus rejects it as ambiguous rather than
+    # silently picking one. Pins the invariant documented on the schema.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                "db_name": "analytics",
+                "password": "pwd",
+                "cluster_identifier": "mc-cluster",
+                "db_user": "mc_user",
+                "aws_region": "eu-west-1",
+            }
+        },
+    )
+    assert payload["valid"] is False
+    assert "connect_args" in payload["errors"]
+
+
+@pytest.mark.parametrize("db_key", ["db_name", "dbname", "database"])
+def test_redshift_db_name_aliases_password_variant(client, db_key):
+    # All three db-name aliases are accepted in the password variant.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                db_key: "analytics",
+                "user": "mc_user",
+                "password": "pwd",
+            }
+        },
+    )
+    assert payload["valid"] is True
+    assert payload["errors"] == {}
+
+
+@pytest.mark.parametrize("db_key", ["db_name", "dbname", "database"])
+def test_redshift_db_name_aliases_federated_variant(client, db_key):
+    # All three db-name aliases are accepted in the federated variant too.
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                db_key: "analytics",
+                "cluster_identifier": "mc-cluster",
+                "db_user": "mc_user",
+                "aws_region": "eu-west-1",
+            }
+        },
+    )
+    assert payload["valid"] is True
+    assert payload["errors"] == {}
+
+
+def test_redshift_federated_variant_optional_fields(client):
+    # The optional IAM-role fields on the federated variant validate and don't
+    # trip the schema (guards against a field-name typo in the schema).
+    payload = _post_validate(
+        client,
+        "redshift",
+        {
+            "connect_args": {
+                "host": "cluster.abc.eu-west-1.redshift.amazonaws.com",
+                "port": "5439",
+                "db_name": "analytics",
+                "cluster_identifier": "mc-cluster",
+                "db_user": "mc_user",
+                "aws_region": "eu-west-1",
+                "assumable_role": "arn:aws:iam::123456789012:role/mc-redshift",
+                "external_id": "ext-123",
+                "duration_seconds": 3600,
+            }
+        },
+    )
+    assert payload["valid"] is True
+    assert payload["errors"] == {}
+
+
 # -- custom connector tests ------------------------------------------------
 
 


### PR DESCRIPTION
## What

Redshift self-hosted credential validation rejected **IAM-federated** (Connection Auth Rules) secrets: `REDSHIFT_CREDENTIALS_SCHEMA` required `connect_args.{host, dbname, password}`. Federated secrets have **no static password** (temporary creds are minted at connect time via `GetClusterCredentials`) and use `db_name`, not `dbname` — so customers had to add a dummy password and duplicate `db_name`/`dbname` keys just to pass validation.

This converts the Redshift raw-credentials schema to a cerberus `oneof_schema` with a **password variant** and a **federated variant** (`cluster_identifier`/`db_user`/`aws_region`, no password) over a shared base — mirroring the existing Snowflake multi-auth-mode pattern. `db_name`/`dbname`/`database` are accepted as aliases so any documented spelling validates.

## Key decisions

- **Fixed in the static schema, not the validator.** `validate_self_hosted_credentials` only receives `connection_type` (no `ctp_config`/auth rule), and neither transport passes it — so a schema-level fix (like Snowflake) is correct and avoids cross-transport plumbing.
- **db-name aliases kept optional** (`db_name`/`dbname`/`database`) rather than requiring one, to avoid rejecting existing `dbname`-keyed password secrets while accepting the documented `db_name`; a genuinely missing db name surfaces at connect time.
- **`host` kept required in both variants** — federated still connects to the cluster endpoint.

## Testing

- New endpoint tests: federated (no password) passes, password passes, neither-auth fails with a `connect_args` error.
- Existing redshift CTP + schema-registry tests green (45), endpoint suite 16 pass, ruff clean.

Linear: SUP-532 · Customer: ZD #28116 (BBC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] Ran `/code-review`
