### PR TITLE
fix(ctp): route credential-resolution requests through SSRF-guarded safe_request

### DIFF
--- a/apollo/integrations/ctp/transforms/oauth.py
+++ b/apollo/integrations/ctp/transforms/oauth.py
@@ -2,6 +2,7 @@ import base64
 
 import requests
 
+from apollo.integrations.http.url_safety import safe_request
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.models import PipelineState, TransformStep
 from apollo.integrations.ctp.template import TemplateEngine
@@ -97,8 +98,12 @@ class OAuthTransform(Transform):
         }
 
         try:
-            response = requests.post(
-                token_endpoint, data=data, headers=headers, timeout=30
+            # SSRF guard: token_endpoint comes from customer connection config
+            # (template-rendered), so route through the SSRF-guarded request
+            # helper, which blocks cloud-metadata / loopback destinations while
+            # still allowing legitimate (incl. private/on-prem) IdP hosts.
+            response = safe_request(
+                "POST", token_endpoint, data=data, headers=headers, timeout=30
             )
             response.raise_for_status()
         except requests.HTTPError as exc:

--- a/apollo/integrations/ctp/transforms/resolve_informatica_session.py
+++ b/apollo/integrations/ctp/transforms/resolve_informatica_session.py
@@ -1,5 +1,6 @@
 import requests
 
+from apollo.integrations.http.url_safety import safe_request
 from apollo.integrations.ctp.errors import CtpPipelineError
 from apollo.integrations.ctp.models import PipelineState, TransformStep
 from apollo.integrations.ctp.template import TemplateEngine
@@ -151,7 +152,11 @@ class ResolveInformaticaSessionTransform(Transform):
     ) -> tuple[str, str]:
         """POST /ma/api/v2/user/login → (api_base_url, session_id)."""
         try:
-            response = requests.post(
+            # SSRF guard: base_url is templated from step.input; route through
+            # the SSRF-guarded helper (blocks cloud-metadata/loopback, allows
+            # private/on-prem Informatica pods).
+            response = safe_request(
+                "POST",
                 f"{base_url}{_V2_LOGIN_PATH}",
                 data={"username": username, "password": password},
                 timeout=_LOGIN_TIMEOUT,
@@ -185,7 +190,9 @@ class ResolveInformaticaSessionTransform(Transform):
     ) -> tuple[str, str]:
         """POST /saas/public/core/v3/login → (api_base_url, session_id)."""
         try:
-            response = requests.post(
+            # SSRF guard: base_url is templated from step.input (see _login_v2).
+            response = safe_request(
+                "POST",
                 f"{base_url}{_V3_LOGIN_PATH}",
                 json={"username": username, "password": password},
                 timeout=_LOGIN_TIMEOUT,
@@ -235,7 +242,9 @@ class ResolveInformaticaSessionTransform(Transform):
         so extraction is identical.
         """
         try:
-            response = requests.post(
+            # SSRF guard: base_url is templated from step.input (see _login_v2).
+            response = safe_request(
+                "POST",
                 f"{base_url}{_JWT_LOGIN_PATH}",
                 json={"orgId": org_id, "oauthToken": jwt_token},
                 timeout=_LOGIN_TIMEOUT,

--- a/tests/ctp/test_informatica_ctp.py
+++ b/tests/ctp/test_informatica_ctp.py
@@ -35,7 +35,9 @@ class TestInformaticaCtpRegistered(TestCase):
 class TestInformaticaCtpPipeline(TestCase):
     """Verify the default CTP pipeline resolves credentials to session_id + api_base_url."""
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_credentials_produce_session_and_base_url(self, mock_post):
         """V2 credentials flow through resolve_informatica_session and produce connect_args."""
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
@@ -56,7 +58,9 @@ class TestInformaticaCtpPipeline(TestCase):
         self.assertNotIn("username", result)
         self.assertNotIn("password", result)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_credentials_produce_session_and_base_url(self, mock_post):
         """V3 credentials flow through resolve_informatica_session and produce connect_args."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
@@ -73,7 +77,9 @@ class TestInformaticaCtpPipeline(TestCase):
         self.assertEqual("session-v3-xyz", result["session_id"])
         self.assertEqual("https://eu1.informaticacloud.com", result["api_base_url"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_minimal_credentials_default_to_v3(self, mock_post):
         """Credentials without informatica_auth default to V3 login."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
@@ -83,7 +89,7 @@ class TestInformaticaCtpPipeline(TestCase):
             {"username": "svc_user", "password": "s3cr3t"},
         )
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("/saas/public/core/v3/login", login_url)
         self.assertEqual("session-v3-xyz", result["session_id"])
 
@@ -91,7 +97,9 @@ class TestInformaticaCtpPipeline(TestCase):
 class TestInformaticaCtpPreResolvedPath(TestCase):
     """Verify the when= guard skips login when session_id is already present."""
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_pre_resolved_session_skips_login_step(self, mock_post):
         """When session_id is present in raw, the resolve_informatica_session step is skipped."""
         result = CtpPipeline().execute(
@@ -110,7 +118,9 @@ class TestInformaticaCtpPreResolvedPath(TestCase):
 class TestInformaticaCtpFactoryResolution(TestCase):
     """Verify CTP pipeline runs before InformaticaProxyClient is instantiated."""
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_flat_credentials_resolved_to_connect_args_before_client_creation(
         self, mock_post
     ):

--- a/tests/ctp/test_informatica_v2_ctp.py
+++ b/tests/ctp/test_informatica_v2_ctp.py
@@ -1,3 +1,4 @@
+import functools
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -54,6 +55,27 @@ def _mock_post(body: dict) -> MagicMock:
     return resp
 
 
+_OAUTH_SR = "apollo.integrations.ctp.transforms.oauth.safe_request"
+_INFO_SR = "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+
+
+def _patch_both_safe_request(test_fn):
+    """Patch safe_request in BOTH transforms (oauth + resolve_informatica_session)
+    to a single shared mock, injected as the first test argument. The v2 pipeline
+    issues its two HTTP calls from different transforms; routing both through one
+    mock lets a test assert on their ordered sequence via a single call_args_list.
+    safe_request's signature is (method, url, **kwargs), so the URL is the second
+    positional arg — call_args_list[i][0][1]."""
+
+    @functools.wraps(test_fn)
+    def wrapper(self, *args, **kwargs):
+        shared = MagicMock()
+        with patch(_OAUTH_SR, shared), patch(_INFO_SR, shared):
+            return test_fn(self, shared, *args, **kwargs)
+
+    return wrapper
+
+
 class TestInformaticaV2CtpRegistered(TestCase):
     def test_registered(self):
         """CtpRegistry.get('informatica-v2') must return a config — not None."""
@@ -63,7 +85,7 @@ class TestInformaticaV2CtpRegistered(TestCase):
 class TestInformaticaV2CtpPipeline(TestCase):
     """Verify the v2 pipeline chains oauth → resolve_informatica_session correctly."""
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_oauth_credentials_produce_session_and_base_url(self, mock_post):
         """Flat OAuth credentials flow through both steps and produce connect_args."""
         mock_post.side_effect = [
@@ -82,7 +104,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
         self.assertNotIn("oauth", result)
         self.assertNotIn("org_id", result)
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_first_call_is_idp_token_endpoint(self, mock_post):
         """Step 1 hits the IDP token URL with the grant_type and scope from raw.oauth."""
         mock_post.side_effect = [
@@ -92,14 +114,14 @@ class TestInformaticaV2CtpPipeline(TestCase):
 
         CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
-        first_call_url = mock_post.call_args_list[0][0][0]
+        first_call_url = mock_post.call_args_list[0][0][1]
         first_call_data = mock_post.call_args_list[0][1]["data"]
         self.assertEqual("https://idp.example.com/oauth2/token", first_call_url)
         self.assertEqual("client_credentials", first_call_data["grant_type"])
         # `scope` from the raw.oauth blob is forwarded to the IDP request body.
         self.assertEqual("informatica", first_call_data["scope"])
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_password_grant_carries_username_and_password(self, mock_post):
         """raw.oauth with grant_type=password forwards username/password to the IDP."""
         mock_post.side_effect = [
@@ -125,7 +147,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
         self.assertEqual("svc-user", first_call_data["username"])
         self.assertEqual("svc-pass", first_call_data["password"])
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_second_call_is_informatica_login_oauth_with_jwt(self, mock_post):
         """Step 2 hits Informatica /loginOAuth with the JWT obtained in step 1."""
         mock_post.side_effect = [
@@ -135,11 +157,11 @@ class TestInformaticaV2CtpPipeline(TestCase):
 
         CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
-        second_call_url = mock_post.call_args_list[1][0][0]
+        second_call_url = mock_post.call_args_list[1][0][1]
         # /ma/api/v2/user/loginOAuth path is exercised when jwt_token is provided
         self.assertIn("/ma/api/v2/user/loginOAuth", second_call_url)
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_default_base_url_when_omitted(self, mock_post):
         """Omitting base_url falls back to the default Informatica POD URL."""
         mock_post.side_effect = [
@@ -155,7 +177,7 @@ class TestInformaticaV2CtpPipeline(TestCase):
         # Second call goes to the exact default URL — pin it so silent drift in
         # `_DEFAULT_BASE_URL` (e.g., dm-us → dm-eu, or to a staging URL) breaks
         # this test instead of slipping by a substring match.
-        second_call_url = mock_post.call_args_list[1][0][0]
+        second_call_url = mock_post.call_args_list[1][0][1]
         self.assertEqual(
             f"{_INFORMATICA_DEFAULT_BASE_URL}/ma/api/v2/user/loginOAuth",
             second_call_url,
@@ -175,7 +197,7 @@ class TestInformaticaV2CtpPasswordMode(TestCase):
         "userInfo": {"sessionId": "session-v3-xyz"},
     }
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_password_mode_skips_oauth_step_and_does_v3_login(self, mock_post):
         mock_post.return_value = _mock_post(self._V3_LOGIN_RESPONSE)
 
@@ -185,7 +207,7 @@ class TestInformaticaV2CtpPasswordMode(TestCase):
 
         # Only one HTTP call — straight to Informatica's V3 login (no OAuth step).
         self.assertEqual(1, mock_post.call_count)
-        login_url = mock_post.call_args_list[0][0][0]
+        login_url = mock_post.call_args_list[0][0][1]
         self.assertIn("/saas/public/core/v3/login", login_url)
         self.assertEqual("session-v3-xyz", result["session_id"])
         self.assertEqual("https://eu1.informaticacloud.com", result["api_base_url"])
@@ -194,7 +216,7 @@ class TestInformaticaV2CtpPasswordMode(TestCase):
 class TestInformaticaV2CtpFailureSurfaces(TestCase):
     """Each external failure surface must raise CtpPipelineError without leaking creds."""
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_idp_token_failure_raises(self, mock_post):
         """A 4xx from the IDP token endpoint surfaces as CtpPipelineError."""
         idp_failure = MagicMock()
@@ -206,7 +228,7 @@ class TestInformaticaV2CtpFailureSurfaces(TestCase):
         with self.assertRaises(CtpPipelineError):
             CtpPipeline().execute(INFORMATICA_V2_DEFAULT_CTP, _OAUTH_MODE_CREDENTIALS)
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_informatica_login_oauth_failure_raises(self, mock_post):
         """A 4xx from /loginOAuth (after IDP succeeded) surfaces as CtpPipelineError."""
         informatica_failure = MagicMock()
@@ -225,7 +247,7 @@ class TestInformaticaV2CtpFailureSurfaces(TestCase):
 class TestInformaticaV2CtpFactoryResolution(TestCase):
     """Verify CTP runs before InformaticaProxyClient is instantiated for v2."""
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_flat_credentials_resolved_to_connect_args_before_client_creation(
         self, mock_post
     ):
@@ -270,7 +292,7 @@ class TestInformaticaV2CtpAuthModeDiscriminator(TestCase):
     make the discriminator case-insensitive (or coerce missing values).
     """
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_case_mismatch_auth_mode_falls_through_to_password_path(self, mock_post):
         """`auth_mode: "OAuth"` (uppercase) falls through to password mode and
         therefore fails when required password fields are missing — surfacing
@@ -294,7 +316,7 @@ class TestInformaticaV2CtpPreResolvedPath(TestCase):
     here in tests rather than at runtime.
     """
 
-    @patch("requests.post")
+    @_patch_both_safe_request
     def test_pre_resolved_session_skips_both_steps(self, mock_post):
         result = CtpPipeline().execute(
             INFORMATICA_V2_DEFAULT_CTP,

--- a/tests/ctp/test_mulesoft_ctp.py
+++ b/tests/ctp/test_mulesoft_ctp.py
@@ -40,9 +40,9 @@ class TestRegistration(TestCase):
 
 
 class TestRegionFullPipeline(TestCase):
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_us_default_region_full_pipeline(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response("us-tok")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_us_default_region_full_pipeline(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response("us-tok")
 
         args = _resolve(_FLAT_CREDS)
 
@@ -50,39 +50,39 @@ class TestRegionFullPipeline(TestCase):
         self.assertEqual("Bearer", args["auth_type"])
         self.assertNotIn("ssl_verify", args)
         # Verify OAuth POSTed to the US region endpoint.
-        post_args = mock_requests.post.call_args
+        post_args = mock_safe_request.call_args
         self.assertEqual(
             "https://anypoint.mulesoft.com/accounts/api/v2/oauth2/token",
-            post_args.args[0],
+            post_args.args[1],
         )
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_eu_region_pipeline(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response("eu-tok")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_eu_region_pipeline(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response("eu-tok")
 
         args = _resolve({**_FLAT_CREDS, "region": "EU"})
 
         self.assertEqual("eu-tok", args["token"])
         self.assertEqual(
             "https://eu1.anypoint.mulesoft.com/accounts/api/v2/oauth2/token",
-            mock_requests.post.call_args.args[0],
+            mock_safe_request.call_args.args[1],
         )
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_gov_region_pipeline(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response("gov-tok")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_gov_region_pipeline(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response("gov-tok")
 
         args = _resolve({**_FLAT_CREDS, "region": "Gov"})
 
         self.assertEqual("gov-tok", args["token"])
         self.assertEqual(
             "https://mpt.mulesoft.com/accounts/api/v2/oauth2/token",
-            mock_requests.post.call_args.args[0],
+            mock_safe_request.call_args.args[1],
         )
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_auth_type_always_bearer(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response()
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_auth_type_always_bearer(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response()
 
         args = _resolve(_FLAT_CREDS)
 
@@ -90,17 +90,17 @@ class TestRegionFullPipeline(TestCase):
 
 
 class TestPreShapedPath(TestCase):
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_pre_shaped_token_skips_both_steps(self, mock_requests):
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_pre_shaped_token_skips_both_steps(self, mock_safe_request):
         args = _resolve({"token": "pre-shaped"})
 
         self.assertEqual("pre-shaped", args["token"])
         self.assertEqual("Bearer", args["auth_type"])
         self.assertNotIn("api_base_url", args)
-        mock_requests.post.assert_not_called()
+        mock_safe_request.assert_not_called()
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_pre_shaped_with_extra_credentials_still_skips(self, mock_requests):
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_pre_shaped_with_extra_credentials_still_skips(self, mock_safe_request):
         # Even with full client_id/secret present, an existing token short-circuits
         # both the endpoints transform and the oauth transform.
         args = _resolve(
@@ -112,39 +112,37 @@ class TestPreShapedPath(TestCase):
         )
 
         self.assertEqual("pre-shaped", args["token"])
-        mock_requests.post.assert_not_called()
+        mock_safe_request.assert_not_called()
 
 
 class TestFailurePaths(TestCase):
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_oauth_failure_raises(self, mock_requests):
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_oauth_failure_raises(self, mock_safe_request):
         # Simulate a 401 from the token endpoint.
         fail_resp = MagicMock()
         fail_resp.status_code = 401
         http_error = requests.HTTPError(response=fail_resp)
         fail_resp.raise_for_status.side_effect = http_error
-        mock_requests.HTTPError = requests.HTTPError
-        mock_requests.RequestException = requests.RequestException
-        mock_requests.post.return_value = fail_resp
+        mock_safe_request.return_value = fail_resp
 
         with self.assertRaises(CtpPipelineError):
             _resolve(_FLAT_CREDS)
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_invalid_region_raises_before_oauth(self, mock_requests):
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_invalid_region_raises_before_oauth(self, mock_safe_request):
         with self.assertRaises(CtpPipelineError) as ctx:
             _resolve({**_FLAT_CREDS, "region": "APAC"})
 
         self.assertIn("APAC", str(ctx.exception))
         # Pipeline must halt at the endpoints transform — OAuth must not be
         # attempted with the wrong (or undetermined) token endpoint.
-        mock_requests.post.assert_not_called()
+        mock_safe_request.assert_not_called()
 
 
 class TestSslPassthrough(TestCase):
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_ssl_verify_passed_through(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response()
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_ssl_verify_passed_through(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response()
 
         args = _resolve({**_FLAT_CREDS, "ssl_verify": "/path/to/ca-bundle.crt"})
 
@@ -157,9 +155,9 @@ class TestHttpProxyClientContract(TestCase):
     test catches it before the integration fails at runtime.
     """
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
-    def test_connect_args_match_http_proxy_client_contract(self, mock_requests):
-        mock_requests.post.return_value = _mock_token_response()
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
+    def test_connect_args_match_http_proxy_client_contract(self, mock_safe_request):
+        mock_safe_request.return_value = _mock_token_response()
 
         args = _resolve(_FLAT_CREDS)
 

--- a/tests/ctp/test_proxy_client_factory_ctp.py
+++ b/tests/ctp/test_proxy_client_factory_ctp.py
@@ -92,9 +92,9 @@ class TestProxyClientFactoryCtp(TestCase):
             captured["credentials"] = credentials
             raise StopIteration
 
-        # Mock the OAuth POST so the CTP pipeline produces a real token.
-        with patch("apollo.integrations.ctp.transforms.oauth.requests") as mock_req:
-            mock_resp = mock_req.post.return_value
+        # Mock the OAuth request so the CTP pipeline produces a real token.
+        with patch("apollo.integrations.ctp.transforms.oauth.safe_request") as mock_req:
+            mock_resp = mock_req.return_value
             mock_resp.json.return_value = {"access_token": "ms-token"}
             mock_resp.raise_for_status.return_value = None
 

--- a/tests/ctp/test_resolve_informatica_session.py
+++ b/tests/ctp/test_resolve_informatica_session.py
@@ -74,7 +74,9 @@ class TestRegistration(TestCase):
 
 
 class TestV2PasswordMode(TestCase):
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_login_extracts_server_url_and_session_id(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
 
@@ -91,7 +93,9 @@ class TestV2PasswordMode(TestCase):
         self.assertEqual("session-v2-abc", state.derived["session_id"])
         self.assertEqual(_API_BASE_URL_V2, state.derived["api_base_url"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_login_posts_to_v2_path(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
 
@@ -105,11 +109,13 @@ class TestV2PasswordMode(TestCase):
         )
         _run(step, {"username": "u", "password": "p"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("/ma/api/v2/user/login", login_url)
         self.assertNotIn("loginOAuth", login_url)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_login_sends_credentials_as_form_data(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
 
@@ -135,7 +141,9 @@ class TestV2PasswordMode(TestCase):
 
 
 class TestV3PasswordMode(TestCase):
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_login_extracts_integration_cloud_base_url(self, mock_post):
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
 
@@ -152,7 +160,9 @@ class TestV3PasswordMode(TestCase):
         self.assertEqual("session-v3-xyz", state.derived["session_id"])
         self.assertEqual(_API_BASE_URL_V3, state.derived["api_base_url"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_login_posts_to_v3_path(self, mock_post):
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
 
@@ -166,10 +176,12 @@ class TestV3PasswordMode(TestCase):
         )
         _run(step, {"username": "u", "password": "p"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("/saas/public/core/v3/login", login_url)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_missing_informatica_auth_defaults_to_v3(self, mock_post):
         """When informatica_auth is absent, V3 is used."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
@@ -182,10 +194,12 @@ class TestV3PasswordMode(TestCase):
         )
         _run(step, {"username": "u", "password": "p"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("/saas/public/core/v3/login", login_url)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_login_sends_credentials_as_json(self, mock_post):
         """V3 endpoint requires application/json — must use json=, not data=."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
@@ -206,7 +220,9 @@ class TestV3PasswordMode(TestCase):
         )
         self.assertNotIn("data", call_kwargs)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_response_ignores_non_integration_cloud_products(self, mock_post):
         """Only the 'Integration Cloud' product's baseApiUrl is used."""
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
@@ -231,7 +247,9 @@ class TestV3PasswordMode(TestCase):
 
 
 class TestJwtMode(TestCase):
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_login_extracts_server_url_and_session_id(self, mock_post):
         mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
 
@@ -247,7 +265,9 @@ class TestJwtMode(TestCase):
         self.assertEqual("session-jwt-123", state.derived["session_id"])
         self.assertEqual(_API_BASE_URL_V2, state.derived["api_base_url"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_login_posts_to_login_oauth_path(self, mock_post):
         mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
 
@@ -260,10 +280,12 @@ class TestJwtMode(TestCase):
         )
         _run(step, {"jwt_token": "eyJhb...", "org_id": "myorg"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("/ma/api/v2/user/loginOAuth", login_url)
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_login_sends_org_id_and_token_as_json(self, mock_post):
         mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
 
@@ -281,7 +303,9 @@ class TestJwtMode(TestCase):
             {"orgId": "myorg123", "oauthToken": "my.jwt.token"}, call_kwargs["json"]
         )
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_mode_uses_custom_base_url(self, mock_post):
         mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
         custom_url = "https://eu1-dm.informaticacloud.com"
@@ -295,7 +319,7 @@ class TestJwtMode(TestCase):
         )
         _run(step, {"jwt_token": "t", "org_id": "org"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertTrue(login_url.startswith(custom_url))
 
 
@@ -305,7 +329,9 @@ class TestJwtMode(TestCase):
 
 
 class TestBaseUrl(TestCase):
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_custom_base_url_used_in_login_request(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
         custom = "https://dm-eu.informaticacloud.com"
@@ -320,10 +346,12 @@ class TestBaseUrl(TestCase):
         )
         _run(step, {"username": "u", "password": "p"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertTrue(login_url.startswith(custom))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_missing_base_url_falls_back_to_default(self, mock_post):
         """When base_url is absent, the US pod default is used."""
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
@@ -337,7 +365,7 @@ class TestBaseUrl(TestCase):
         )
         _run(step, {"username": "u", "password": "p"})
 
-        login_url = mock_post.call_args[0][0]
+        login_url = mock_post.call_args[0][1]
         self.assertIn("dm-us.informaticacloud.com", login_url)
 
 
@@ -347,7 +375,9 @@ class TestBaseUrl(TestCase):
 
 
 class TestOutputKeys(TestCase):
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_custom_output_keys_written_to_derived(self, mock_post):
         """Output key names in step.output control where values land in derived."""
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
@@ -374,9 +404,11 @@ class TestOutputKeys(TestCase):
 
 
 class TestLoginTimeout(TestCase):
-    """All three login paths must pass timeout= to requests.post."""
+    """All three login paths must pass timeout= to safe_request."""
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_login_passes_timeout(self, mock_post):
         mock_post.return_value = _mock_post(_V2_LOGIN_RESPONSE)
         step = _make_step(
@@ -390,7 +422,9 @@ class TestLoginTimeout(TestCase):
         _run(step, {})
         self.assertEqual(30, mock_post.call_args[1]["timeout"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_login_passes_timeout(self, mock_post):
         mock_post.return_value = _mock_post(_V3_LOGIN_RESPONSE)
         step = _make_step(
@@ -404,7 +438,9 @@ class TestLoginTimeout(TestCase):
         _run(step, {})
         self.assertEqual(30, mock_post.call_args[1]["timeout"])
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_login_passes_timeout(self, mock_post):
         mock_post.return_value = _mock_post(_JWT_LOGIN_RESPONSE)
         step = _make_step({"jwt_token": "tok", "org_id": "org", "base_url": _BASE_URL})
@@ -444,7 +480,9 @@ class TestErrorPaths(TestCase):
             _run(step, {})
         self.assertIn("v99", str(ctx.exception))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v2_response_missing_server_url_raises(self, mock_post):
         mock_post.return_value = _mock_post({"icSessionId": "s"})  # no serverUrl
 
@@ -460,7 +498,9 @@ class TestErrorPaths(TestCase):
             _run(step, {})
         self.assertIn("serverUrl", str(ctx.exception))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_v3_response_missing_integration_cloud_raises(self, mock_post):
         mock_post.return_value = _mock_post(
             {
@@ -481,7 +521,9 @@ class TestErrorPaths(TestCase):
             _run(step, {})
         self.assertIn("baseApiUrl", str(ctx.exception))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_response_missing_session_id_raises(self, mock_post):
         mock_post.return_value = _mock_post(
             {"serverUrl": "https://x.com"}
@@ -498,7 +540,9 @@ class TestErrorPaths(TestCase):
             _run(step, {})
         self.assertIn("icSessionId", str(ctx.exception))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_http_error_during_login_raises_ctp_error(self, mock_post):
         from requests import HTTPError
 
@@ -533,7 +577,9 @@ class TestCredentialSafety(TestCase):
     _PASSWORD = "super_secret_password_xyz"
     _JWT = "eyJhbGciOiJSUzI1NiJ9.secret_payload.signature"
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_password_not_leaked_in_login_failure_message(self, mock_post):
         from requests import HTTPError
 
@@ -554,7 +600,9 @@ class TestCredentialSafety(TestCase):
 
         self.assertNotIn(self._PASSWORD, str(ctx.exception))
 
-    @patch("requests.post")
+    @patch(
+        "apollo.integrations.ctp.transforms.resolve_informatica_session.safe_request"
+    )
     def test_jwt_token_not_leaked_in_login_failure_message(self, mock_post):
         from requests import HTTPError
 

--- a/tests/ctp/test_snowflake_ctp.py
+++ b/tests/ctp/test_snowflake_ctp.py
@@ -152,7 +152,7 @@ class TestSnowflakeCtp(TestCase):
 
     # ── OAuth via token acquisition ───────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_oauth_client_credentials(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"access_token": "tok_sfdc"}
@@ -177,7 +177,7 @@ class TestSnowflakeCtp(TestCase):
         self.assertNotIn("private_key", args)
         self.assertNotIn("oauth", args)
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_oauth_password_grant(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"access_token": "tok_pw"}
@@ -201,7 +201,7 @@ class TestSnowflakeCtp(TestCase):
         self.assertEqual("tok_pw", args["token"])
         self.assertEqual("oauth", args["authenticator"])
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_oauth_does_not_override_explicit_token(self, mock_post):
         # When both raw.token and raw.oauth are present, the OAuth step fires
         # and its field_map wins (step field_map overrides mapper field_map).

--- a/tests/ctp/test_transforms.py
+++ b/tests/ctp/test_transforms.py
@@ -226,14 +226,14 @@ def _mock_token_response(token="tok_abc123"):
 class TestOAuthTransform(TestCase):
     # ── Client credentials grant ──────────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_client_credentials_stores_token(self, mock_post):
         mock_post.return_value = _mock_token_response("tok_cc")
         state = PipelineState(raw={"oauth": _CC_CONFIG})
         OAuthTransform().execute(_make_oauth_step(), state)
         self.assertEqual("tok_cc", state.derived["oauth_token"])
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_client_credentials_sends_basic_auth_header(self, mock_post):
         mock_post.return_value = _mock_token_response()
         state = PipelineState(raw={"oauth": _CC_CONFIG})
@@ -243,7 +243,7 @@ class TestOAuthTransform(TestCase):
         expected = base64.b64encode(b"my-client:my-secret").decode()
         self.assertEqual(f"Basic {expected}", kwargs["headers"]["Authorization"])
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_client_credentials_sends_grant_type_in_body(self, mock_post):
         mock_post.return_value = _mock_token_response()
         state = PipelineState(raw={"oauth": _CC_CONFIG})
@@ -252,7 +252,7 @@ class TestOAuthTransform(TestCase):
         _, kwargs = mock_post.call_args
         self.assertEqual("client_credentials", kwargs["data"]["grant_type"])
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_client_credentials_with_scope(self, mock_post):
         mock_post.return_value = _mock_token_response()
         config = {**_CC_CONFIG, "scope": "read:data"}
@@ -264,14 +264,14 @@ class TestOAuthTransform(TestCase):
 
     # ── Password grant ────────────────────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_password_grant_stores_token(self, mock_post):
         mock_post.return_value = _mock_token_response("tok_pw")
         state = PipelineState(raw={"oauth": _PW_CONFIG})
         OAuthTransform().execute(_make_oauth_step(), state)
         self.assertEqual("tok_pw", state.derived["oauth_token"])
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_password_grant_sends_username_and_password(self, mock_post):
         mock_post.return_value = _mock_token_response()
         state = PipelineState(raw={"oauth": _PW_CONFIG})
@@ -283,7 +283,7 @@ class TestOAuthTransform(TestCase):
 
     # ── Error handling ────────────────────────────────────────────────
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_http_error_raises_ctp_error(self, mock_post):
         import requests as req
 
@@ -298,7 +298,7 @@ class TestOAuthTransform(TestCase):
             OAuthTransform().execute(_make_oauth_step(), state)
         self.assertIn("401", str(ctx.exception))
 
-    @patch("apollo.integrations.ctp.transforms.oauth.requests.post")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_missing_access_token_in_response_raises(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"error": "invalid_client"}

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1397,15 +1397,15 @@ class TestMulesoftAgentEndToEnd(TestCase):
         self._agent = Agent(LoggingUtils())
 
     @patch("requests.request")
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_mulesoft_agent_execute_operation_routes_through_http_proxy(
-        self, mock_oauth_requests, mock_request
+        self, mock_oauth_sr, mock_request
     ):
         # Stage 1 mock: OAuth POST returns a token.
         oauth_resp = MagicMock()
         oauth_resp.json.return_value = {"access_token": "ms-token"}
         oauth_resp.raise_for_status.return_value = None
-        mock_oauth_requests.post.return_value = oauth_resp
+        mock_oauth_sr.return_value = oauth_resp
 
         # Stage 2 mock: downstream API GET returns JSON.
         api_resp = create_autospec(Response)
@@ -1433,7 +1433,7 @@ class TestMulesoftAgentEndToEnd(TestCase):
         # OAuth was attempted at the US region endpoint.
         self.assertEqual(
             "https://anypoint.mulesoft.com/accounts/api/v2/oauth2/token",
-            mock_oauth_requests.post.call_args.args[0],
+            mock_oauth_sr.call_args.args[1],
         )
         # Downstream call hit the DC-supplied URL with the Bearer header from CTP.
         mock_request.assert_called_with(
@@ -1445,15 +1445,15 @@ class TestMulesoftAgentEndToEnd(TestCase):
         self.assertEqual({"orgs": []}, response.result.get(ATTRIBUTE_NAME_RESULT))
 
     @patch("requests.request")
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_mulesoft_eu_region_routes_through_eu_endpoint(
-        self, mock_oauth_requests, mock_request
+        self, mock_oauth_sr, mock_request
     ):
         # Stage 1 mock: OAuth POST returns a token.
         oauth_resp = MagicMock()
         oauth_resp.json.return_value = {"access_token": "ms-eu-token"}
         oauth_resp.raise_for_status.return_value = None
-        mock_oauth_requests.post.return_value = oauth_resp
+        mock_oauth_sr.return_value = oauth_resp
 
         # Stage 2 mock: downstream API GET returns JSON.
         api_resp = create_autospec(Response)
@@ -1481,7 +1481,7 @@ class TestMulesoftAgentEndToEnd(TestCase):
         # OAuth was attempted at the EU region endpoint.
         self.assertEqual(
             "https://eu1.anypoint.mulesoft.com/accounts/api/v2/oauth2/token",
-            mock_oauth_requests.post.call_args.args[0],
+            mock_oauth_sr.call_args.args[1],
         )
         # Downstream call hit the EU base URL.
         mock_request.assert_called_with(
@@ -1493,9 +1493,9 @@ class TestMulesoftAgentEndToEnd(TestCase):
         self.assertEqual({"orgs": []}, response.result.get(ATTRIBUTE_NAME_RESULT))
 
     @patch("requests.request")
-    @patch("apollo.integrations.ctp.transforms.oauth.requests")
+    @patch("apollo.integrations.ctp.transforms.oauth.safe_request")
     def test_mulesoft_do_request_accepts_arbitrary_url_from_caller(
-        self, mock_oauth_requests, mock_request
+        self, mock_oauth_sr, mock_request
     ):
         """Documents the design decision: do_request does NOT validate the URL —
         the agent trusts the DC for URL construction. The DC may supply any URL
@@ -1504,7 +1504,7 @@ class TestMulesoftAgentEndToEnd(TestCase):
         oauth_resp = MagicMock()
         oauth_resp.json.return_value = {"access_token": "tok"}
         oauth_resp.raise_for_status.return_value = None
-        mock_oauth_requests.post.return_value = oauth_resp
+        mock_oauth_sr.return_value = oauth_resp
 
         api_resp = create_autospec(Response)
         api_resp.json.return_value = {}


### PR DESCRIPTION
## Summary

Four CTP credential-resolution transforms build HTTP requests to **customer-supplied, template-rendered endpoints** and call `requests.post` directly, bypassing the SSRF guard:

- `oauth.py` — OAuth `token_endpoint` (C4)
- `resolve_informatica_session.py` — Informatica V2 login (C5), V3 login (C6), JWT/OAuth login (C7)

`apollo/integrations/http/CLAUDE.md` states that request paths not going through `HttpProxyClient.do_request` **must** wrap with `safe_request`. These four don't — so this routes them through it.

## Change

`requests.post(url, …)` → `safe_request("POST", url, …)` (a documented drop-in for `requests.request`). **Default tier**: blocks cloud-metadata / loopback destinations, while still allowing legitimate **private/on-prem RFC1918** IdP and Informatica hosts — so existing customer connections keep working. No behavior change beyond the destination-validation guard.

## Test updates

The transforms now issue requests via `safe_request` instead of `requests.post`, so the tests that mocked the old call path were updated (8 files, ~60 tests):

- Patch the module-level `safe_request` name (instead of `requests.post` / `oauth.requests`) so mocks intercept the new call and validation/DNS is fully bypassed — pure unit isolation.
- `safe_request(method, url, **kwargs)` puts the URL at the **second** positional arg, so URL assertions moved from `[0][0]` → `[0][1]`.
- `test_informatica_v2_ctp`: the v2 pipeline issues its two HTTP calls from two different transforms — a small helper patches both to one shared mock so the ordered first-call/second-call assertions keep working.
- Dropped now-unneeded requests-module exception-attr restores in the mulesoft failure test.

Full suite green locally (1450 passed).

## Provenance

Extracted from the **code-only** portion of rybot's SAST PR #361 (findings C4–C7, each Tank-triaged REAL_VULN). The AI-tooling files rybot also staged there (`.claude/skills/fix-repo-vulns/*`, `.mcp.json`) are **intentionally excluded** — they don't belong in this public repo. (Note: rybot's #361 changed the code without updating these tests, so it would fail CI as-is — another reason to take this PR instead.)

## Checklist
- [x] Code changes verified locally (safe_request is a drop-in; default tier preserves RFC1918)
- [x] Aligned with repo SSRF policy (`apollo/integrations/http/CLAUDE.md`)
- [x] Tests updated for the new call path — full suite green (1450 passed)
- [na] Docs — policy already documented in http/CLAUDE.md

> Note: `oauth.py` is also touched by the in-flight dependency PR (#360) on a different line (its `HTTPError` handler); no conflict expected in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)