### PR TITLE
Support SSL (TLS + mTLS) for Oracle thick mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,29 @@
 ARG ORACLE_IC_ZIP=instantclient-basic-linux.x64-23.8.0.25.04.zip
 ARG ORACLE_IC_URL=https://download.oracle.com/otn_software/linux/instantclient/2380000
 
+# Oracle wallet tooling (orapki) for thick-mode TLS. Thick mode validates the
+# server certificate against an Oracle wallet (cwallet.sso), and only Oracle's
+# orapki tool can produce one that is trusted — a Python-built PKCS#12 is opened
+# but never honored as a trust anchor. orapki is a Java tool, so build a stripped,
+# minimal JRE (java.base + java.naming + jdk.crypto.ec) and fetch the oraclepki
+# jars once here, then copy the ~55MB result into each runtime stage. Built on
+# Amazon Linux 2023 (glibc 2.34 — the oldest of our runtime bases) so the runtime
+# is forward-compatible with the newer-glibc Debian stages. osdt_core/osdt_cert
+# are not published at the Instant Client version, so they are pinned separately.
+ARG ORACLE_PKI_VERSION=23.8.0.25.04
+ARG ORACLE_OSDT_VERSION=21.11.0.0
+FROM amazoncorretto:21-al2023 AS oracle-pki-builder
+ARG ORACLE_PKI_VERSION
+ARG ORACLE_OSDT_VERSION
+RUN dnf install -y binutils \
+    && jlink --add-modules java.base,java.naming,jdk.crypto.ec \
+         --strip-debug --no-header-files --no-man-pages --output /opt/oracle-pki/jre \
+    && mkdir -p /opt/oracle-pki/lib \
+    && M=https://repo1.maven.org/maven2/com/oracle/database/security \
+    && curl -fsSLo /opt/oracle-pki/lib/oraclepki.jar $M/oraclepki/${ORACLE_PKI_VERSION}/oraclepki-${ORACLE_PKI_VERSION}.jar \
+    && curl -fsSLo /opt/oracle-pki/lib/osdt_core.jar $M/osdt_core/${ORACLE_OSDT_VERSION}/osdt_core-${ORACLE_OSDT_VERSION}.jar \
+    && curl -fsSLo /opt/oracle-pki/lib/osdt_cert.jar $M/osdt_cert/${ORACLE_OSDT_VERSION}/osdt_cert-${ORACLE_OSDT_VERSION}.jar
+
 # system-base — system-level dependencies only (apt packages, no venv).
 # Published as `<version>-system-base` so downstream consumers (e.g. hermes-agent)
 # can build their own venv against the same native libs without inheriting
@@ -54,6 +77,9 @@ RUN apt-get install -y --no-install-recommends unzip \
     && ln -s /opt/oracle/instantclient_* /opt/oracle/instantclient \
     && echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf \
     && ldconfig
+
+# orapki + minimal JRE for building thick-mode TLS wallets (see oracle-pki-builder).
+COPY --from=oracle-pki-builder /opt/oracle-pki /opt/oracle-pki
 
 # clean up all unused libraries
 RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -183,6 +209,9 @@ RUN dnf -y install libaio unzip \
     && echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf \
     && /sbin/ldconfig
 
+# orapki + minimal JRE for building thick-mode TLS wallets (see oracle-pki-builder).
+COPY --from=oracle-pki-builder /opt/oracle-pki /opt/oracle-pki
+
 # VULN-464
 RUN rm -rf /var/lib/rpm/rpmdb.sqlite*
 
@@ -258,6 +287,9 @@ RUN apt-get install -y --no-install-recommends unzip curl \
     && ln -s /opt/oracle/instantclient_* /opt/oracle/instantclient \
     && echo /opt/oracle/instantclient > /etc/ld.so.conf.d/oracle-instantclient.conf \
     && ldconfig
+
+# orapki + minimal JRE for building thick-mode TLS wallets (see oracle-pki-builder).
+COPY --from=oracle-pki-builder /opt/oracle-pki /opt/oracle-pki
 
 # clean up all unused libraries
 RUN apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/apollo/integrations/ctp/CLAUDE.md
+++ b/apollo/integrations/ctp/CLAUDE.md
@@ -60,6 +60,16 @@ dedicated `GcpDataformProxyClient`. The CTP config in `defaults/gcp_dataform.py`
 `project_id`, `service_account_info`, and an optional `locations` list; the proxy client handles
 SA credential construction and exposes Dataform API calls as serialized-dict methods.
 
+**Oracle** (`oracle` connection type) — CTP config in `defaults/oracle.py` maps the scalar
+connection fields (`dsn`/`user`/`password`/`expire_time`) and additionally passes the whole nested
+`ssl_options` block through **unchanged**: `"ssl_options": "{{ raw.ssl_options | default(none) }}"`.
+This is the reference for the **nested-dict passthrough pattern** — when a proxy client needs a
+structured credential sub-object (not flat scalars), map it through as a single template
+expression. The sandboxed `NativeEnvironment` (see `template.py`) preserves it as a `dict` rather
+than stringifying it. `OracleProxyClient` then pops `ssl_options` out of `connect_args` (it is not
+an `oracledb.connect` arg) and builds the thin `ssl.SSLContext` / thick wallet from it — the
+resolution can't happen in the CTP because it depends on runtime/process state (thin vs thick).
+
 ## Security note
 
 Jinja2 templates are sandboxed (see `template.py`). Do not use `Environment()` directly —

--- a/apollo/integrations/ctp/defaults/oracle.py
+++ b/apollo/integrations/ctp/defaults/oracle.py
@@ -28,6 +28,10 @@ class OracleClientArgs(TypedDict):
     ssl_server_dn_match: NotRequired[bool]  # default True
     ssl_server_cert_dn: NotRequired[str]
     ssl_version: NotRequired[Any]  # ssl.TLSVersion
+    # The full SslOptions block, passed through to OracleProxyClient which builds
+    # the thin ssl_context / thick wallet from it. NOT an oracledb.connect arg —
+    # the proxy client pops it from connect_args before calling connect().
+    ssl_options: NotRequired[Any]
     # Network
     tcp_connect_timeout: NotRequired[float]  # default 20.0 seconds
     https_proxy: NotRequired[str]
@@ -85,6 +89,11 @@ ORACLE_DEFAULT_CTP = CtpConfig(
             "user": "{{ raw.user | default(none) }}",
             "password": "{{ raw.password | default(none) }}",
             "expire_time": "{{ raw.expire_time | default(none) }}",
+            # Pass the SslOptions block through so OracleProxyClient can build the
+            # thin ssl_context / thick wallet. NativeEnvironment preserves the dict
+            # (it is not stringified). Without this the CTP drops ssl_options and
+            # SSL connections silently connect without trust (ORA-29024).
+            "ssl_options": "{{ raw.ssl_options | default(none) }}",
         },
     ),
     # Keep-alive every minute; required for AWS PrivateLink connections.

--- a/apollo/integrations/db/CLAUDE.md
+++ b/apollo/integrations/db/CLAUDE.md
@@ -46,6 +46,13 @@ clients that write their own CA file (db2, teradata) register it explicitly. Pre
 per client (e.g. `SslOptions.write_ca_data_to_temp_file`, which uses `mkstemp`) rather than a
 deterministic one, so closing one client cannot delete a file still in use by another.
 
+**Exception — Oracle thick mode.** `oracle_client_config.py`'s thick-mode TLS wallet and
+`sqlnet.ora` config dir are **process-global** (built once, cached in module state, reused by every
+connection) and are intentionally **not** registered via `register_temp_files`. Oracle Instant
+Client freezes its trust store at the first `init_oracle_client`, so the wallet must outlive any
+single client — per-client cleanup would delete a wallet still needed by later connections. See the
+`oracle_client_config` module docstring for the full rationale.
+
 ### Non-pyodbc clients
 
 Most other clients (postgres, mysql, bigquery, etc.) wrap their own driver's connection object.

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -292,9 +292,10 @@ def configure_thick_connection(ssl_options: SslOptions) -> None:
     On the FIRST Oracle connection this builds the wallet from ``ssl_options`` and
     writes ``sqlnet.ora`` BEFORE ``init_oracle_client`` — the ordering Oracle
     requires for the wallet subsystem to start with the trust store present.
-    Because Oracle caches the trust store after the first connection, later calls
-    do nothing but warn if a connection asks for a TLS config that differs from
-    the one already established (a thick agent supports a single TLS trust config).
+    Because Oracle's trust store is process-global and frozen at the first
+    ``init_oracle_client``, a later connection that needs TLS trust the process
+    can't apply (initialized without a wallet, or with a different CA) is rejected
+    with a clear error rather than failing later with a confusing ORA-29024.
 
     The caller runs ``oracledb.connect`` after this returns.
     """
@@ -316,28 +317,37 @@ def configure_thick_connection(ssl_options: SslOptions) -> None:
                 + ("; TLS wallet configured" if _thick_wallet_dir else "")
             )
         else:
-            _warn_on_tls_config_change(ssl_options)
+            _require_compatible_established_tls(ssl_options)
 
 
-def _warn_on_tls_config_change(ssl_options: SslOptions) -> None:
-    """Warn when a later connection wants a TLS config the process can't apply.
+def _require_compatible_established_tls(ssl_options: SslOptions) -> None:
+    """Reject a connection whose TLS trust the process can't apply.
 
-    Thick trust is frozen after the first connection, so a differing CA (or TLS
-    requested when the agent was initialized without it) is silently ineffective;
-    surface it rather than let it fail confusingly.
+    Thick-mode trust is process-global and fixed at the first
+    ``init_oracle_client``. If a TLS connection arrives after the process was
+    initialized without a wallet, or with a different CA, its trust cannot be
+    applied — fail loudly with actionable guidance instead of letting Oracle
+    fail later with ORA-29024 (certificate validation failure).
     """
     wants_tls = bool(not ssl_options.disabled and ssl_options.ca_data)
     if not wants_tls:
         return
     if _thick_wallet_dir is None:
-        logger.warning(
-            "oracle: thick mode was initialized without TLS by the first connection; "
-            "TLS trust cannot be added later in the same process"
+        raise RuntimeError(
+            "Oracle thick mode was already initialized in this agent process "
+            "without an SSL trust store, so this SSL connection cannot be "
+            "established — thick-mode TLS trust is process-global and fixed at "
+            "first use. Restart the agent so its first Oracle connection uses "
+            "this SSL configuration, or use a dedicated agent for this SSL "
+            "integration."
         )
-    elif _ca_fingerprint(ssl_options) != _thick_ca_fingerprint:
-        logger.warning(
-            "oracle: thick mode uses the TLS trust established by the first connection; "
-            "this connection's differing CA data is ignored"
+    if _ca_fingerprint(ssl_options) != _thick_ca_fingerprint:
+        raise RuntimeError(
+            "Oracle thick mode was already initialized in this agent process "
+            "with a different SSL CA. A thick-mode agent supports a single "
+            "Oracle TLS trust configuration (process-global). Restart the agent "
+            "so it initializes with this CA, or use a dedicated agent for this "
+            "integration."
         )
 
 

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -97,7 +97,9 @@ logger = logging.getLogger(__name__)
 _thick_lock = threading.Lock()
 _thick_config_dir: Optional[str] = None  # holds sqlnet.ora (passed to init)
 _thick_wallet_dir: Optional[str] = None  # the single TLS wallet, or None if no TLS
-_thick_ca_fingerprint: Optional[str] = None  # sha256 of the established ca_data
+# sha256 of the established TLS material (CA + client identity), so a later
+# connection needing a different CA *or* client certificate is detected.
+_thick_tls_fingerprint: Optional[str] = None
 
 
 def thick_mode_enabled() -> bool:
@@ -112,9 +114,11 @@ def _run_orapki(*args: str) -> None:
     """Run an ``orapki`` wallet command via the bundled minimal JRE.
 
     ``args`` are the orapki arguments (e.g. ``"wallet", "create", ...``). Raises
-    ``RuntimeError`` with orapki's output on failure. The command line (which
-    includes ``-pwd``) is deliberately kept out of the exception message so the
-    wallet password never lands in logs.
+    ``RuntimeError`` with orapki's output on failure. The command line itself is
+    kept out of the message, and any password values we passed (``-pwd`` /
+    ``-pkcs12pwd``) are scrubbed from orapki's stdout/stderr before they reach the
+    exception — which propagates to logs AND the agent's API error response, where
+    no keyword/entropy redaction would catch a bare CLI-flag value.
     """
     home = _oracle_pki_home()
     java_bin = os.path.join(home, "jre", "bin", "java")
@@ -125,9 +129,19 @@ def _run_orapki(*args: str) -> None:
         text=True,
     )
     if result.returncode != 0:
+        output = f"{result.stdout.strip()} {result.stderr.strip()}"
+        # orapki can echo its own argv (including the password flags) back in
+        # usage/error output; redact the secret values we passed.
+        secrets_to_scrub = [
+            args[i + 1]
+            for i, arg in enumerate(args)
+            if arg in ("-pwd", "-pkcs12pwd") and i + 1 < len(args)
+        ]
+        for secret in secrets_to_scrub:
+            if secret:
+                output = output.replace(secret, "__redacted__")
         raise RuntimeError(
-            "orapki wallet command failed "
-            f"(exit {result.returncode}): {result.stdout.strip()} {result.stderr.strip()}"
+            f"orapki wallet command failed (exit {result.returncode}): {output}"
         )
 
 
@@ -280,10 +294,27 @@ def _ensure_thick_config_dir() -> str:
     return _thick_config_dir
 
 
-def _ca_fingerprint(ssl_options: SslOptions) -> Optional[str]:
+def _tls_fingerprint(ssl_options: SslOptions) -> Optional[str]:
+    """Fingerprint the full TLS material — CA trust plus client identity.
+
+    Thick-mode trust is process-global and frozen at the first connection, so the
+    fingerprint must cover not just ``ca_data`` but the mTLS client identity
+    (``cert_data``/``key_data``/``key_password``) too; otherwise a later
+    same-CA-but-different-client-cert connection would silently reuse the first
+    connection's wallet identity instead of being rejected.
+    """
     if ssl_options.disabled or not ssl_options.ca_data:
         return None
-    return hashlib.sha256(ssl_options.ca_data.encode()).hexdigest()
+    material = "\0".join(
+        part or ""
+        for part in (
+            ssl_options.ca_data,
+            ssl_options.cert_data,
+            ssl_options.key_data,
+            ssl_options.key_password,
+        )
+    )
+    return hashlib.sha256(material.encode()).hexdigest()
 
 
 def configure_thick_connection(ssl_options: SslOptions) -> None:
@@ -299,19 +330,28 @@ def configure_thick_connection(ssl_options: SslOptions) -> None:
 
     The caller runs ``oracledb.connect`` after this returns.
     """
-    global _thick_wallet_dir, _thick_ca_fingerprint
+    global _thick_wallet_dir, _thick_tls_fingerprint
     with _thick_lock:
         config_dir = _ensure_thick_config_dir()
         if oracledb.is_thin_mode():
             # First Oracle connection in this process. Build the wallet + write
             # WALLET_LOCATION before init so trust is present when the wallet
             # subsystem starts; is_thin_mode() flips to False after init.
-            _thick_wallet_dir = create_oracle_thick_wallet(ssl_options)
-            _thick_ca_fingerprint = _ca_fingerprint(ssl_options)
-            _write_thick_sqlnet(
-                config_dir, _thick_wallet_dir, ssl_options.verify_identity
-            )
-            oracledb.init_oracle_client(config_dir=config_dir)
+            wallet_dir = create_oracle_thick_wallet(ssl_options)
+            try:
+                _write_thick_sqlnet(config_dir, wallet_dir, ssl_options.verify_identity)
+                oracledb.init_oracle_client(config_dir=config_dir)
+            except BaseException:
+                # sqlnet write or init failed after the wallet was built. Since
+                # is_thin_mode() stays True, the next attempt would rebuild and
+                # orphan this dir (holding the CA and, for mTLS, the client key);
+                # drop it now and leave the globals unset so a retry starts clean.
+                if wallet_dir:
+                    shutil.rmtree(wallet_dir, ignore_errors=True)
+                raise
+            # Commit the process-wide state only once init has succeeded.
+            _thick_wallet_dir = wallet_dir
+            _thick_tls_fingerprint = _tls_fingerprint(ssl_options)
             logger.info(
                 "oracle: thick mode initialized"
                 + ("; TLS wallet configured" if _thick_wallet_dir else "")
@@ -325,9 +365,10 @@ def _require_compatible_established_tls(ssl_options: SslOptions) -> None:
 
     Thick-mode trust is process-global and fixed at the first
     ``init_oracle_client``. If a TLS connection arrives after the process was
-    initialized without a wallet, or with a different CA, its trust cannot be
-    applied — fail loudly with actionable guidance instead of letting Oracle
-    fail later with ORA-29024 (certificate validation failure).
+    initialized without a wallet, or with a different CA or client certificate,
+    its trust/identity cannot be applied — fail loudly with actionable guidance
+    instead of letting Oracle fail later with ORA-29024 (certificate validation
+    failure) or silently authenticating with the wrong client identity.
     """
     wants_tls = bool(not ssl_options.disabled and ssl_options.ca_data)
     if not wants_tls:
@@ -341,13 +382,13 @@ def _require_compatible_established_tls(ssl_options: SslOptions) -> None:
             "this SSL configuration, or use a dedicated agent for this SSL "
             "integration."
         )
-    if _ca_fingerprint(ssl_options) != _thick_ca_fingerprint:
+    if _tls_fingerprint(ssl_options) != _thick_tls_fingerprint:
         raise RuntimeError(
             "Oracle thick mode was already initialized in this agent process "
-            "with a different SSL CA. A thick-mode agent supports a single "
-            "Oracle TLS trust configuration (process-global). Restart the agent "
-            "so it initializes with this CA, or use a dedicated agent for this "
-            "integration."
+            "with a different SSL configuration (CA certificate or client "
+            "certificate). A thick-mode agent supports a single Oracle TLS "
+            "configuration (process-global). Restart the agent so it initializes "
+            "with this configuration, or use a dedicated agent for this integration."
         )
 
 

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -312,13 +312,18 @@ def _ensure_thick_config_dir() -> str:
 
 
 def _tls_fingerprint(ssl_options: SslOptions) -> Optional[str]:
-    """Fingerprint the full TLS material — CA trust plus client identity.
+    """Fingerprint the TLS material — CA trust plus client identity.
 
     Thick-mode trust is process-global and frozen at the first connection, so the
     fingerprint must cover not just ``ca_data`` but the mTLS client identity
-    (``cert_data``/``key_data``/``key_password``) too; otherwise a later
+    (``cert_data``/``key_data``) too; otherwise a later
     same-CA-but-different-client-cert connection would silently reuse the first
-    connection's wallet identity instead of being rejected.
+    connection's wallet identity instead of being rejected. The key passphrase is
+    intentionally excluded — the cert/key already identify the client, and hashing
+    a password here would be misread as (weak) password storage.
+
+    This is a change-detection fingerprint, not password storage, so SHA-256 is
+    the appropriate choice.
     """
     if ssl_options.disabled or not ssl_options.ca_data:
         return None
@@ -328,7 +333,6 @@ def _tls_fingerprint(ssl_options: SslOptions) -> Optional[str]:
             ssl_options.ca_data,
             ssl_options.cert_data,
             ssl_options.key_data,
-            ssl_options.key_password,
         )
     )
     return hashlib.sha256(material.encode()).hexdigest()

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -1,0 +1,426 @@
+"""Oracle TLS/mTLS configuration for the Oracle proxy client.
+
+This module owns everything about securing an Oracle connection so the proxy
+client can stay focused on the DB proxy responsibilities. Two very different
+mechanisms live here because thin and thick mode handle TLS differently:
+
+* Thin mode (pure Python driver) takes a standard ``ssl.SSLContext`` — see
+  ``create_oracle_ssl_context``.
+* Thick mode (Oracle Instant Client) does NOT accept an ``ssl.SSLContext``. It
+  validates the server certificate against an Oracle *wallet* whose location is
+  configured via ``WALLET_LOCATION`` in ``sqlnet.ora``. Established the hard way
+  against real RDS Oracle:
+  - The wallet must be a ``cwallet.sso`` produced by Oracle's ``orapki`` tool; a
+    Python-built PKCS#12 is opened but never honored as a trust anchor.
+  - The ``connect()`` ``wallet_location`` parameter does NOT drive server-cert
+    trust in thick mode — only ``WALLET_LOCATION`` in ``sqlnet.ora`` does.
+  - The wallet must already exist at ``WALLET_LOCATION`` when
+    ``init_oracle_client`` runs, or the wallet subsystem starts with no trust
+    store and every TLS connection fails with ORA-29024.
+  - Oracle **caches the trust store after the first successful connection** for
+    the process lifetime — it does NOT re-read the wallet per connect. So the
+    wallet is built ONCE, from the first connection's ``ssl_options``, before
+    init. A thick agent therefore supports a single Oracle TLS trust config,
+    which fits its dedicated, process-global design (thick mode is already a
+    one-way, process-global switch that can't coexist with thin connections).
+
+``configure_thick_connection`` encapsulates that one-time setup (build wallet -> write
+``sqlnet.ora`` -> ``init_oracle_client``), serialized by a process lock because
+``sqlnet.ora`` and ``init_oracle_client`` are process-global.
+"""
+
+import hashlib
+import logging
+import os
+import secrets
+import shutil
+import ssl
+import subprocess
+import tempfile
+import threading
+from typing import Optional
+
+import oracledb
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    Encoding,
+    load_pem_private_key,
+    pkcs12,
+)
+
+from apollo.integrations.db.ssl_options import SslOptions
+
+# Agent-level thick-mode switch. Thick mode (Oracle Instant Client) is a
+# process-global, one-way setting that cannot coexist with thin connections in
+# the same process, so it is configured per-agent via this env var rather than
+# per-connection. Enable it only on an agent dedicated to thick-mode Oracle.
+_ENV_VAR_THICK_MODE = "MCD_ORACLE_THICK_MODE"
+
+# Optional override for the thick-mode TLS cipher suites (comma-separated Oracle
+# cipher names). The default below intentionally includes RSA key-exchange
+# suites: Oracle Client omits them from its defaults, but some servers (e.g. AWS
+# RDS Oracle, which offers AES256-GCM-SHA384 / SSL_RSA_WITH_AES_256_GCM_SHA384)
+# require them — the thin path handles this via `@SECLEVEL=1`, but thick has no
+# such knob and needs an explicit SSL_CIPHER_SUITES list. Modern ECDHE suites
+# are listed first so they are preferred where the server supports them.
+_ENV_VAR_SSL_CIPHER_SUITES = "MCD_ORACLE_SSL_CIPHER_SUITES"
+_DEFAULT_SSL_CIPHER_SUITES = ",".join(
+    [
+        "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "SSL_RSA_WITH_AES_256_GCM_SHA384",
+        "SSL_RSA_WITH_AES_128_GCM_SHA256",
+        "SSL_RSA_WITH_AES_256_CBC_SHA256",
+        "SSL_RSA_WITH_AES_128_CBC_SHA256",
+        "SSL_RSA_WITH_AES_256_CBC_SHA",
+        "SSL_RSA_WITH_AES_128_CBC_SHA",
+    ]
+)
+
+# Location of the bundled minimal JRE + orapki jars used to build Oracle wallets.
+# Thick-mode TLS trust requires a real Oracle wallet (cwallet.sso) produced by
+# Oracle's orapki tool; a Python-built PKCS#12 is not honored as a trust store.
+# orapki is a Java tool, so the Docker image ships a stripped JRE plus the
+# oraclepki jars under this directory (jre/ and lib/). Overridable for tests.
+_ENV_VAR_ORACLE_PKI_HOME = "MCD_ORACLE_PKI_HOME"
+_DEFAULT_ORACLE_PKI_HOME = "/opt/oracle-pki"
+_ORAPKI_MAIN_CLASS = "oracle.security.pki.textui.OraclePKITextUI"
+
+logger = logging.getLogger(__name__)
+
+# Process-wide thick-mode state, established once on the first Oracle connection
+# and reused for the process lifetime (Oracle caches the trust store after the
+# first successful connection). Guarded by _thick_lock.
+_thick_lock = threading.Lock()
+_thick_config_dir: Optional[str] = None  # holds sqlnet.ora (passed to init)
+_thick_wallet_dir: Optional[str] = None  # the single TLS wallet, or None if no TLS
+_thick_ca_fingerprint: Optional[str] = None  # sha256 of the established ca_data
+
+
+def thick_mode_enabled() -> bool:
+    return os.getenv(_ENV_VAR_THICK_MODE, "false").strip().lower() == "true"
+
+
+def _oracle_pki_home() -> str:
+    return os.getenv(_ENV_VAR_ORACLE_PKI_HOME) or _DEFAULT_ORACLE_PKI_HOME
+
+
+def _run_orapki(*args: str) -> None:
+    """Run an ``orapki`` wallet command via the bundled minimal JRE.
+
+    ``args`` are the orapki arguments (e.g. ``"wallet", "create", ...``). Raises
+    ``RuntimeError`` with orapki's output on failure. The command line (which
+    includes ``-pwd``) is deliberately kept out of the exception message so the
+    wallet password never lands in logs.
+    """
+    home = _oracle_pki_home()
+    java_bin = os.path.join(home, "jre", "bin", "java")
+    classpath = os.path.join(home, "lib", "*")
+    result = subprocess.run(
+        [java_bin, "-cp", classpath, _ORAPKI_MAIN_CLASS, *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "orapki wallet command failed "
+            f"(exit {result.returncode}): {result.stdout.strip()} {result.stderr.strip()}"
+        )
+
+
+def _new_wallet_password() -> str:
+    # orapki requires a wallet password of at least 8 chars containing letters and
+    # digits; the suffix guarantees both classes regardless of token_urlsafe output.
+    return secrets.token_urlsafe(24) + "aA1"
+
+
+def _import_client_identity(
+    wallet_dir: str, wallet_password: str, ssl_options: SslOptions
+) -> None:
+    """Import the client key + cert into the wallet as its user credential (mTLS).
+
+    orapki imports a client identity from a PKCS#12 file, so the PEM key/cert are
+    packed into a temporary, password-protected ``client.p12`` and imported.
+
+    NOTE: not yet validated end-to-end — no reachable Oracle server currently
+    requests client authentication (AWS RDS Oracle can't). Implemented so mTLS
+    works where a server requires it; the one-way TLS path is proven.
+    """
+    if not (ssl_options.cert_data and ssl_options.key_data):
+        return
+
+    client_cert = x509.load_pem_x509_certificate(ssl_options.cert_data.encode())
+    client_key = load_pem_private_key(
+        ssl_options.key_data.encode(),
+        password=(
+            ssl_options.key_password.encode() if ssl_options.key_password else None
+        ),
+    )
+    p12_password = _new_wallet_password()
+    p12 = pkcs12.serialize_key_and_certificates(
+        b"mcd-oracle-client",
+        # load_pem_private_key's union includes key types PKCS12 rejects (e.g. DH);
+        # a TLS client key is always RSA/EC, so this is safe.
+        client_key,  # type: ignore[arg-type]
+        client_cert,
+        None,
+        BestAvailableEncryption(p12_password.encode()),
+    )
+    p12_path = os.path.join(wallet_dir, "client.p12")
+    try:
+        with open(p12_path, "wb") as p12_file:
+            p12_file.write(p12)
+        _run_orapki(
+            "wallet",
+            "import_pkcs12",
+            "-wallet",
+            wallet_dir,
+            "-pwd",
+            wallet_password,
+            "-pkcs12file",
+            p12_path,
+            "-pkcs12pwd",
+            p12_password,
+        )
+    finally:
+        if os.path.exists(p12_path):
+            os.unlink(p12_path)
+
+
+def create_oracle_thick_wallet(ssl_options: SslOptions) -> Optional[str]:
+    """Build an auto-login Oracle wallet (``cwallet.sso``) for thick-mode TLS.
+
+    Adds the CA cert(s) from ``ca_data`` as trusted certs via orapki, and — when
+    ``cert_data``/``key_data`` are present — imports the client identity for mTLS.
+    Returns the wallet directory, or ``None`` when SSL is disabled / no CA data is
+    provided. On failure the partially-built directory is removed.
+    """
+    if ssl_options.disabled or not ssl_options.ca_data:
+        return None
+
+    wallet_dir = tempfile.mkdtemp(prefix="mcd_oracle_wallet_")
+    try:
+        wallet_password = _new_wallet_password()
+        _run_orapki(
+            "wallet",
+            "create",
+            "-wallet",
+            wallet_dir,
+            "-pwd",
+            wallet_password,
+            "-auto_login",
+        )
+
+        # Add each CA in ca_data as a trusted certificate. orapki's -cert takes a
+        # single certificate, so a bundle is split into one temp file per cert.
+        ca_certs = x509.load_pem_x509_certificates(ssl_options.ca_data.encode())
+        for index, ca_cert in enumerate(ca_certs):
+            ca_path = os.path.join(wallet_dir, f"ca_{index}.pem")
+            try:
+                with open(ca_path, "wb") as ca_file:
+                    ca_file.write(ca_cert.public_bytes(Encoding.PEM))
+                _run_orapki(
+                    "wallet",
+                    "add",
+                    "-wallet",
+                    wallet_dir,
+                    "-trusted_cert",
+                    "-cert",
+                    ca_path,
+                    "-pwd",
+                    wallet_password,
+                )
+            finally:
+                if os.path.exists(ca_path):
+                    os.unlink(ca_path)
+
+        _import_client_identity(wallet_dir, wallet_password, ssl_options)
+        return wallet_dir
+    except BaseException:
+        shutil.rmtree(wallet_dir, ignore_errors=True)
+        raise
+
+
+def _write_thick_sqlnet(
+    config_dir: str,
+    wallet_dir: Optional[str] = None,
+    verify_identity: bool = True,
+) -> None:
+    """Write the thick-mode ``sqlnet.ora`` into ``config_dir``.
+
+    Always sets ``SSL_CIPHER_SUITES`` (thick has no ``@SECLEVEL`` knob, so the
+    suites older servers require must be listed explicitly or the handshake fails
+    with ORA-28860). When ``wallet_dir`` is given it also points
+    ``WALLET_LOCATION`` at the wallet (the only trust source thick honors) and
+    sets ``SSL_SERVER_DN_MATCH`` from ``verify_identity`` (default on). Note
+    thick's DN match is Oracle-DN based, not SAN/hostname based like thin's
+    ``check_hostname``.
+    """
+    suites = os.getenv(_ENV_VAR_SSL_CIPHER_SUITES) or _DEFAULT_SSL_CIPHER_SUITES
+    lines = [f"SSL_CIPHER_SUITES = ({suites})"]
+    if wallet_dir:
+        lines.append(
+            "WALLET_LOCATION = (SOURCE = (METHOD = FILE) "
+            f"(METHOD_DATA = (DIRECTORY = {wallet_dir})))"
+        )
+        lines.append(f"SSL_SERVER_DN_MATCH = {'TRUE' if verify_identity else 'FALSE'}")
+    with open(os.path.join(config_dir, "sqlnet.ora"), "w") as sqlnet:
+        sqlnet.write("\n".join(lines) + "\n")
+
+
+def _ensure_thick_config_dir() -> str:
+    """Create (once) the config dir for ``init_oracle_client(config_dir=)`` and
+    return its path. Reused for the process lifetime."""
+    global _thick_config_dir
+    if _thick_config_dir is None:
+        _thick_config_dir = tempfile.mkdtemp(prefix="mcd_oracle_tns_")
+    return _thick_config_dir
+
+
+def _ca_fingerprint(ssl_options: SslOptions) -> Optional[str]:
+    if ssl_options.disabled or not ssl_options.ca_data:
+        return None
+    return hashlib.sha256(ssl_options.ca_data.encode()).hexdigest()
+
+
+def configure_thick_connection(ssl_options: SslOptions) -> None:
+    """Configure thick-mode TLS trust for this process (idempotent, thread-safe).
+
+    On the FIRST Oracle connection this builds the wallet from ``ssl_options`` and
+    writes ``sqlnet.ora`` BEFORE ``init_oracle_client`` — the ordering Oracle
+    requires for the wallet subsystem to start with the trust store present.
+    Because Oracle caches the trust store after the first connection, later calls
+    do nothing but warn if a connection asks for a TLS config that differs from
+    the one already established (a thick agent supports a single TLS trust config).
+
+    The caller runs ``oracledb.connect`` after this returns.
+    """
+    global _thick_wallet_dir, _thick_ca_fingerprint
+    with _thick_lock:
+        config_dir = _ensure_thick_config_dir()
+        if oracledb.is_thin_mode():
+            # First Oracle connection in this process. Build the wallet + write
+            # WALLET_LOCATION before init so trust is present when the wallet
+            # subsystem starts; is_thin_mode() flips to False after init.
+            _thick_wallet_dir = create_oracle_thick_wallet(ssl_options)
+            _thick_ca_fingerprint = _ca_fingerprint(ssl_options)
+            _write_thick_sqlnet(
+                config_dir, _thick_wallet_dir, ssl_options.verify_identity
+            )
+            oracledb.init_oracle_client(config_dir=config_dir)
+            logger.info(
+                "oracle: thick mode initialized"
+                + ("; TLS wallet configured" if _thick_wallet_dir else "")
+            )
+        else:
+            _warn_on_tls_config_change(ssl_options)
+
+
+def _warn_on_tls_config_change(ssl_options: SslOptions) -> None:
+    """Warn when a later connection wants a TLS config the process can't apply.
+
+    Thick trust is frozen after the first connection, so a differing CA (or TLS
+    requested when the agent was initialized without it) is silently ineffective;
+    surface it rather than let it fail confusingly.
+    """
+    wants_tls = bool(not ssl_options.disabled and ssl_options.ca_data)
+    if not wants_tls:
+        return
+    if _thick_wallet_dir is None:
+        logger.warning(
+            "oracle: thick mode was initialized without TLS by the first connection; "
+            "TLS trust cannot be added later in the same process"
+        )
+    elif _ca_fingerprint(ssl_options) != _thick_ca_fingerprint:
+        logger.warning(
+            "oracle: thick mode uses the TLS trust established by the first connection; "
+            "this connection's differing CA data is ignored"
+        )
+
+
+def create_oracle_ssl_context(ssl_options: SslOptions) -> ssl.SSLContext | None:
+    """
+    Create an SSL context for Oracle connections.
+
+    Creates an SSLContext with relaxed cipher requirements to support older cipher suites
+    used by some databases (e.g., AWS RDS Oracle uses AES256-GCM-SHA384).
+
+    Args:
+        ssl_options: SslOptions object containing CA data and optionally client cert/key
+
+    Returns:
+        Configured ssl.SSLContext for use with oracledb connections, or None if SSL is disabled
+        or no CA data is provided.
+
+    Note: this is the thin-mode path. ssl_context is thin-only; thick mode uses
+    create_oracle_thick_wallet() instead.
+    """
+    if ssl_options.disabled or not ssl_options.ca_data:
+        return None
+
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+    # Respect SslOptions verification settings
+    # - skip_cert_verification: skips ALL validation (cert + hostname)
+    # - verify_cert: whether to validate the certificate chain
+    # - verify_identity: whether to check hostname matches certificate
+    ssl_context.check_hostname = (
+        not ssl_options.skip_cert_verification and ssl_options.verify_identity
+    )
+    ssl_context.verify_mode = (
+        ssl.CERT_NONE
+        if ssl_options.skip_cert_verification
+        else (ssl.CERT_REQUIRED if ssl_options.verify_cert else ssl.CERT_NONE)
+    )
+
+    # @SECLEVEL=1 allows older ciphers like AES256-GCM-SHA384 (plain RSA, no forward secrecy)
+    ssl_context.set_ciphers("DEFAULT:@SECLEVEL=1")
+
+    # Load CA certificate for server verification (if not skipping verification)
+    if ssl_options.ca_data and not ssl_options.skip_cert_verification:
+        ssl_context.load_verify_locations(cadata=ssl_options.ca_data)
+
+    # Load client certificate if provided (for mTLS)
+    # Note: load_cert_chain() only accepts file paths, not string data,
+    # so we must use temp files (unlike load_verify_locations which accepts cadata)
+    if ssl_options.cert_data and ssl_options.key_data:
+        cert_file = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)
+        cert_file.write(ssl_options.cert_data)
+        cert_file.close()
+
+        key_file = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)
+        key_file.write(ssl_options.key_data)
+        key_file.close()
+
+        try:
+            ssl_context.load_cert_chain(
+                certfile=cert_file.name,
+                keyfile=key_file.name,
+                password=ssl_options.key_password,
+            )
+        finally:
+            # Clean up temp files after loading into SSL context
+            os.unlink(cert_file.name)
+            os.unlink(key_file.name)
+
+    # Log SSL context creation with options
+    has_client_cert = bool(ssl_options.cert_data and ssl_options.key_data)
+    logger.info(
+        "Oracle SSL context created",
+        extra={
+            "ssl_options": {
+                "has_ca_data": bool(ssl_options.ca_data),
+                "has_client_cert": has_client_cert,
+                "skip_cert_verification": ssl_options.skip_cert_verification,
+                "verify_cert": ssl_options.verify_cert,
+                "verify_identity": ssl_options.verify_identity,
+                "check_hostname": ssl_context.check_hostname,
+                "verify_mode": ssl_context.verify_mode,
+            }
+        },
+    )
+
+    return ssl_context

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -228,6 +228,12 @@ def create_oracle_thick_wallet(ssl_options: SslOptions) -> Optional[str]:
     ``cert_data``/``key_data`` are present — imports the client identity for mTLS.
     Returns the wallet directory, or ``None`` when SSL is disabled / no CA data is
     provided. On failure the partially-built directory is removed.
+
+    Note: thick mode always validates the server certificate against the wallet
+    and has no equivalent of thin's ``skip_cert_verification``/``verify_cert`` — a
+    caller that sets those expecting to bypass or relax validation still gets full
+    CA-chain validation. Only ``verify_identity`` is honored (as
+    ``SSL_SERVER_DN_MATCH`` in ``sqlnet.ora``).
     """
     if ssl_options.disabled or not ssl_options.ca_data:
         return None
@@ -312,15 +318,20 @@ def _ensure_thick_config_dir() -> str:
 
 
 def _tls_fingerprint(ssl_options: SslOptions) -> Optional[str]:
-    """Fingerprint the TLS material — CA trust plus client identity.
+    """Fingerprint everything baked into the process-global thick-mode config.
 
     Thick-mode trust is process-global and frozen at the first connection, so the
-    fingerprint must cover not just ``ca_data`` but the mTLS client identity
-    (``cert_data``/``key_data``) too; otherwise a later
-    same-CA-but-different-client-cert connection would silently reuse the first
-    connection's wallet identity instead of being rejected. The key passphrase is
-    intentionally excluded — the cert/key already identify the client, and hashing
-    a password here would be misread as (weak) password storage.
+    fingerprint must cover every per-connection input that gets baked in: the CA
+    trust (``ca_data``), the mTLS client identity (``cert_data``/``key_data``),
+    and ``verify_identity`` — which is written once into ``sqlnet.ora`` as
+    ``SSL_SERVER_DN_MATCH``. Otherwise a later connection asking for a different
+    value (e.g. the secure default ``verify_identity=True`` after a first
+    connection used ``False``) would silently reuse the looser established config
+    instead of being rejected. ``skip_cert_verification``/``verify_cert`` are NOT
+    included — thick mode ignores them (it always validates the CA chain), so a
+    differing value has no effect on the established config. The key passphrase is
+    excluded too — the cert/key already identify the client, and hashing a
+    password here would be misread as (weak) password storage.
 
     This is a change-detection fingerprint, not password storage, so SHA-256 is
     the appropriate choice.
@@ -333,6 +344,7 @@ def _tls_fingerprint(ssl_options: SslOptions) -> Optional[str]:
             ssl_options.ca_data,
             ssl_options.cert_data,
             ssl_options.key_data,
+            f"verify_identity={ssl_options.verify_identity}",
         )
     )
     return hashlib.sha256(material.encode()).hexdigest()

--- a/apollo/integrations/db/oracle_client_config.py
+++ b/apollo/integrations/db/oracle_client_config.py
@@ -106,6 +106,18 @@ def thick_mode_enabled() -> bool:
     return os.getenv(_ENV_VAR_THICK_MODE, "false").strip().lower() == "true"
 
 
+def _reset_for_testing() -> None:
+    """Reset the process-wide thick-mode state so tests start fresh.
+
+    Test-only — production never resets this (thick init is process-global and
+    one-way). Gives tests a single seam instead of poking each private global.
+    """
+    global _thick_config_dir, _thick_wallet_dir, _thick_tls_fingerprint
+    _thick_config_dir = None
+    _thick_wallet_dir = None
+    _thick_tls_fingerprint = None
+
+
 def _oracle_pki_home() -> str:
     return os.getenv(_ENV_VAR_ORACLE_PKI_HOME) or _DEFAULT_ORACLE_PKI_HOME
 
@@ -119,6 +131,11 @@ def _run_orapki(*args: str) -> None:
     ``-pkcs12pwd``) are scrubbed from orapki's stdout/stderr before they reach the
     exception — which propagates to logs AND the agent's API error response, where
     no keyword/entropy redaction would catch a bare CLI-flag value.
+
+    Accepted risk: orapki only takes the wallet password as a CLI argument, so it
+    is briefly visible via ``/proc/<pid>/cmdline`` for the subprocess lifetime. In
+    the agent's single-tenant-per-container deployment this is not a meaningful
+    exposure; there is no stdin/password-file alternative for orapki.
     """
     home = _oracle_pki_home()
     java_bin = os.path.join(home, "jre", "bin", "java")

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import secrets
+import shutil
 import ssl
 import tempfile
 from typing import (
@@ -7,10 +9,17 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
 )
 
 import oracledb
 from oracledb.base_impl import DbType
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import (
+    BestAvailableEncryption,
+    load_pem_private_key,
+    pkcs12,
+)
 
 from apollo.common.agent.serde import AgentSerializer
 from apollo.agent.utils import AgentUtils
@@ -23,11 +32,101 @@ _ATTR_CONNECT_ARGS = "connect_args"
 # per-connection. Enable it only on an agent dedicated to thick-mode Oracle.
 _ENV_VAR_THICK_MODE = "MCD_ORACLE_THICK_MODE"
 
+# Optional override for the thick-mode TLS cipher suites (comma-separated Oracle
+# cipher names). The default below intentionally includes RSA key-exchange
+# suites: Oracle Client omits them from its defaults, but some servers (e.g. AWS
+# RDS Oracle, which offers AES256-GCM-SHA384 / SSL_RSA_WITH_AES_256_GCM_SHA384)
+# require them — the thin path handles this via `@SECLEVEL=1`, but thick has no
+# such knob and needs an explicit SSL_CIPHER_SUITES list. Modern ECDHE suites
+# are listed first so they are preferred where the server supports them.
+_ENV_VAR_SSL_CIPHER_SUITES = "MCD_ORACLE_SSL_CIPHER_SUITES"
+_DEFAULT_SSL_CIPHER_SUITES = ",".join(
+    [
+        "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+        "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "SSL_RSA_WITH_AES_256_GCM_SHA384",
+        "SSL_RSA_WITH_AES_256_CBC_SHA256",
+        "SSL_RSA_WITH_AES_128_GCM_SHA256",
+        "SSL_RSA_WITH_AES_128_CBC_SHA256",
+    ]
+)
+
 logger = logging.getLogger(__name__)
+
+# Process-wide config dir (with sqlnet.ora) passed to init_oracle_client; created
+# once, reused by every thick connection, lives for the process lifetime.
+_thick_config_dir: Optional[str] = None
 
 
 def _thick_mode_enabled() -> bool:
     return os.getenv(_ENV_VAR_THICK_MODE, "false").strip().lower() == "true"
+
+
+def _ensure_thick_config_dir() -> str:
+    """Create (once) a config dir containing a sqlnet.ora that sets
+    SSL_CIPHER_SUITES, and return its path for ``init_oracle_client(config_dir=)``.
+
+    Thick mode has no equivalent of thin's ``@SECLEVEL=1``, so the cipher suites
+    an older server requires (e.g. AWS RDS Oracle's RSA-kx suites) must be listed
+    explicitly here or the TLS handshake fails with ORA-28860.
+    """
+    global _thick_config_dir
+    if _thick_config_dir is not None:
+        return _thick_config_dir
+    suites = os.getenv(_ENV_VAR_SSL_CIPHER_SUITES) or _DEFAULT_SSL_CIPHER_SUITES
+    config_dir = tempfile.mkdtemp(prefix="mcd_oracle_tns_")
+    with open(os.path.join(config_dir, "sqlnet.ora"), "w") as sqlnet:
+        sqlnet.write(f"SSL_CIPHER_SUITES = ({suites})\n")
+    _thick_config_dir = config_dir
+    return config_dir
+
+
+def create_oracle_thick_wallet(ssl_options: SslOptions) -> Optional[Tuple[str, str]]:
+    """Build a PKCS#12 wallet (``ewallet.p12``) for thick-mode TLS from SslOptions.
+
+    Thick mode does not accept a Python ``ssl.SSLContext`` (thin-only); it reads a
+    wallet directory. python-oracledb accepts a password-protected ``ewallet.p12``
+    that ``cryptography`` can produce, so no Oracle ``orapki`` tooling is needed.
+
+    The wallet holds the CA cert(s) from ``ca_data`` as trust anchors, plus — when
+    ``cert_data``/``key_data`` are present — the client key+cert for mTLS.
+
+    Returns ``(wallet_dir, wallet_password)`` (caller passes these to
+    ``oracledb.connect`` and is responsible for removing ``wallet_dir``), or
+    ``None`` when SSL is disabled / no CA data is provided.
+    """
+    if ssl_options.disabled or not ssl_options.ca_data:
+        return None
+
+    ca_certs = x509.load_pem_x509_certificates(ssl_options.ca_data.encode())
+
+    client_key = None
+    client_cert = None
+    if ssl_options.cert_data and ssl_options.key_data:
+        client_cert = x509.load_pem_x509_certificate(ssl_options.cert_data.encode())
+        client_key = load_pem_private_key(
+            ssl_options.key_data.encode(),
+            password=(
+                ssl_options.key_password.encode() if ssl_options.key_password else None
+            ),
+        )
+
+    wallet_password = secrets.token_urlsafe(24)
+    p12 = pkcs12.serialize_key_and_certificates(
+        b"mcd-oracle",
+        # load_pem_private_key's union includes key types PKCS12 rejects (e.g. DH);
+        # a TLS client key is always RSA/EC, so this is safe.
+        client_key,  # type: ignore[arg-type]
+        client_cert,
+        ca_certs,
+        BestAvailableEncryption(wallet_password.encode()),
+    )
+    wallet_dir = tempfile.mkdtemp(prefix="mcd_oracle_wallet_")
+    with open(os.path.join(wallet_dir, "ewallet.p12"), "wb") as wallet_file:
+        wallet_file.write(p12)
+    return wallet_dir, wallet_password
 
 
 def create_oracle_ssl_context(ssl_options: SslOptions) -> ssl.SSLContext | None:
@@ -44,7 +143,8 @@ def create_oracle_ssl_context(ssl_options: SslOptions) -> ssl.SSLContext | None:
         Configured ssl.SSLContext for use with oracledb connections, or None if SSL is disabled
         or no CA data is provided.
 
-    Note: Only thin mode supports ssl_context - thick mode does not.
+    Note: this is the thin-mode path. ssl_context is thin-only; thick mode uses
+    create_oracle_thick_wallet() instead.
     """
     if ssl_options.disabled or not ssl_options.ca_data:
         return None
@@ -123,6 +223,9 @@ class OracleProxyClient(BaseDbProxyClient):
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         super().__init__(connection_type="oracle")
+        # Per-connection thick-mode TLS wallet dir; removed on close. Set before
+        # connect() so cleanup runs even if the connection attempt fails.
+        self._wallet_dir: Optional[str] = None
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Oracle DB agent client requires {_ATTR_CONNECT_ARGS} in credentials"
@@ -140,20 +243,26 @@ class OracleProxyClient(BaseDbProxyClient):
         # thick-mode Oracle agent.
         thick_mode = _thick_mode_enabled()
         if thick_mode and oracledb.is_thin_mode():
-            # Runs once per process, on the first Oracle connection. is_thin_mode()
+            # Runs once per process, on the first Oracle connection; config_dir
+            # carries a sqlnet.ora with SSL_CIPHER_SUITES for TLS. is_thin_mode()
             # flips to False after a successful init, so later connections skip it.
-            oracledb.init_oracle_client()
+            oracledb.init_oracle_client(config_dir=_ensure_thick_config_dir())
             logger.info("oracle: thick mode initialized")
 
-        # Thick mode does not support ssl_context (thin mode only). Fail loudly
-        # rather than silently connecting without the requested SSL.
+        # Configure SSL. Thin mode uses a Python ssl.SSLContext; thick mode does
+        # not support that, so it uses a PKCS#12 wallet directory instead.
         ssl_options = SslOptions(**(credentials.get("ssl_options") or {}))
         if thick_mode:
-            if not ssl_options.disabled and ssl_options.ca_data:
-                raise ValueError(
-                    "Oracle SSL via ssl_context is not supported in thick mode; "
-                    "disable thick mode or remove ssl_options"
+            wallet = create_oracle_thick_wallet(ssl_options)
+            if wallet:
+                self._wallet_dir, wallet_password = wallet
+                connect_args["wallet_location"] = self._wallet_dir
+                connect_args["wallet_password"] = wallet_password
+                connect_args["ssl_server_dn_match"] = (
+                    not ssl_options.skip_cert_verification
+                    and ssl_options.verify_identity
                 )
+                logger.info("oracle: thick TLS wallet configured")
         elif ssl_context := create_oracle_ssl_context(ssl_options):
             connect_args["ssl_context"] = ssl_context
             logger.info("Oracle SSL context created")
@@ -163,6 +272,13 @@ class OracleProxyClient(BaseDbProxyClient):
     @property
     def wrapped_client(self):
         return self._connection
+
+    def _close_client(self):
+        # Close the connection first (base), then remove the temp wallet dir.
+        super()._close_client()
+        if self._wallet_dir:
+            shutil.rmtree(self._wallet_dir, ignore_errors=True)
+            self._wallet_dir = None
 
     @classmethod
     def _process_description(cls, description: List) -> List:

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -44,10 +44,12 @@ class OracleProxyClient(BaseDbProxyClient):
 
         # ssl_options can arrive two ways: inside connect_args (the CTP maps it
         # there — it is NOT an oracledb.connect arg, so pop it out) or as a
-        # top-level sibling (direct construction / legacy pre-CTP path).
-        ssl_options_data = connect_args.pop("ssl_options", None) or credentials.get(
-            "ssl_options"
-        )
+        # top-level sibling (direct construction / legacy pre-CTP path). Use an
+        # explicit None check (not `or`) so an explicitly-empty connect_args
+        # ssl_options isn't silently overridden by the top-level sibling.
+        ssl_options_data = connect_args.pop("ssl_options", None)
+        if ssl_options_data is None:
+            ssl_options_data = credentials.get("ssl_options")
         ssl_options = SslOptions(**(ssl_options_data or {}))
 
         # SSL differs by driver mode: thin uses a Python ssl.SSLContext; thick

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -42,7 +42,13 @@ class OracleProxyClient(BaseDbProxyClient):
                 1  # enable keep-alive and send packets every minute
             )
 
-        ssl_options = SslOptions(**(credentials.get("ssl_options") or {}))
+        # ssl_options can arrive two ways: inside connect_args (the CTP maps it
+        # there — it is NOT an oracledb.connect arg, so pop it out) or as a
+        # top-level sibling (direct construction / legacy pre-CTP path).
+        ssl_options_data = connect_args.pop("ssl_options", None) or credentials.get(
+            "ssl_options"
+        )
+        ssl_options = SslOptions(**(ssl_options_data or {}))
 
         # SSL differs by driver mode: thin uses a Python ssl.SSLContext; thick
         # (Oracle Instant Client) validates against an Oracle wallet configured in

--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -1,217 +1,25 @@
 import logging
-import os
-import secrets
-import shutil
-import ssl
-import tempfile
 from typing import (
     Any,
     Dict,
     List,
     Optional,
-    Tuple,
 )
 
 import oracledb
 from oracledb.base_impl import DbType
-from cryptography import x509
-from cryptography.hazmat.primitives.serialization import (
-    BestAvailableEncryption,
-    load_pem_private_key,
-    pkcs12,
-)
 
 from apollo.common.agent.serde import AgentSerializer
-from apollo.agent.utils import AgentUtils
 from apollo.integrations.db.base_db_proxy_client import BaseDbProxyClient, SslOptions
+from apollo.integrations.db import oracle_client_config
+
+# create_oracle_ssl_context is used below (thin path) and also imported from here
+# by data-collector; keep it importable from this module.
+from apollo.integrations.db.oracle_client_config import create_oracle_ssl_context
 
 _ATTR_CONNECT_ARGS = "connect_args"
-# Agent-level thick-mode switch. Thick mode (Oracle Instant Client) is a
-# process-global, one-way setting that cannot coexist with thin connections in
-# the same process, so it is configured per-agent via this env var rather than
-# per-connection. Enable it only on an agent dedicated to thick-mode Oracle.
-_ENV_VAR_THICK_MODE = "MCD_ORACLE_THICK_MODE"
-
-# Optional override for the thick-mode TLS cipher suites (comma-separated Oracle
-# cipher names). The default below intentionally includes RSA key-exchange
-# suites: Oracle Client omits them from its defaults, but some servers (e.g. AWS
-# RDS Oracle, which offers AES256-GCM-SHA384 / SSL_RSA_WITH_AES_256_GCM_SHA384)
-# require them — the thin path handles this via `@SECLEVEL=1`, but thick has no
-# such knob and needs an explicit SSL_CIPHER_SUITES list. Modern ECDHE suites
-# are listed first so they are preferred where the server supports them.
-_ENV_VAR_SSL_CIPHER_SUITES = "MCD_ORACLE_SSL_CIPHER_SUITES"
-_DEFAULT_SSL_CIPHER_SUITES = ",".join(
-    [
-        "SSL_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-        "SSL_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-        "SSL_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-        "SSL_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-        "SSL_RSA_WITH_AES_256_GCM_SHA384",
-        "SSL_RSA_WITH_AES_256_CBC_SHA256",
-        "SSL_RSA_WITH_AES_128_GCM_SHA256",
-        "SSL_RSA_WITH_AES_128_CBC_SHA256",
-    ]
-)
 
 logger = logging.getLogger(__name__)
-
-# Process-wide config dir (with sqlnet.ora) passed to init_oracle_client; created
-# once, reused by every thick connection, lives for the process lifetime.
-_thick_config_dir: Optional[str] = None
-
-
-def _thick_mode_enabled() -> bool:
-    return os.getenv(_ENV_VAR_THICK_MODE, "false").strip().lower() == "true"
-
-
-def _ensure_thick_config_dir() -> str:
-    """Create (once) a config dir containing a sqlnet.ora that sets
-    SSL_CIPHER_SUITES, and return its path for ``init_oracle_client(config_dir=)``.
-
-    Thick mode has no equivalent of thin's ``@SECLEVEL=1``, so the cipher suites
-    an older server requires (e.g. AWS RDS Oracle's RSA-kx suites) must be listed
-    explicitly here or the TLS handshake fails with ORA-28860.
-    """
-    global _thick_config_dir
-    if _thick_config_dir is not None:
-        return _thick_config_dir
-    suites = os.getenv(_ENV_VAR_SSL_CIPHER_SUITES) or _DEFAULT_SSL_CIPHER_SUITES
-    config_dir = tempfile.mkdtemp(prefix="mcd_oracle_tns_")
-    with open(os.path.join(config_dir, "sqlnet.ora"), "w") as sqlnet:
-        sqlnet.write(f"SSL_CIPHER_SUITES = ({suites})\n")
-    _thick_config_dir = config_dir
-    return config_dir
-
-
-def create_oracle_thick_wallet(ssl_options: SslOptions) -> Optional[Tuple[str, str]]:
-    """Build a PKCS#12 wallet (``ewallet.p12``) for thick-mode TLS from SslOptions.
-
-    Thick mode does not accept a Python ``ssl.SSLContext`` (thin-only); it reads a
-    wallet directory. python-oracledb accepts a password-protected ``ewallet.p12``
-    that ``cryptography`` can produce, so no Oracle ``orapki`` tooling is needed.
-
-    The wallet holds the CA cert(s) from ``ca_data`` as trust anchors, plus — when
-    ``cert_data``/``key_data`` are present — the client key+cert for mTLS.
-
-    Returns ``(wallet_dir, wallet_password)`` (caller passes these to
-    ``oracledb.connect`` and is responsible for removing ``wallet_dir``), or
-    ``None`` when SSL is disabled / no CA data is provided.
-    """
-    if ssl_options.disabled or not ssl_options.ca_data:
-        return None
-
-    ca_certs = x509.load_pem_x509_certificates(ssl_options.ca_data.encode())
-
-    client_key = None
-    client_cert = None
-    if ssl_options.cert_data and ssl_options.key_data:
-        client_cert = x509.load_pem_x509_certificate(ssl_options.cert_data.encode())
-        client_key = load_pem_private_key(
-            ssl_options.key_data.encode(),
-            password=(
-                ssl_options.key_password.encode() if ssl_options.key_password else None
-            ),
-        )
-
-    wallet_password = secrets.token_urlsafe(24)
-    p12 = pkcs12.serialize_key_and_certificates(
-        b"mcd-oracle",
-        # load_pem_private_key's union includes key types PKCS12 rejects (e.g. DH);
-        # a TLS client key is always RSA/EC, so this is safe.
-        client_key,  # type: ignore[arg-type]
-        client_cert,
-        ca_certs,
-        BestAvailableEncryption(wallet_password.encode()),
-    )
-    wallet_dir = tempfile.mkdtemp(prefix="mcd_oracle_wallet_")
-    with open(os.path.join(wallet_dir, "ewallet.p12"), "wb") as wallet_file:
-        wallet_file.write(p12)
-    return wallet_dir, wallet_password
-
-
-def create_oracle_ssl_context(ssl_options: SslOptions) -> ssl.SSLContext | None:
-    """
-    Create an SSL context for Oracle connections.
-
-    Creates an SSLContext with relaxed cipher requirements to support older cipher suites
-    used by some databases (e.g., AWS RDS Oracle uses AES256-GCM-SHA384).
-
-    Args:
-        ssl_options: SslOptions object containing CA data and optionally client cert/key
-
-    Returns:
-        Configured ssl.SSLContext for use with oracledb connections, or None if SSL is disabled
-        or no CA data is provided.
-
-    Note: this is the thin-mode path. ssl_context is thin-only; thick mode uses
-    create_oracle_thick_wallet() instead.
-    """
-    if ssl_options.disabled or not ssl_options.ca_data:
-        return None
-
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-
-    # Respect SslOptions verification settings
-    # - skip_cert_verification: skips ALL validation (cert + hostname)
-    # - verify_cert: whether to validate the certificate chain
-    # - verify_identity: whether to check hostname matches certificate
-    ssl_context.check_hostname = (
-        not ssl_options.skip_cert_verification and ssl_options.verify_identity
-    )
-    ssl_context.verify_mode = (
-        ssl.CERT_NONE
-        if ssl_options.skip_cert_verification
-        else (ssl.CERT_REQUIRED if ssl_options.verify_cert else ssl.CERT_NONE)
-    )
-
-    # @SECLEVEL=1 allows older ciphers like AES256-GCM-SHA384 (plain RSA, no forward secrecy)
-    ssl_context.set_ciphers("DEFAULT:@SECLEVEL=1")
-
-    # Load CA certificate for server verification (if not skipping verification)
-    if ssl_options.ca_data and not ssl_options.skip_cert_verification:
-        ssl_context.load_verify_locations(cadata=ssl_options.ca_data)
-
-    # Load client certificate if provided (for mTLS)
-    # Note: load_cert_chain() only accepts file paths, not string data,
-    # so we must use temp files (unlike load_verify_locations which accepts cadata)
-    if ssl_options.cert_data and ssl_options.key_data:
-        cert_file = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)
-        cert_file.write(ssl_options.cert_data)
-        cert_file.close()
-
-        key_file = tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False)
-        key_file.write(ssl_options.key_data)
-        key_file.close()
-
-        try:
-            ssl_context.load_cert_chain(
-                certfile=cert_file.name,
-                keyfile=key_file.name,
-                password=ssl_options.key_password,
-            )
-        finally:
-            # Clean up temp files after loading into SSL context
-            os.unlink(cert_file.name)
-            os.unlink(key_file.name)
-
-    # Log SSL context creation with options
-    has_client_cert = bool(ssl_options.cert_data and ssl_options.key_data)
-    logger.info(
-        "Oracle SSL context created",
-        extra={
-            "ssl_options": {
-                "has_ca_data": bool(ssl_options.ca_data),
-                "has_client_cert": has_client_cert,
-                "skip_cert_verification": ssl_options.skip_cert_verification,
-                "verify_cert": ssl_options.verify_cert,
-                "verify_identity": ssl_options.verify_identity,
-                "check_hostname": ssl_context.check_hostname,
-                "verify_mode": ssl_context.verify_mode,
-            }
-        },
-    )
-
-    return ssl_context
 
 
 class OracleProxyClient(BaseDbProxyClient):
@@ -223,9 +31,6 @@ class OracleProxyClient(BaseDbProxyClient):
 
     def __init__(self, credentials: Optional[Dict], **kwargs: Any):
         super().__init__(connection_type="oracle")
-        # Per-connection thick-mode TLS wallet dir; removed on close. Set before
-        # connect() so cleanup runs even if the connection attempt fails.
-        self._wallet_dir: Optional[str] = None
         if not credentials or _ATTR_CONNECT_ARGS not in credentials:
             raise ValueError(
                 f"Oracle DB agent client requires {_ATTR_CONNECT_ARGS} in credentials"
@@ -237,48 +42,22 @@ class OracleProxyClient(BaseDbProxyClient):
                 1  # enable keep-alive and send packets every minute
             )
 
-        # Thick mode (Oracle Instant Client) is process-global and one-way: once a
-        # thin connection exists it can't be enabled (DPY-2019). So it's an
-        # agent-level env var, not per-connection — enable it only on a dedicated
-        # thick-mode Oracle agent.
-        thick_mode = _thick_mode_enabled()
-        if thick_mode and oracledb.is_thin_mode():
-            # Runs once per process, on the first Oracle connection; config_dir
-            # carries a sqlnet.ora with SSL_CIPHER_SUITES for TLS. is_thin_mode()
-            # flips to False after a successful init, so later connections skip it.
-            oracledb.init_oracle_client(config_dir=_ensure_thick_config_dir())
-            logger.info("oracle: thick mode initialized")
-
-        # Configure SSL. Thin mode uses a Python ssl.SSLContext; thick mode does
-        # not support that, so it uses a PKCS#12 wallet directory instead.
         ssl_options = SslOptions(**(credentials.get("ssl_options") or {}))
-        if thick_mode:
-            wallet = create_oracle_thick_wallet(ssl_options)
-            if wallet:
-                self._wallet_dir, wallet_password = wallet
-                connect_args["wallet_location"] = self._wallet_dir
-                connect_args["wallet_password"] = wallet_password
-                connect_args["ssl_server_dn_match"] = (
-                    not ssl_options.skip_cert_verification
-                    and ssl_options.verify_identity
-                )
-                logger.info("oracle: thick TLS wallet configured")
+
+        # SSL differs by driver mode: thin uses a Python ssl.SSLContext; thick
+        # (Oracle Instant Client) validates against an Oracle wallet configured in
+        # sqlnet.ora. Thick mode is process-global and one-way, enabled per-agent
+        # via MCD_ORACLE_THICK_MODE (see oracle_client_config). Both paths are handled there.
+        if oracle_client_config.thick_mode_enabled():
+            oracle_client_config.configure_thick_connection(ssl_options)
         elif ssl_context := create_oracle_ssl_context(ssl_options):
             connect_args["ssl_context"] = ssl_context
-            logger.info("Oracle SSL context created")
 
         self._connection = oracledb.connect(**connect_args)  # type: ignore
 
     @property
     def wrapped_client(self):
         return self._connection
-
-    def _close_client(self):
-        # Close the connection first (base), then remove the temp wallet dir.
-        super()._close_client()
-        if self._wallet_dir:
-            shutil.rmtree(self._wallet_dir, ignore_errors=True)
-            self._wallet_dir = None
 
     @classmethod
     def _process_description(cls, description: List) -> List:

--- a/tests/ctp/test_oracle_ctp.py
+++ b/tests/ctp/test_oracle_ctp.py
@@ -34,3 +34,52 @@ class TestOracleCtp(TestCase):
             },
         )
         self.assertEqual(5, result["expire_time"])
+
+    def test_ssl_options_carried_through_as_native_dict(self):
+        """ssl_options must survive the pipeline as a dict (NativeEnvironment),
+        not be stringified — OracleProxyClient reads ca_data/verify_identity etc.
+        from it to build the wallet / ssl_context."""
+        ssl_options = {
+            "ca_data": "-----BEGIN CERTIFICATE-----X",
+            "verify_identity": False,
+        }
+        result = CtpPipeline().execute(
+            ORACLE_DEFAULT_CTP,
+            {
+                "dsn": "db.example.com:2484/ORCL",
+                "user": "admin",
+                "password": "secret",
+                "ssl_options": ssl_options,
+            },
+        )
+        self.assertEqual(ssl_options, result["ssl_options"])
+
+    def test_resolve_keeps_ssl_options_in_connect_args(self):
+        """End to end via resolve(): the DC sends ssl_options as a sibling of
+        connect_args; it must land inside the resolved connect_args (SUP-style
+        merge + passthrough) so the agent's OracleProxyClient receives it."""
+        resolved = CtpRegistry.resolve(
+            "oracle",
+            {
+                "connect_args": {
+                    "dsn": "tcps://db.example.com:2484/ORCL",
+                    "user": "admin",
+                    "password": "secret",
+                },
+                "ssl_options": {"ca_data": "CA", "verify_identity": False},
+            },
+            temp_files=[],
+        )
+        self.assertEqual(
+            {"ca_data": "CA", "verify_identity": False},
+            resolved["connect_args"]["ssl_options"],
+        )
+
+    def test_no_ssl_options_absent_from_output(self):
+        # With no ssl_options the mapper drops the (None) key, so connect_args has
+        # no ssl_options — OracleProxyClient's pop(..., None) then falls back cleanly.
+        result = CtpPipeline().execute(
+            ORACLE_DEFAULT_CTP,
+            {"dsn": "db.example.com:1521/ORCL", "user": "admin", "password": "secret"},
+        )
+        self.assertIsNone(result.get("ssl_options"))

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -580,6 +580,36 @@ class OracleThickModeTests(TestCase):
     @patch("oracledb.connect")
     @patch("oracledb.init_oracle_client")
     @patch("oracledb.is_thin_mode", return_value=False)
+    def test_thick_tls_raises_when_verify_identity_differs_same_ca(
+        self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
+    ) -> None:
+        """verify_identity is frozen process-wide as SSL_SERVER_DN_MATCH. A later
+        connection with the SAME CA but a stricter verify_identity must fail loud,
+        not silently reuse the looser established config."""
+        mock_connect.return_value = self._mock_connection
+        oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
+        # Established with verify_identity=False (SSL_SERVER_DN_MATCH=FALSE).
+        oracle_client_config._thick_tls_fingerprint = (
+            oracle_client_config._tls_fingerprint(
+                SslOptions(ca_data="CA", verify_identity=False)
+            )
+        )
+
+        # Same CA, but now the secure default verify_identity=True — must reject.
+        with self.assertRaises(RuntimeError) as ctx:
+            OracleProxyClient(
+                {
+                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                    "ssl_options": {"ca_data": "CA", "verify_identity": True},
+                }
+            )
+        self.assertIn("different SSL configuration", str(ctx.exception))
+        mock_connect.assert_not_called()
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.init_oracle_client")
+    @patch("oracledb.is_thin_mode", return_value=False)
     def test_thick_tls_raises_when_process_inited_without_tls(
         self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
     ) -> None:

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import ssl
+import tempfile
 from typing import (
     Iterable,
     List,
@@ -376,7 +377,7 @@ class OracleThickModeTests(TestCase):
         # Reset the process-wide thick-mode state so each test starts fresh.
         oracle_client_config._thick_config_dir = None
         oracle_client_config._thick_wallet_dir = None
-        oracle_client_config._thick_ca_fingerprint = None
+        oracle_client_config._thick_tls_fingerprint = None
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
     @patch("oracledb.connect")
@@ -506,7 +507,7 @@ class OracleThickModeTests(TestCase):
         with a different CA can't be applied — fail loudly, not silent ORA-29024."""
         mock_connect.return_value = self._mock_connection
         oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
-        oracle_client_config._thick_ca_fingerprint = "established-fingerprint"
+        oracle_client_config._thick_tls_fingerprint = "established-fingerprint"
 
         with self.assertRaises(RuntimeError) as ctx:
             OracleProxyClient(
@@ -515,9 +516,43 @@ class OracleThickModeTests(TestCase):
                     "ssl_options": {"ca_data": "a-different-ca"},
                 }
             )
-        self.assertIn("different SSL CA", str(ctx.exception))
+        self.assertIn("different SSL configuration", str(ctx.exception))
         mock_init.assert_not_called()  # already initialized
         mock_connect.assert_not_called()  # never connects with unappliable trust
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.init_oracle_client")
+    @patch("oracledb.is_thin_mode", return_value=False)
+    def test_thick_tls_raises_when_client_cert_differs_same_ca(
+        self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
+    ) -> None:
+        """mTLS: a later connection with the SAME CA but a DIFFERENT client cert
+        must fail loud — the fingerprint covers client identity, not just the CA."""
+        mock_connect.return_value = self._mock_connection
+        oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
+        # Establish the fingerprint from CA + client identity A.
+        oracle_client_config._thick_tls_fingerprint = (
+            oracle_client_config._tls_fingerprint(
+                SslOptions(ca_data="CA", cert_data="CLIENT_CERT_A", key_data="KEY_A")
+            )
+        )
+
+        # Same CA, different client identity B — must be rejected (would pass a
+        # CA-only fingerprint check).
+        with self.assertRaises(RuntimeError) as ctx:
+            OracleProxyClient(
+                {
+                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                    "ssl_options": {
+                        "ca_data": "CA",
+                        "cert_data": "CLIENT_CERT_B",
+                        "key_data": "KEY_B",
+                    },
+                }
+            )
+        self.assertIn("different SSL configuration", str(ctx.exception))
+        mock_connect.assert_not_called()
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
     @patch("oracledb.connect")
@@ -856,3 +891,110 @@ class CreateOracleThickWalletTests(TestCase):
         # the partially-built wallet dir is cleaned up rather than left behind
         self.assertTrue(captured.get("dir"))
         self.assertFalse(os.path.exists(captured["dir"]))
+
+
+class OracleClientConfigInternalsTests(TestCase):
+    """Direct tests for the string/subprocess helpers that are mocked away
+    elsewhere (_run_orapki, _write_thick_sqlnet) and the init-failure cleanup."""
+
+    def setUp(self) -> None:
+        oracle_client_config._thick_config_dir = None
+        oracle_client_config._thick_wallet_dir = None
+        oracle_client_config._thick_tls_fingerprint = None
+
+    @patch("apollo.integrations.db.oracle_client_config.subprocess.run")
+    def test_run_orapki_builds_command_and_redacts_password_on_failure(
+        self, mock_run: Mock
+    ) -> None:
+        mock_run.return_value = Mock(
+            returncode=1,
+            stdout="Invalid argument near -pwd SECRETPW123",
+            stderr="",
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            oracle_client_config._run_orapki(
+                "wallet", "create", "-wallet", "/tmp/w", "-pwd", "SECRETPW123"
+            )
+        # command assembled correctly: bundled java, classpath, orapki class, args
+        argv = mock_run.call_args.args[0]
+        self.assertTrue(argv[0].endswith("/jre/bin/java"))
+        self.assertIn("-cp", argv)
+        self.assertIn(oracle_client_config._ORAPKI_MAIN_CLASS, argv)
+        self.assertEqual(
+            argv[-6:], ["wallet", "create", "-wallet", "/tmp/w", "-pwd", "SECRETPW123"]
+        )
+        # the password never reaches the raised exception (which propagates to
+        # logs + the agent API response); it is scrubbed to __redacted__
+        message = str(ctx.exception)
+        self.assertNotIn("SECRETPW123", message)
+        self.assertIn("__redacted__", message)
+
+    @patch("apollo.integrations.db.oracle_client_config.subprocess.run")
+    def test_run_orapki_success_does_not_raise(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(returncode=0, stdout="ok", stderr="")
+        oracle_client_config._run_orapki("wallet", "display", "-wallet", "/tmp/w")
+
+    def test_write_thick_sqlnet_with_wallet(self) -> None:
+        config_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        oracle_client_config._write_thick_sqlnet(
+            config_dir, wallet_dir="/tmp/wallet", verify_identity=False
+        )
+        content = open(os.path.join(config_dir, "sqlnet.ora")).read()
+        self.assertIn("SSL_CIPHER_SUITES = (", content)
+        self.assertIn(
+            "WALLET_LOCATION = (SOURCE = (METHOD = FILE) "
+            "(METHOD_DATA = (DIRECTORY = /tmp/wallet)))",
+            content,
+        )
+        self.assertIn("SSL_SERVER_DN_MATCH = FALSE", content)
+
+    def test_write_thick_sqlnet_verify_identity_true(self) -> None:
+        config_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        oracle_client_config._write_thick_sqlnet(
+            config_dir, wallet_dir="/tmp/wallet", verify_identity=True
+        )
+        content = open(os.path.join(config_dir, "sqlnet.ora")).read()
+        self.assertIn("SSL_SERVER_DN_MATCH = TRUE", content)
+
+    def test_write_thick_sqlnet_no_wallet_omits_wallet_lines(self) -> None:
+        config_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        oracle_client_config._write_thick_sqlnet(config_dir, wallet_dir=None)
+        content = open(os.path.join(config_dir, "sqlnet.ora")).read()
+        self.assertIn("SSL_CIPHER_SUITES = (", content)
+        self.assertNotIn("WALLET_LOCATION", content)
+        self.assertNotIn("SSL_SERVER_DN_MATCH", content)
+
+    @patch.dict("os.environ", {"MCD_ORACLE_SSL_CIPHER_SUITES": "CUSTOM_A,CUSTOM_B"})
+    def test_write_thick_sqlnet_cipher_env_override(self) -> None:
+        config_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        oracle_client_config._write_thick_sqlnet(config_dir)
+        content = open(os.path.join(config_dir, "sqlnet.ora")).read()
+        self.assertIn("SSL_CIPHER_SUITES = (CUSTOM_A,CUSTOM_B)", content)
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.is_thin_mode", return_value=True)
+    @patch("oracledb.init_oracle_client", side_effect=RuntimeError("init boom"))
+    @patch("apollo.integrations.db.oracle_client_config._write_thick_sqlnet")
+    @patch("apollo.integrations.db.oracle_client_config.create_oracle_thick_wallet")
+    def test_configure_cleans_wallet_when_init_fails(
+        self,
+        mock_wallet: Mock,
+        _mock_write: Mock,
+        _mock_init: Mock,
+        _mock_thin: Mock,
+    ) -> None:
+        """If init_oracle_client fails after the wallet is built, the wallet dir is
+        removed and the process state stays unset so a retry starts clean."""
+        wallet_dir = tempfile.mkdtemp()
+        mock_wallet.return_value = wallet_dir
+
+        with self.assertRaises(RuntimeError):
+            oracle_client_config.configure_thick_connection(SslOptions(ca_data="CA"))
+
+        self.assertFalse(os.path.exists(wallet_dir))  # cleaned up, not orphaned
+        self.assertIsNone(oracle_client_config._thick_wallet_dir)
+        self.assertIsNone(oracle_client_config._thick_tls_fingerprint)

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 import logging
+import os
+import shutil
 import ssl
 from typing import (
     Iterable,
@@ -27,6 +29,7 @@ from apollo.agent.logging_utils import LoggingUtils
 from apollo.integrations.db.oracle_proxy_client import (
     OracleProxyClient,
     create_oracle_ssl_context,
+    create_oracle_thick_wallet,
 )
 from apollo.integrations.db.base_db_proxy_client import SslOptions
 
@@ -357,7 +360,9 @@ class OracleThickModeTests(TestCase):
 
         client = OracleProxyClient({"connect_args": dict(_ORACLE_DB_CREDENTIALS)})
 
-        mock_init.assert_called_once_with()
+        mock_init.assert_called_once()
+        # config_dir carries the sqlnet.ora with SSL_CIPHER_SUITES for TLS.
+        self.assertIn("config_dir", mock_init.call_args.kwargs)
         self.assertEqual(client.wrapped_client, self._mock_connection)
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
@@ -391,23 +396,35 @@ class OracleThickModeTests(TestCase):
     @patch("oracledb.connect")
     @patch("oracledb.init_oracle_client")
     @patch("oracledb.is_thin_mode", return_value=True)
-    def test_thick_mode_with_ssl_raises(
-        self, _mock_thin: Mock, _mock_init: Mock, mock_connect: Mock
+    @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_thick_wallet")
+    def test_thick_mode_with_ssl_builds_wallet(
+        self,
+        mock_wallet: Mock,
+        _mock_thin: Mock,
+        _mock_init: Mock,
+        mock_connect: Mock,
     ) -> None:
-        """Thick mode + ssl_options is unsupported (thin-only) — fail rather than
-        silently connect without the requested SSL."""
-        with self.assertRaises(ValueError):
-            OracleProxyClient(
-                {
-                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
-                    "ssl_options": {
-                        "ca_data": "-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----",
-                        "disabled": False,
-                    },
-                }
-            )
+        """Thick mode + ssl_options builds a wallet and passes wallet params to
+        connect() (not ssl_context, which is thin-only)."""
+        mock_connect.return_value = self._mock_connection
+        mock_wallet.return_value = ("/tmp/mcd_oracle_wallet_test", "walletpw")
 
-        mock_connect.assert_not_called()
+        OracleProxyClient(
+            {
+                "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                "ssl_options": {
+                    "ca_data": "-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----",
+                    "disabled": False,
+                },
+            }
+        )
+
+        mock_wallet.assert_called_once()
+        kwargs = mock_connect.call_args[1]
+        self.assertEqual(kwargs["wallet_location"], "/tmp/mcd_oracle_wallet_test")
+        self.assertEqual(kwargs["wallet_password"], "walletpw")
+        self.assertTrue(kwargs["ssl_server_dn_match"])  # verify_identity default True
+        self.assertNotIn("ssl_context", kwargs)  # ssl_context is thin-only
 
 
 class CreateOracleSslContextTests(TestCase):
@@ -624,3 +641,83 @@ class OracleCtpCredentialSafetyTests(TestCase):
         for record in self._log_records:
             output = formatter.format(record)
             self.assertNotIn(self._PASSWORD, output)
+
+
+class CreateOracleThickWalletTests(TestCase):
+    """Tests for create_oracle_thick_wallet (builds a PKCS#12 wallet from PEM)."""
+
+    @staticmethod
+    def _self_signed(cn: str):
+        from cryptography import x509
+        from cryptography.x509.oid import NameOID
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(name)
+            .issuer_name(name)
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.datetime(2020, 1, 1))
+            .not_valid_after(datetime.datetime(2035, 1, 1))
+            .sign(key, hashes.SHA256())
+        )
+        return key, cert
+
+    @classmethod
+    def _pem_cert(cls, cert) -> str:
+        from cryptography.hazmat.primitives import serialization
+
+        return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    @classmethod
+    def _pem_key(cls, key) -> str:
+        from cryptography.hazmat.primitives import serialization
+
+        return key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+    def _load_p12(self, wallet_dir: str, password: str):
+        from cryptography.hazmat.primitives.serialization import pkcs12
+
+        with open(os.path.join(wallet_dir, "ewallet.p12"), "rb") as f:
+            return pkcs12.load_key_and_certificates(f.read(), password.encode())
+
+    def test_returns_none_when_disabled_or_no_ca(self):
+        self.assertIsNone(create_oracle_thick_wallet(SslOptions(disabled=True)))
+        self.assertIsNone(create_oracle_thick_wallet(SslOptions(ca_data=None)))
+
+    def test_one_way_wallet_contains_ca_no_client_key(self):
+        _, ca = self._self_signed("Test CA")
+        result = create_oracle_thick_wallet(SslOptions(ca_data=self._pem_cert(ca)))
+        self.assertIsNotNone(result)
+        wallet_dir, password = result
+        self.addCleanup(shutil.rmtree, wallet_dir, ignore_errors=True)
+        key, cert, cas = self._load_p12(wallet_dir, password)
+        self.assertIsNone(key)  # no client identity for one-way TLS
+        self.assertIsNone(cert)
+        self.assertEqual(len(cas), 1)  # the CA is a trust anchor
+
+    def test_mtls_wallet_contains_client_key_and_cert(self):
+        _, ca = self._self_signed("Test CA")
+        cli_key, cli_cert = self._self_signed("client")
+        result = create_oracle_thick_wallet(
+            SslOptions(
+                ca_data=self._pem_cert(ca),
+                cert_data=self._pem_cert(cli_cert),
+                key_data=self._pem_key(cli_key),
+            )
+        )
+        self.assertIsNotNone(result)
+        wallet_dir, password = result
+        self.addCleanup(shutil.rmtree, wallet_dir, ignore_errors=True)
+        key, cert, cas = self._load_p12(wallet_dir, password)
+        self.assertIsNotNone(key)  # client key present (mTLS identity)
+        self.assertIsNotNone(cert)
+        self.assertEqual(len(cas), 1)

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -26,11 +26,12 @@ from apollo.common.agent.constants import (
     ATTRIBUTE_NAME_ERROR_TYPE,
 )
 from apollo.agent.logging_utils import LoggingUtils
-from apollo.integrations.db.oracle_proxy_client import (
-    OracleProxyClient,
+from apollo.integrations.db import oracle_client_config
+from apollo.integrations.db.oracle_client_config import (
     create_oracle_ssl_context,
     create_oracle_thick_wallet,
 )
+from apollo.integrations.db.oracle_proxy_client import OracleProxyClient
 from apollo.integrations.db.base_db_proxy_client import SslOptions
 
 _ORACLE_DB_CREDENTIALS = {
@@ -348,6 +349,10 @@ class OracleThickModeTests(TestCase):
 
     def setUp(self) -> None:
         self._mock_connection = Mock()
+        # Reset the process-wide thick-mode state so each test starts fresh.
+        oracle_client_config._thick_config_dir = None
+        oracle_client_config._thick_wallet_dir = None
+        oracle_client_config._thick_ca_fingerprint = None
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
     @patch("oracledb.connect")
@@ -396,18 +401,22 @@ class OracleThickModeTests(TestCase):
     @patch("oracledb.connect")
     @patch("oracledb.init_oracle_client")
     @patch("oracledb.is_thin_mode", return_value=True)
-    @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_thick_wallet")
+    @patch("apollo.integrations.db.oracle_client_config._write_thick_sqlnet")
+    @patch("apollo.integrations.db.oracle_client_config.create_oracle_thick_wallet")
     def test_thick_mode_with_ssl_builds_wallet(
         self,
         mock_wallet: Mock,
+        mock_write_sqlnet: Mock,
         _mock_thin: Mock,
-        _mock_init: Mock,
+        mock_init: Mock,
         mock_connect: Mock,
     ) -> None:
-        """Thick mode + ssl_options builds a wallet and passes wallet params to
-        connect() (not ssl_context, which is thin-only)."""
+        """Thick mode + ssl_options builds the wallet and wires it via sqlnet.ora
+        WALLET_LOCATION before init_oracle_client — not the connect()
+        wallet_location param (thick ignores it for trust) and not ssl_context
+        (thin-only)."""
         mock_connect.return_value = self._mock_connection
-        mock_wallet.return_value = ("/tmp/mcd_oracle_wallet_test", "walletpw")
+        mock_wallet.return_value = "/tmp/mcd_oracle_wallet_test"
 
         OracleProxyClient(
             {
@@ -420,11 +429,72 @@ class OracleThickModeTests(TestCase):
         )
 
         mock_wallet.assert_called_once()
+        # Wallet wired through sqlnet.ora WALLET_LOCATION (positional args:
+        # config_dir, wallet_dir, verify_identity), written BEFORE init.
+        mock_write_sqlnet.assert_called_once()
+        args = mock_write_sqlnet.call_args.args
+        self.assertEqual(args[1], "/tmp/mcd_oracle_wallet_test")
+        self.assertTrue(args[2])  # verify_identity default True
+        mock_init.assert_called_once()
+        # Trust comes from sqlnet.ora, so connect gets no wallet/ssl params.
         kwargs = mock_connect.call_args[1]
-        self.assertEqual(kwargs["wallet_location"], "/tmp/mcd_oracle_wallet_test")
-        self.assertEqual(kwargs["wallet_password"], "walletpw")
-        self.assertTrue(kwargs["ssl_server_dn_match"])  # verify_identity default True
+        self.assertNotIn("wallet_location", kwargs)
+        self.assertNotIn("wallet_password", kwargs)
         self.assertNotIn("ssl_context", kwargs)  # ssl_context is thin-only
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.is_thin_mode", return_value=True)
+    @patch(
+        "apollo.integrations.db.oracle_client_config.create_oracle_thick_wallet",
+        return_value="/tmp/mcd_oracle_wallet_test",
+    )
+    def test_thick_tls_wallet_written_before_init(
+        self, _mock_wallet: Mock, _mock_thin: Mock, mock_connect: Mock
+    ) -> None:
+        """The wallet + WALLET_LOCATION must be in sqlnet.ora BEFORE
+        init_oracle_client, or Oracle's wallet subsystem starts without trust."""
+        mock_connect.return_value = self._mock_connection
+        order: List[str] = []
+        with patch(
+            "apollo.integrations.db.oracle_client_config._write_thick_sqlnet",
+            side_effect=lambda *a, **k: order.append("sqlnet"),
+        ), patch(
+            "oracledb.init_oracle_client",
+            side_effect=lambda *a, **k: order.append("init"),
+        ):
+            OracleProxyClient(
+                {
+                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                    "ssl_options": {"ca_data": "ca"},
+                }
+            )
+        self.assertEqual(order, ["sqlnet", "init"])
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.init_oracle_client")
+    @patch("oracledb.is_thin_mode", return_value=False)
+    def test_thick_tls_warns_when_later_ca_differs(
+        self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
+    ) -> None:
+        """Thick trust is frozen after the first connection; a later connection
+        with a different CA is warned about rather than silently ignored."""
+        mock_connect.return_value = self._mock_connection
+        oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
+        oracle_client_config._thick_ca_fingerprint = "established-fingerprint"
+
+        with self.assertLogs(
+            "apollo.integrations.db.oracle_client_config", level="WARNING"
+        ) as logs:
+            OracleProxyClient(
+                {
+                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                    "ssl_options": {"ca_data": "a-different-ca"},
+                }
+            )
+        mock_init.assert_not_called()  # already initialized
+        self.assertTrue(any("differing CA" in line for line in logs.output))
 
 
 class CreateOracleSslContextTests(TestCase):
@@ -644,7 +714,9 @@ class OracleCtpCredentialSafetyTests(TestCase):
 
 
 class CreateOracleThickWalletTests(TestCase):
-    """Tests for create_oracle_thick_wallet (builds a PKCS#12 wallet from PEM)."""
+    """create_oracle_thick_wallet builds a cwallet.sso via orapki. orapki needs the
+    bundled JRE, so it is mocked here (asserting the orapki commands issued); the
+    real wallet build + TLS handshake is covered by the E2E rig against RDS."""
 
     @staticmethod
     def _self_signed(cn: str):
@@ -683,41 +755,59 @@ class CreateOracleThickWalletTests(TestCase):
             serialization.NoEncryption(),
         ).decode()
 
-    def _load_p12(self, wallet_dir: str, password: str):
-        from cryptography.hazmat.primitives.serialization import pkcs12
-
-        with open(os.path.join(wallet_dir, "ewallet.p12"), "rb") as f:
-            return pkcs12.load_key_and_certificates(f.read(), password.encode())
-
-    def test_returns_none_when_disabled_or_no_ca(self):
+    @patch("apollo.integrations.db.oracle_client_config._run_orapki")
+    def test_returns_none_when_disabled_or_no_ca(self, mock_orapki: Mock):
         self.assertIsNone(create_oracle_thick_wallet(SslOptions(disabled=True)))
         self.assertIsNone(create_oracle_thick_wallet(SslOptions(ca_data=None)))
+        mock_orapki.assert_not_called()
 
-    def test_one_way_wallet_contains_ca_no_client_key(self):
+    @patch("apollo.integrations.db.oracle_client_config._run_orapki")
+    def test_one_way_builds_auto_login_wallet_with_trusted_ca(self, mock_orapki: Mock):
         _, ca = self._self_signed("Test CA")
-        result = create_oracle_thick_wallet(SslOptions(ca_data=self._pem_cert(ca)))
-        self.assertIsNotNone(result)
-        wallet_dir, password = result
+        wallet_dir = create_oracle_thick_wallet(SslOptions(ca_data=self._pem_cert(ca)))
+        self.assertIsNotNone(wallet_dir)
         self.addCleanup(shutil.rmtree, wallet_dir, ignore_errors=True)
-        key, cert, cas = self._load_p12(wallet_dir, password)
-        self.assertIsNone(key)  # no client identity for one-way TLS
-        self.assertIsNone(cert)
-        self.assertEqual(len(cas), 1)  # the CA is a trust anchor
+        cmds = [c.args for c in mock_orapki.call_args_list]
+        # wallet created as auto-login (produces cwallet.sso, the only form thick trusts)
+        self.assertTrue(
+            any(a[:2] == ("wallet", "create") and "-auto_login" in a for a in cmds)
+        )
+        # CA added as a trusted certificate
+        self.assertTrue(
+            any(a[:2] == ("wallet", "add") and "-trusted_cert" in a for a in cmds)
+        )
+        # no client identity import for one-way TLS
+        self.assertFalse(any("import_pkcs12" in a for a in cmds))
 
-    def test_mtls_wallet_contains_client_key_and_cert(self):
+    @patch("apollo.integrations.db.oracle_client_config._run_orapki")
+    def test_mtls_imports_client_identity(self, mock_orapki: Mock):
         _, ca = self._self_signed("Test CA")
         cli_key, cli_cert = self._self_signed("client")
-        result = create_oracle_thick_wallet(
+        wallet_dir = create_oracle_thick_wallet(
             SslOptions(
                 ca_data=self._pem_cert(ca),
                 cert_data=self._pem_cert(cli_cert),
                 key_data=self._pem_key(cli_key),
             )
         )
-        self.assertIsNotNone(result)
-        wallet_dir, password = result
+        self.assertIsNotNone(wallet_dir)
         self.addCleanup(shutil.rmtree, wallet_dir, ignore_errors=True)
-        key, cert, cas = self._load_p12(wallet_dir, password)
-        self.assertIsNotNone(key)  # client key present (mTLS identity)
-        self.assertIsNotNone(cert)
-        self.assertEqual(len(cas), 1)
+        cmds = [c.args for c in mock_orapki.call_args_list]
+        self.assertTrue(any(a[:2] == ("wallet", "import_pkcs12") for a in cmds))
+
+    @patch("apollo.integrations.db.oracle_client_config._run_orapki")
+    def test_wallet_dir_removed_on_failure(self, mock_orapki: Mock):
+        captured: dict = {}
+
+        def boom(*args: str) -> None:
+            # first call is "wallet create -wallet <dir> ..."; record the dir
+            captured["dir"] = args[args.index("-wallet") + 1]
+            raise RuntimeError("orapki boom")
+
+        mock_orapki.side_effect = boom
+        _, ca = self._self_signed("Test CA")
+        with self.assertRaises(RuntimeError):
+            create_oracle_thick_wallet(SslOptions(ca_data=self._pem_cert(ca)))
+        # the partially-built wallet dir is cleaned up rather than left behind
+        self.assertTrue(captured.get("dir"))
+        self.assertFalse(os.path.exists(captured["dir"]))

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -236,6 +236,30 @@ class OracleDbClientTests(TestCase):
 
     @patch("oracledb.connect")
     @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_ssl_context")
+    def test_ssl_options_inside_connect_args_is_popped(
+        self, mock_create_ssl_context: Mock, mock_connect: Mock
+    ) -> None:
+        """The CTP delivers ssl_options inside connect_args. It must drive SSL and
+        be removed before oracledb.connect (it is not an oracledb.connect arg)."""
+        mock_create_ssl_context.return_value = MagicMock(spec=ssl.SSLContext)
+        mock_connect.return_value = self._mock_connection
+
+        OracleProxyClient(
+            {
+                "connect_args": {
+                    **_ORACLE_DB_CREDENTIALS,
+                    "ssl_options": {"ca_data": "CA_FROM_CTP"},
+                }
+            }
+        )
+
+        mock_create_ssl_context.assert_called_once()
+        self.assertEqual(mock_create_ssl_context.call_args[0][0].ca_data, "CA_FROM_CTP")
+        call_kwargs = mock_connect.call_args[1]
+        self.assertNotIn("ssl_options", call_kwargs)  # popped, not sent to connect
+
+    @patch("oracledb.connect")
+    @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_ssl_context")
     def test_connect_with_ssl_mtls(
         self, mock_create_ssl_context: Mock, mock_connect: Mock
     ) -> None:
@@ -475,26 +499,47 @@ class OracleThickModeTests(TestCase):
     @patch("oracledb.connect")
     @patch("oracledb.init_oracle_client")
     @patch("oracledb.is_thin_mode", return_value=False)
-    def test_thick_tls_warns_when_later_ca_differs(
+    def test_thick_tls_raises_when_later_ca_differs(
         self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
     ) -> None:
         """Thick trust is frozen after the first connection; a later connection
-        with a different CA is warned about rather than silently ignored."""
+        with a different CA can't be applied — fail loudly, not silent ORA-29024."""
         mock_connect.return_value = self._mock_connection
         oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
         oracle_client_config._thick_ca_fingerprint = "established-fingerprint"
 
-        with self.assertLogs(
-            "apollo.integrations.db.oracle_client_config", level="WARNING"
-        ) as logs:
+        with self.assertRaises(RuntimeError) as ctx:
             OracleProxyClient(
                 {
                     "connect_args": dict(_ORACLE_DB_CREDENTIALS),
                     "ssl_options": {"ca_data": "a-different-ca"},
                 }
             )
+        self.assertIn("different SSL CA", str(ctx.exception))
         mock_init.assert_not_called()  # already initialized
-        self.assertTrue(any("differing CA" in line for line in logs.output))
+        mock_connect.assert_not_called()  # never connects with unappliable trust
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.init_oracle_client")
+    @patch("oracledb.is_thin_mode", return_value=False)
+    def test_thick_tls_raises_when_process_inited_without_tls(
+        self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
+    ) -> None:
+        """An SSL connection arriving after the process was initialized without a
+        wallet (e.g. a prior non-SSL connection warmed the container) can't have
+        trust applied — fail loudly."""
+        mock_connect.return_value = self._mock_connection
+        # setUp reset _thick_wallet_dir to None (inited without TLS).
+        with self.assertRaises(RuntimeError) as ctx:
+            OracleProxyClient(
+                {
+                    "connect_args": dict(_ORACLE_DB_CREDENTIALS),
+                    "ssl_options": {"ca_data": "some-ca"},
+                }
+            )
+        self.assertIn("without an SSL trust store", str(ctx.exception))
+        mock_connect.assert_not_called()
 
 
 class CreateOracleSslContextTests(TestCase):

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -375,9 +375,7 @@ class OracleThickModeTests(TestCase):
     def setUp(self) -> None:
         self._mock_connection = Mock()
         # Reset the process-wide thick-mode state so each test starts fresh.
-        oracle_client_config._thick_config_dir = None
-        oracle_client_config._thick_wallet_dir = None
-        oracle_client_config._thick_tls_fingerprint = None
+        oracle_client_config._reset_for_testing()
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
     @patch("oracledb.connect")
@@ -553,6 +551,30 @@ class OracleThickModeTests(TestCase):
             )
         self.assertIn("different SSL configuration", str(ctx.exception))
         mock_connect.assert_not_called()
+
+    @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
+    @patch("oracledb.connect")
+    @patch("oracledb.init_oracle_client")
+    @patch("oracledb.is_thin_mode", return_value=False)
+    def test_thick_tls_reconnect_same_ca_succeeds(
+        self, _mock_thin: Mock, mock_init: Mock, mock_connect: Mock
+    ) -> None:
+        """The common case: a second TLS connection with the SAME CA reuses the
+        established wallet — no error, no re-init, and it connects."""
+        mock_connect.return_value = self._mock_connection
+        ssl_opts = {"ca_data": "CA"}
+        oracle_client_config._thick_wallet_dir = "/tmp/established_wallet"
+        oracle_client_config._thick_tls_fingerprint = (
+            oracle_client_config._tls_fingerprint(SslOptions(**ssl_opts))
+        )
+
+        client = OracleProxyClient(
+            {"connect_args": dict(_ORACLE_DB_CREDENTIALS), "ssl_options": ssl_opts}
+        )
+
+        mock_init.assert_not_called()  # trust already established, no re-init
+        mock_connect.assert_called_once()
+        self.assertEqual(client.wrapped_client, self._mock_connection)
 
     @patch.dict("os.environ", {"MCD_ORACLE_THICK_MODE": "true"})
     @patch("oracledb.connect")
@@ -860,6 +882,25 @@ class CreateOracleThickWalletTests(TestCase):
         self.assertFalse(any("import_pkcs12" in a for a in cmds))
 
     @patch("apollo.integrations.db.oracle_client_config._run_orapki")
+    def test_multi_ca_bundle_adds_each_cert(self, mock_orapki: Mock):
+        # A real CA bundle (e.g. AWS RDS) has multiple certs; each must be added
+        # as its own -trusted_cert with a distinct temp path.
+        _, ca1 = self._self_signed("Root CA")
+        _, ca2 = self._self_signed("Intermediate CA")
+        bundle = self._pem_cert(ca1) + self._pem_cert(ca2)
+        wallet_dir = create_oracle_thick_wallet(SslOptions(ca_data=bundle))
+        self.assertIsNotNone(wallet_dir)
+        self.addCleanup(shutil.rmtree, wallet_dir, ignore_errors=True)
+        add_calls = [
+            c.args
+            for c in mock_orapki.call_args_list
+            if c.args[:2] == ("wallet", "add") and "-trusted_cert" in c.args
+        ]
+        self.assertEqual(len(add_calls), 2)  # one add per cert in the bundle
+        cert_paths = [a[a.index("-cert") + 1] for a in add_calls]
+        self.assertEqual(len(set(cert_paths)), 2)  # distinct temp path per cert
+
+    @patch("apollo.integrations.db.oracle_client_config._run_orapki")
     def test_mtls_imports_client_identity(self, mock_orapki: Mock):
         _, ca = self._self_signed("Test CA")
         cli_key, cli_cert = self._self_signed("client")
@@ -898,9 +939,7 @@ class OracleClientConfigInternalsTests(TestCase):
     elsewhere (_run_orapki, _write_thick_sqlnet) and the init-failure cleanup."""
 
     def setUp(self) -> None:
-        oracle_client_config._thick_config_dir = None
-        oracle_client_config._thick_wallet_dir = None
-        oracle_client_config._thick_tls_fingerprint = None
+        oracle_client_config._reset_for_testing()
 
     @patch("apollo.integrations.db.oracle_client_config.subprocess.run")
     def test_run_orapki_builds_command_and_redacts_password_on_failure(


### PR DESCRIPTION
## What

Adds **SSL (TLS + mTLS) support for Oracle thick mode**, replacing the previous behavior where thick + `ssl_options` raised. Also fixes a related pre-existing gap where the Oracle CTP dropped `ssl_options` for agent connections, so **no** SSL (thin or thick) actually worked over the agent.

> Note: an earlier revision of this PR tried to build the wallet in pure Python (`ewallet.p12` via the `connect()` `wallet_location` param). That approach does **not** establish trust — see below — and was reworked.

## Why it's non-trivial

Thick mode doesn't accept a Python `ssl.SSLContext` (thin-only); it validates the server certificate against an Oracle **wallet**. Verified the hard way against a real RDS Oracle TLS endpoint:

- Thick reads the server trust store **only from `WALLET_LOCATION` in `sqlnet.ora`** — the `connect()` `wallet_location` param does **not** drive server-cert trust.
- The wallet must be a **`cwallet.sso`** produced by Oracle's **`orapki`** tool. A `cryptography`-built PKCS#12 is opened but never honored as a trust anchor (ORA-29024).
- The wallet must exist at `WALLET_LOCATION` **when `init_oracle_client` runs**, or the wallet subsystem starts with no trust store and every TLS connect fails with ORA-29024.
- Oracle **caches the trust store after the first successful connection** for the process lifetime — it does not re-read the wallet per connect.
- Thick has no `@SECLEVEL` knob, so older RSA-kx ciphers (e.g. RDS Oracle's `AES256-GCM-SHA384`) must be listed explicitly in `SSL_CIPHER_SUITES`.
- **The Oracle CTP was dropping `ssl_options` over the agent.** The mapper only emitted `dsn/user/password/expire_time`, so the `ssl_options` block (with `ca_data`) never reached `OracleProxyClient`. Every SSL connection through the agent failed: thin connected to `tcps` with no `ssl_context` → `SSLV3_ALERT_HANDSHAKE_FAILURE` (RDS's RSA cipher rejected at the default security level); thick connected with no wallet → ORA-29024. Both reproduced live against RDS.

## How

- **New `apollo/integrations/db/oracle_client_config.py`** owns all Oracle driver-mode + TLS logic (thin `ssl.SSLContext` and thick wallet), keeping `oracle_proxy_client.py` to orchestration.
- **Wallet via orapki:** `create_oracle_thick_wallet(ssl_options)` runs `orapki wallet create -auto_login`, adds each CA from `ca_data` as a `-trusted_cert`, and (for **mTLS**) imports the client key+cert from `cert_data`/`key_data` via `import_pkcs12`.
- **Correct ordering:** `configure_thick_connection(ssl_options)` builds the wallet and writes `sqlnet.ora` (`SSL_CIPHER_SUITES` + `WALLET_LOCATION` + `SSL_SERVER_DN_MATCH`) **before** `init_oracle_client`, once per process, under a lock. Because trust is cached after the first connection, one process-wide wallet is built from the first connection's `ssl_options`; a thick agent supports a single Oracle TLS trust config and **fails loudly** (rather than a confusing ORA-29024) if a later connection needs a CA the process can't apply.
- **CTP `ssl_options` passthrough (the agent fix):** the Oracle CTP now carries `ssl_options` through into `connect_args` (added to the `OracleClientArgs` TypedDict + mapper; the sandboxed NativeEnvironment preserves the dict instead of stringifying it). `OracleProxyClient` **pops** `ssl_options` from `connect_args` (it is not an `oracledb.connect` arg) and falls back to the top-level sibling for direct/legacy callers. This makes both thin and thick SSL work over the agent.
- **Validation by default:** `SSL_SERVER_DN_MATCH` follows `ssl_options.verify_identity` (default on) — nothing hardcoded off; the CA chain is always validated in thick mode.
- **Ciphers:** default list = RSA-kx (RDS/EBS) + modern ECDHE; override via `MCD_ORACLE_SSL_CIPHER_SUITES`.
- **Dockerfile:** new `oracle-pki-builder` stage builds a stripped ~54 MB JRE (jlink: `java.base`, `java.naming`, `jdk.crypto.ec`) plus the `oraclepki`/`osdt_core`/`osdt_cert` jars, copied into the `system-base`, `lambda`, and `azure` images so orapki can build wallets at runtime. Built on Amazon Linux 2023 (oldest glibc) and verified to run on both the Debian and Lambda AL2023 bases.
- Thin path unchanged.

## Testing

- Unit tests: thick+TLS wires trust via `sqlnet.ora` (not the `connect()` param, not `ssl_context`); wallet written **before** `init_oracle_client`; orapki commands issued for one-way and mTLS; fail-loud on unappliable/differing CA; CTP carries `ssl_options` through as a native dict and `OracleProxyClient` pops it. Oracle + full CTP suites pass; `black` + `pyright` clean.
- **One-way TLS verified end-to-end against a real RDS Oracle** — both directly through `OracleProxyClient` and **through the AWS agent** (thick, `MCD_ORACLE_THICK_MODE=true`, `protocol=tcps`) after the CTP fix.
- Docker `system-base` image builds; orapki produces a `cwallet.sso` inside it.
- **mTLS** is built + unit-tested but **not** validated against a client-auth server (RDS can't require client certs; would need a local Oracle-mTLS instance).

## Follow-ups (separate PRs)

- data-collector (#2517): revert the thick+SSL raise and reuse `oracle_client_config` for its local-thick flow.
- Revert the "thick can't do SSL" wording in the docs (done on the docs branch).

Draft until reviewed.