### PR TITLE
fix(sfdc): surface a360 exchange status/body on query-path token failures (YET-1790)

### DIFF
--- a/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
+++ b/apollo/integrations/db/salesforce_data_cloud_proxy_client.py
@@ -224,9 +224,34 @@ class SalesforceDataCloudConnection(SalesforceCDPConnection):
                 dataspace=dataspace,
             )
 
+            # The library swallows the a360 exchange failure (`except Exception:
+            # pass` in _get_token) before falling into _renew_token, so by the
+            # time raise_on_renewal fires the real HTTP status/body is gone.
+            # Capture the exchange traffic so the error and log carry the actual
+            # Salesforce rejection (YET-1790).
+            capturing = _attach_capturing_session(self)
+
             def raise_on_renewal(*args: Any, **kwargs: Any) -> NoReturn:
+                status = capturing.last_exchange_status if capturing else None
+                body = _redact_body(capturing.last_exchange_body if capturing else None)
+                logger.warning(
+                    "Salesforce Data Cloud: a360/token exchange failed (core-token path)",
+                    extra={
+                        "dataspace": dataspace,
+                        "exchange_status_code": status,
+                        "exchange_error_type": _classify_exchange_status(status),
+                        "exchange_response_body": body,
+                    },
+                )
+                if status is None:
+                    detail = ""
+                elif body:
+                    detail = f" (HTTP {status}, Salesforce response: {body})"
+                else:
+                    detail = f" (HTTP {status})"
                 raise Exception(
-                    "Token exchange failed. The access token may have expired or the dataspace may not exist."
+                    "Token exchange failed. The access token may have expired "
+                    f"or the dataspace may not exist.{detail}"
                 )
 
             if (

--- a/tests/test_salesforce_data_cloud_client.py
+++ b/tests/test_salesforce_data_cloud_client.py
@@ -4,6 +4,7 @@ import uuid
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+import requests
 import responses
 import urllib3.exceptions
 
@@ -308,6 +309,96 @@ class SalesforceDataCloudProxyClientTests(TestCase):
         for i, (key, value) in enumerate(self.data_response["metadata"].items()):
             self.assertEqual(result["description"][i][0], key)
             self.assertEqual(result["description"][i][1], value["type"])
+
+    def test_query_token_exchange_failure_surfaces_status_and_body(self):
+        """
+        Old-DC-path query connections (core_token present) must surface the captured
+        a360/token exchange HTTP status and response body instead of only the generic
+        "Token exchange failed..." message (YET-1790). The library swallows the
+        exchange failure (``except Exception: pass``) before falling into
+        ``_renew_token``, so the detail must come from the ``_CapturingSession``
+        attached to the connection's authentication_helper.
+        """
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/a360/token"
+        )
+        self.mock_responses.add(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            status=400,
+            body=json.dumps(
+                {"error": "invalid_request", "error_description": "dataspace not found"}
+            ),
+        )
+        # Model the size-collection dispatch: dataspace-scoped query credentials.
+        self.credentials["connect_args"]["dataspace"] = "csg"
+
+        operation = {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "args": ["SELECT COUNT(*) FROM t__dll"],
+                    "method": "execute",
+                    "target": "_cursor",
+                },
+            ],
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_query_token_exchange_failure",
+            operation_dict=operation,
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        msg = str(response.result)
+        self.assertIn("Token exchange failed", msg)
+        self.assertIn("HTTP 400", msg)
+        self.assertIn("dataspace not found", msg)
+
+    def test_query_token_exchange_failure_without_response_stays_generic(self):
+        """
+        When the a360 exchange fails without an HTTP response (e.g. the connection
+        drops), there is nothing to capture — the query-path error must stay the
+        generic message without a bogus "HTTP None" suffix.
+        """
+        self.mock_responses.remove(
+            responses.POST, "https://test.salesforce.com/services/a360/token"
+        )
+        self.mock_responses.add(
+            method=responses.POST,
+            url="https://test.salesforce.com/services/a360/token",
+            body=requests.exceptions.ConnectionError("connection dropped"),
+        )
+
+        operation = {
+            "trace_id": "test-trace-id",
+            "skip_cache": True,
+            "commands": [
+                {"method": "cursor", "store": "_cursor"},
+                {
+                    "args": ["SELECT COUNT(*) FROM t__dll"],
+                    "method": "execute",
+                    "target": "_cursor",
+                },
+            ],
+        }
+
+        response = self.agent.execute_operation(
+            connection_type="salesforce-data-cloud",
+            operation_name="test_query_token_exchange_failure_no_response",
+            operation_dict=operation,
+            credentials=self.credentials,
+        )
+
+        self.assertTrue(response.is_error)
+        msg = str(response.result)
+        self.assertIn("Token exchange failed", msg)
+        self.assertNotIn("HTTP", msg)
+        self.assertNotIn("Salesforce response", msg)
 
     def test_list_tables_with_invalid_dataspace_raises_clear_error(self):
         """


### PR DESCRIPTION
# Changes

On the old-DC query path (core_token present), `salesforcecdpconnector` swallows the a360 token-exchange failure (`except Exception: pass` in `_get_token`) before falling into `_renew_token`, so the overridden `raise_on_renewal` could only raise a generic "Token exchange failed. The access token may have expired or the dataspace may not exist." — the real Salesforce rejection (HTTP status + body) was lost. That turned incidents like YET-1789 (the exchange rejecting a lowercased dataspace name) into multi-hour investigations.

This PR attaches the existing `_CapturingSession` to the connection's `authentication_helper` at construction — the same pattern the `list_tables` path already uses — so `raise_on_renewal` now:

- appends `(HTTP <status>, Salesforce response: <redacted body>)` to the raised error, and
- emits the structured warning fields already indexed for the other paths (`exchange_status_code`, `exchange_error_type`, `exchange_response_body`, `dataspace`).

When the exchange fails without an HTTP response (e.g. connection drop), the message stays exactly the previous generic one.

Deliberately NOT wrapping the new-DC (client-credentials) path's `get_token`: its library error already carries the status code, and re-typing it would bypass the `SalesforceCDPError` handlers in `list_tables` (YET-1631 behavior). The optional bounded retry for transient a360 500s is left out of scope (noted on the ticket).

## Testing

Test-first: two new tests in `tests/test_salesforce_data_cloud_client.py`:

- a dataspace-scoped query whose a360 exchange returns 400 must surface `HTTP 400` and the response body (failed before the fix with only the generic message)
- a connection-drop exchange failure keeps the generic message (no bogus `HTTP None` suffix)

`pytest tests/test_salesforce_data_cloud_client.py` — 42/42. Full suite: 1335 passed; the remaining local failures/collection errors reproduce identically on pristine origin/main (missing local pyodbc/GCP/S3 native deps) and are unrelated.

black + pyright clean.

## Context

- Linear: YET-1790 (parent epic YET-1406, related YET-1789)
- Companion monolith root fix: YET-1789 (size-collection dataspace case)
- The capture/redaction/classification helpers were introduced for the list_tables path (YET-1546/YET-1630/YET-1631 work); this extends them to the query path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
