### PR TITLE
Run only periodic validations in smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ jobs:
           command: |
             export MCD_DEFAULT_API_ID=${MCD_SMOKE_TESTS_API_ID}
             export MCD_DEFAULT_API_TOKEN=${MCD_SMOKE_TESTS_API_TOKEN}
-            montecarlo collectors run-validations --all-validations --agent-id << parameters.agent_uuid >>
+            montecarlo collectors run-validations --only-periodic --agent-id << parameters.agent_uuid >>
 
 workflows:
   version: 2


### PR DESCRIPTION
## What

Change the CI smoke-test "Run validations" step from `--all-validations` to `--only-periodic` (`.circleci/config.yml:410`). This job runs on dev builds and the merge queue against the golden/smoke agents (aws/az/gcp, shared parameterized job).

## Why

`--all-validations` runs every supported validation, including non-periodic ones. Several non-periodic checks are flaky against the shared dev backend and fail almost every run:

| Recurring failure | Connection | `periodic_validation` |
|---|---|---|
| `validate_list_schemas` | databricks-aws | `False` |
| `validate_select` | databricks (sql warehouse) | `False` |
| `validate_svv_datashares` | redshift-aws | `False` |

Sampled dev builds (3160, 3185, 3193, 3194): **every** failing validation was `periodic_validation: False`. No periodic validation failed in any of them — the periodic core (`*_connection`, `storage_access`, `supported_type`, `autoscaling_disabled`) passed in every build. Result: dev builds fail almost every run.

## How

`--only-periodic` keeps only validations flagged `periodic_validation: True` (the same reduced set run by scheduled periodic validations), dropping the flaky deep-metadata checks. Those deeper checks (schema/table listing, select, metadata) are better covered by real monitoring than by a boot-time smoke test.

The flag is client-side filtering in the CLI (`getSupportedValidationsV2` returns the full list; the CLI filters on each validation's `periodic_validation` attribute) — no backend change needed.

## Not addressed

Separate, unrelated smoke-test flakiness remains out of scope: CloudFormation `UPDATE_IN_PROGRESS` in the "Update agent" step, and agent-version-mismatch timing in the golden-agent version check. Backend `502` / GraphQL-timeout noise is present but only *blocks* via the non-periodic checks this PR drops.

## Testing

- [x] Verified the flag mapping in the CLI (`--only-periodic/--all-validations` → `only_periodic`, client-side filter on `periodic_validation`)
- [x] Confirmed all recurring dev-build validation failures are `periodic_validation: False` and thus dropped by `--only-periodic`
- [na] Unit tests — CI config change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)