### PR TITLE
Fix Oracle verify_identity: set ssl_server_dn_match in thin mode

### DIFF
--- a/apollo/integrations/db/oracle_proxy_client.py
+++ b/apollo/integrations/db/oracle_proxy_client.py
@@ -60,6 +60,11 @@ class OracleProxyClient(BaseDbProxyClient):
             oracle_client_config.configure_thick_connection(ssl_options)
         elif ssl_context := create_oracle_ssl_context(ssl_options):
             connect_args["ssl_context"] = ssl_context
+            # oracledb thin does its own DN/hostname match via ssl_server_dn_match
+            # (default True), separate from ssl_context.check_hostname; mirror the flag.
+            connect_args["ssl_server_dn_match"] = (
+                not ssl_options.skip_cert_verification and ssl_options.verify_identity
+            )
 
         self._connection = oracledb.connect(**connect_args)  # type: ignore
 

--- a/tests/test_oracle_client.py
+++ b/tests/test_oracle_client.py
@@ -237,6 +237,37 @@ class OracleDbClientTests(TestCase):
 
     @patch("oracledb.connect")
     @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_ssl_context")
+    def test_ssl_server_dn_match_follows_verify_identity(
+        self, mock_create_ssl_context: Mock, mock_connect: Mock
+    ) -> None:
+        """oracledb thin mode does its own server-DN/hostname match via the
+        ``ssl_server_dn_match`` connect arg (default True), independent of the
+        SSLContext's ``check_hostname``. ``verify_identity`` /
+        ``skip_cert_verification`` must drive it, otherwise turning off
+        "verify identity" cannot disable the DPY-6006 hostname-mismatch check."""
+        mock_create_ssl_context.return_value = MagicMock(spec=ssl.SSLContext)
+        mock_connect.return_value = self._mock_connection
+        ca_cert_data = "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----"
+
+        cases = [
+            ({"ca_data": ca_cert_data}, True),  # verify_identity defaults to True
+            ({"ca_data": ca_cert_data, "verify_identity": False}, False),
+            ({"ca_data": ca_cert_data, "skip_cert_verification": True}, False),
+        ]
+        for ssl_options, expected in cases:
+            with self.subTest(ssl_options=ssl_options):
+                mock_connect.reset_mock()
+                OracleProxyClient(
+                    {
+                        "connect_args": _ORACLE_DB_CREDENTIALS,
+                        "ssl_options": ssl_options,
+                    }
+                )
+                call_kwargs = mock_connect.call_args[1]
+                self.assertEqual(call_kwargs.get("ssl_server_dn_match"), expected)
+
+    @patch("oracledb.connect")
+    @patch("apollo.integrations.db.oracle_proxy_client.create_oracle_ssl_context")
     def test_ssl_options_inside_connect_args_is_popped(
         self, mock_create_ssl_context: Mock, mock_connect: Mock
     ) -> None:


### PR DESCRIPTION
### What's new?
`verify_identity=false` was silently ignored for Oracle SSL. python-oracledb **thin mode** does its own server-DN/hostname match via the `ssl_server_dn_match` connect arg (default `True`), independent of `ssl_context.check_hostname`. We set `check_hostname` but never `ssl_server_dn_match`, so disabling "verify identity" left the check on and connections still failed with `DPY-6006`.

Fix: mirror `verify_identity` / `skip_cert_verification` into `ssl_server_dn_match` at the `oracledb.connect()` call site (thin SSL path only; thick/wallet and disabled paths unchanged).

### How tested
- Test-first: added `test_ssl_server_dn_match_follows_verify_identity` (default→True, verify_identity=false→False, skip_cert_verification=true→False), confirmed fail, then fixed → passes.
- Full Oracle suite green (38 passed).
- Verified against RDS Oracle over IP: `verify_identity=true` → DPY-6006; `verify_identity=false` → connects.

### Notes
- Companion fix in data-collector `plugin_oracle.py` (docker path). This change covers the **agent** path.
- Draft: integration-test on dev after release before marking ready.