### PR TITLE
fix(teradata): honor data-collector dbs_port key in SSL CTP render (was crashing with UndefinedError)

### DIFF
--- a/apollo/integrations/ctp/defaults/teradata.py
+++ b/apollo/integrations/ctp/defaults/teradata.py
@@ -84,7 +84,7 @@ TERADATA_DEFAULT_CTP = CtpConfig(
             field_map={
                 "sslca": "{{ derived.ssl_ca_path }}",
                 "encryptdata": "true",
-                "https_port": "{{ raw.port }}",
+                "https_port": "{{ raw.port | default(none) }}",
                 "dbs_port": "{{ none }}",  # suppress mapper's dbs_port
             },
         ),

--- a/apollo/integrations/ctp/defaults/teradata.py
+++ b/apollo/integrations/ctp/defaults/teradata.py
@@ -84,7 +84,7 @@ TERADATA_DEFAULT_CTP = CtpConfig(
             field_map={
                 "sslca": "{{ derived.ssl_ca_path }}",
                 "encryptdata": "true",
-                "https_port": "{{ raw.port | default(none) }}",
+                "https_port": "{{ raw.port | default(raw.dbs_port) | default(none) }}",
                 "dbs_port": "{{ none }}",  # suppress mapper's dbs_port
             },
         ),
@@ -96,8 +96,10 @@ TERADATA_DEFAULT_CTP = CtpConfig(
             "host": "{{ raw.host }}",
             "user": "{{ raw.user }}",
             "password": "{{ raw.password }}",
-            # Plain-connection port; overridden to none by the SSL step when active
-            "dbs_port": "{{ raw.port | default(none) }}",
+            # Plain-connection port; overridden to none by the SSL step when active.
+            # Honor either `port` (flat credentials) or `dbs_port` (the shape the
+            # data-collector pre-sends inside connect_args).
+            "dbs_port": "{{ raw.port | default(raw.dbs_port) | default(none) }}",
             "request_timeout": "{{ raw.query_timeout_in_seconds | default(none) }}",
             "logon_timeout": "{{ raw.login_timeout_in_seconds | default(none) }}",
             # Protocol options — default values match DC's TeradataConnectionSettingsSchema

--- a/tests/ctp/test_teradata_ctp.py
+++ b/tests/ctp/test_teradata_ctp.py
@@ -36,6 +36,16 @@ class TestTeradataCtp(TestCase):
         self.assertNotIn("dbs_port", args)
         self.assertNotIn("https_port", args)
 
+    def test_dc_shaped_dbs_port_maps_to_dbs_port(self):
+        # The data-collector sends the port pre-shaped as `dbs_port` inside
+        # connect_args; registry.py unwraps connect_args as `raw`, so `raw`
+        # carries `dbs_port` (not `port`). The template must honor that key.
+        args = _resolve(
+            {"host": "td.example.com", "user": "u", "password": "p", "dbs_port": 1025}
+        )
+        self.assertEqual(1025, args["dbs_port"])
+        self.assertNotIn("https_port", args)
+
     # ── Protocol option defaults ───────────────────────────────────────
 
     def test_tmode_defaults_to_TERA(self):
@@ -155,6 +165,27 @@ class TestTeradataCtp(TestCase):
         # falls back to its own SSL default instead of the agent crashing.
         self.assertNotIn("https_port", args)
         self.assertNotIn("dbs_port", args)
+        if os.path.exists(args.get("sslca", "")):
+            os.unlink(args["sslca"])
+
+    def test_ssl_dc_shaped_dbs_port_used_as_https_port(self):
+        # Customer-reported case: data-collector supplies the port as
+        # `dbs_port` (not `port`) AND SSL is active. The SSL step must pick
+        # up dbs_port as the https_port instead of silently dropping it.
+        pem = b"FAKE_CERT"
+        args = _resolve(
+            {
+                "host": "h",
+                "user": "u",
+                "password": "p",
+                "dbs_port": 1025,
+                "ssl_options": {"ca_data": pem},
+            }
+        )
+        self.assertEqual(1025, args["https_port"])
+        self.assertNotIn("dbs_port", args)
+        self.assertIn("sslca", args)
+        self.assertEqual("true", args["encryptdata"])
         if os.path.exists(args.get("sslca", "")):
             os.unlink(args["sslca"])
 

--- a/tests/ctp/test_teradata_ctp.py
+++ b/tests/ctp/test_teradata_ctp.py
@@ -134,6 +134,30 @@ class TestTeradataCtp(TestCase):
         if os.path.exists(args.get("sslca", "")):
             os.unlink(args["sslca"])
 
+    def test_ssl_no_port_omits_https_port(self):
+        # SSL active (ca_data present, not disabled) but no port supplied.
+        # The SSL step must guard https_port the same way the mapper guards
+        # dbs_port, otherwise the StrictUndefined render raises
+        # UndefinedError: 'port' is undefined and validate_connection crashes.
+        pem = b"FAKE_CERT"
+        args = _resolve(
+            {
+                "host": "h",
+                "user": "u",
+                "password": "p",
+                "ssl_options": {"ca_data": pem},
+            }
+        )
+        # SSL is still active: CA file written and encryptdata set.
+        self.assertIn("sslca", args)
+        self.assertEqual("true", args["encryptdata"])
+        # No port supplied -> neither port key is emitted, so teradatasql
+        # falls back to its own SSL default instead of the agent crashing.
+        self.assertNotIn("https_port", args)
+        self.assertNotIn("dbs_port", args)
+        if os.path.exists(args.get("sslca", "")):
+            os.unlink(args["sslca"])
+
     # ── SSL — disabled flag ───────────────────────────────────────────
 
     def test_ssl_disabled_flag_skips_ssl_step(self):

--- a/tests/ctp/test_teradata_ctp.py
+++ b/tests/ctp/test_teradata_ctp.py
@@ -158,6 +158,9 @@ class TestTeradataCtp(TestCase):
                 "ssl_options": {"ca_data": pem},
             }
         )
+        sslca_path = args.get("sslca")
+        if sslca_path:
+            self.addCleanup(lambda p=sslca_path: os.path.exists(p) and os.unlink(p))
         # SSL is still active: CA file written and encryptdata set.
         self.assertIn("sslca", args)
         self.assertEqual("true", args["encryptdata"])
@@ -165,8 +168,6 @@ class TestTeradataCtp(TestCase):
         # falls back to its own SSL default instead of the agent crashing.
         self.assertNotIn("https_port", args)
         self.assertNotIn("dbs_port", args)
-        if os.path.exists(args.get("sslca", "")):
-            os.unlink(args["sslca"])
 
     def test_ssl_dc_shaped_dbs_port_used_as_https_port(self):
         # Customer-reported case: data-collector supplies the port as
@@ -182,12 +183,13 @@ class TestTeradataCtp(TestCase):
                 "ssl_options": {"ca_data": pem},
             }
         )
+        sslca_path = args.get("sslca")
+        if sslca_path:
+            self.addCleanup(lambda p=sslca_path: os.path.exists(p) and os.unlink(p))
         self.assertEqual(1025, args["https_port"])
         self.assertNotIn("dbs_port", args)
         self.assertIn("sslca", args)
         self.assertEqual("true", args["encryptdata"])
-        if os.path.exists(args.get("sslca", "")):
-            os.unlink(args["sslca"])
 
     # ── SSL — disabled flag ───────────────────────────────────────────
 


### PR DESCRIPTION
## The bug

Testing a Teradata connection with SSL (a CA cert, i.e. `ssl_options.ca_data`) failed on the dev AWS agent with a Jinja2 strict-undefined error while rendering the Teradata connection type profile (CTP):

```
module=proxy_client_factory function=get_proxy_client
mcd_operation_name=teradata/validate_connection
exception: {type: UndefinedError, message: "'port' is undefined"}
```

There are two defects on this path, both fixed here:

1. **Crash** — the CTP renders with Jinja `StrictUndefined`. The SSL step rendered `https_port` with an unguarded `{{ raw.port }}`, so when SSL was active but `raw.port` was absent, the render raised `UndefinedError: 'port' is undefined` and `validate_connection` never completed.
2. **Dropped port (the real functional cause)** — even guarded, the template only ever read `raw.port`, but the **data-collector doesn't send `port`**. It sends the port pre-shaped as `dbs_port` inside `connect_args` (`plugin_teradata.py`). The agent CTP unwraps connect_args as `raw` (`registry.py`: `raw = credentials.get("connect_args", credentials)`), so `raw` carries `dbs_port` but **not** `port`. The DC-supplied port was therefore never mapped, and teradatasql silently fell back to its SSL default (443).

## The fix

In `apollo/integrations/ctp/defaults/teradata.py`, read the port from `raw.port` **or** `raw.dbs_port` in both places:

```diff
  # mapper
- "dbs_port": "{{ raw.port | default(none) }}",
+ "dbs_port": "{{ raw.port | default(raw.dbs_port) | default(none) }}",

  # SSL transform step
- "https_port": "{{ raw.port }}",
+ "https_port": "{{ raw.port | default(raw.dbs_port) | default(none) }}",
```

- `default(raw.dbs_port)` only kicks in when `port` is absent, so all existing `port`-based behavior is byte-for-byte identical.
- `default(none)` still applies when neither key is present, so the SSL path no longer crashes when there is no port at all.
- The SSL step's `dbs_port: "{{ none }}"` suppression is unchanged (SSL connections still use `https_port`, not the plain `dbs_port`).

### Data-collector intentionally NOT changed

`dbs_port` is the shape the data-collector's own local teradatasql path and the legacy non-CTP agent client already require, so the DC key stays as-is. The correct place to adapt is the agent CTP template, which is what this PR does.

## Tests

Added to `tests/ctp/test_teradata_ctp.py`:
- `test_ssl_no_port_omits_https_port` — SSL active, no port at all: no crash, `sslca`/`encryptdata` set, both port keys omitted (covers defect 1).
- `test_dc_shaped_dbs_port_maps_to_dbs_port` — DC-shaped plain (`dbs_port=1025`, no `port`): `dbs_port=1025`, no `https_port`.
- `test_ssl_dc_shaped_dbs_port_used_as_https_port` — the customer-reported case: DC-shaped `dbs_port=1025` + SSL active → `https_port=1025`, `dbs_port` omitted, `sslca` set, `encryptdata="true"` (covers defect 2).

Each new test was confirmed to fail on the prior state and pass after the change. All existing tests stay green, including `test_ssl_uses_https_port_not_dbs_port` (`port=443` → `https_port=443`).

## Verification

- `pytest tests/ctp/test_teradata_ctp.py` — 21 passed (18 original + 3 new)
- `black --check` on both changed files — clean
- `pyright apollo/integrations/ctp/defaults/teradata.py` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)