### PR TITLE
chore(security): bump pyasn1, httplib2, click for fixable HIGH CVEs

### DIFF
--- a/requirements-cloudrun.txt
+++ b/requirements-cloudrun.txt
@@ -97,7 +97,7 @@ protobuf==5.29.6
     #   grpc-google-iam-v1
     #   grpcio-status
     #   proto-plus
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -c requirements.txt
     #   pyasn1-modules

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     # via
     #   -c requirements.txt
     #   requests
-click==8.1.7
+click==8.4.2
     # via
     #   -c requirements.txt
     #   black

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ azure-storage-blob==12.23.0
 brotli==1.2.0  # Upgrade transient dependency of flask-compress to address SEC-1143 (CVE-2025-6176)
 cachetools==5.3.3  # Runtime dep for apollo/credentials/external_credentials_cache.py; pinned here so it shows up in install_requires for downstream consumers
 cerberus>=1.3.5
+click>=8.3.3  # transitive (clickhouse-connect, flask); pinned for CVE-2026-7246
 clickhouse-connect==0.8.18
 cryptography>=48.0.1  # CVE-2026-26007; >=48.0.1 for GHSA-537c-gmf6-5ccf (bundled OpenSSL OOB read, fixed in 48.0.1)
 databricks-sql-connector==4.2.5  # highest 4.x compatible with impyla's thrift==0.16.0 pin (4.2.6+ require thrift>=0.22.0); 4.0.0 also capped numpy<2.0.0, which blocked the Python 3.13 numpy 2 bump
@@ -19,6 +20,7 @@ google-api-python-client==2.176.0  # Upgraded in VULN-620
 google-cloud-dataform==0.6.2
 google-cloud-secret-manager==2.25.0
 google-cloud-storage==2.19.0  # 2.10.0 shipped a legacy setuptools namespace (nspkg.pth + namespace_packages.txt for `google`), which corrupts the `google` namespace under Python 3.13 and crashes the Azure Functions worker (KeyError: 'google'). 2.19.0 uses native PEP 420 namespaces.
+httplib2>=0.32.0  # transitive (google-auth-httplib2); pinned for CVE-2026-59939
 gunicorn==26.0.0  # VULN-1117/YET-1356: request-smuggling & header-framing hardening (AIKIDO-2026-10742); stricter RFC 9112/9110 parsing. Default sync/gthread workers unaffected by the eventlet-worker removal.
 hdbcli==2.18.27
 ibm-db==3.2.7
@@ -35,7 +37,7 @@ trino==0.336.0
 protobuf==5.29.6
 psycopg2-binary==2.9.12  # latest 2.9.x; bumped from 2.9.9 which had no Python 3.13 (cp313) wheels
 pyarrow==23.0.1  # CVE-2026-25087 (Python bindings unaffected per GHSA-rgxp-2hwp-jwgg, but Trivy/Scout flag <23.0.1)
-pyasn1>=0.6.3  # CVE-2026-30922 (uncontrolled recursion), CVE-2026-23490
+pyasn1>=0.6.4  # CVE-2026-30922 (uncontrolled recursion), CVE-2026-23490, CVE-2026-59884/59885/59886
 pycryptodome>=3.21.0
 pyjwt>=2.13.0  # CVE-2026-32597, CVE-2026-48526
 PyMySQL>=1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,8 +68,9 @@ charset-normalizer==3.3.2
     # via
     #   requests
     #   snowflake-connector-python
-click==8.1.7
+click==8.4.2
     # via
+    #   -r requirements.in
     #   flask
     #   presto-python-client
 clickhouse-connect==0.8.18
@@ -164,8 +165,9 @@ gunicorn==26.0.0
     # via -r requirements.in
 hdbcli==2.18.27
     # via -r requirements.in
-httplib2==0.22.0
+httplib2==0.32.0
     # via
+    #   -r requirements.in
     #   google-api-python-client
     #   google-auth-httplib2
 ibm-db==3.2.7
@@ -279,7 +281,7 @@ pyarrow==23.0.1
     # via
     #   -r requirements.in
     #   salesforce-cdp-connector
-pyasn1==0.6.3
+pyasn1==0.6.4
     # via
     #   -r requirements.in
     #   pyasn1-modules


### PR DESCRIPTION
Closes the fixable HIGH findings shared across all tags in the 2026-07-23 #collection-agent-vuln-scans report:

- pyasn1 0.6.3 -> 0.6.4: CVE-2026-59884, CVE-2026-59885, CVE-2026-59886
- httplib2 0.22.0 -> 0.32.0: CVE-2026-59939
- click 8.1.7 -> 8.4.2: CVE-2026-7246 (floor pinned >=8.3.3)

httplib2 and click are transitive-only, so they get explicit floor pins in requirements.in. Recompiled all lockfiles under Python 3.13 with no transitive churn (only the three target versions moved).

The MessagePack HIGH CVEs (CVE-2026-48109, CVE-2026-48506) on latest-azure are deferred, pending a Microsoft base-image rebuild. The remaining HIGH/CRITICAL findings (debian/perl, xvfb) have no upstream fix available.